### PR TITLE
DSi / 3DS themes: Add hiding files / folders

### DIFF
--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -149,6 +149,7 @@ int cursorPosition[2] = {0};
 int startMenu_cursorPosition = 0;
 int pagenum[2] = {0};
 bool showDirectories = true;
+bool showHidden = false;
 bool showBoxArt = true;
 bool animateDsiIcons = false;
 int launcherApp = -1;
@@ -181,6 +182,7 @@ void LoadSettings(void) {
 	theme = settingsini.GetInt("SRLOADER", "THEME", 0);
 	subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", 0);
 	showDirectories = settingsini.GetInt("SRLOADER", "SHOW_DIRECTORIES", 1);
+	showHidden = settingsini.GetInt("SRLOADER", "SHOW_HIDDEN", 0);
 	showBoxArt = settingsini.GetInt("SRLOADER", "SHOW_BOX_ART", 1);
 	animateDsiIcons = settingsini.GetInt("SRLOADER", "ANIMATE_DSI_ICONS", 1);
 	if (consoleModel < 2) {

--- a/settings/arm9/source/common/dsimenusettings.cpp
+++ b/settings/arm9/source/common/dsimenusettings.cpp
@@ -20,6 +20,7 @@ DSiMenuPlusPlusSettings::DSiMenuPlusPlusSettings()
     subtheme = 0;
 
     showDirectories = true;
+    showHidden = false;
     showBoxArt = true;
     animateDsiIcons = true;
     sysRegion = -1;
@@ -88,6 +89,7 @@ void DSiMenuPlusPlusSettings::loadSettings()
     theme = settingsini.GetInt("SRLOADER", "THEME", theme);
     subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", subtheme);
     showDirectories = settingsini.GetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);
+    showHidden = settingsini.GetInt("SRLOADER", "SHOW_HIDDEN", showHidden);
     showBoxArt = settingsini.GetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
     animateDsiIcons = settingsini.GetInt("SRLOADER", "ANIMATE_DSI_ICONS", animateDsiIcons);
 	if (consoleModel < 2) {
@@ -151,6 +153,7 @@ void DSiMenuPlusPlusSettings::saveSettings()
     settingsini.SetInt("SRLOADER", "THEME", theme);
     settingsini.SetInt("SRLOADER", "SUB_THEME", subtheme);
     settingsini.SetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);
+    settingsini.SetInt("SRLOADER", "SHOW_HIDDEN", showHidden);
     settingsini.SetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
     settingsini.SetInt("SRLOADER", "ANIMATE_DSI_ICONS", animateDsiIcons);
 	if (consoleModel < 2) {

--- a/settings/arm9/source/common/dsimenusettings.h
+++ b/settings/arm9/source/common/dsimenusettings.h
@@ -131,6 +131,7 @@ class DSiMenuPlusPlusSettings
     int theme;
     int subtheme;
     bool showDirectories;
+    bool showHidden;
     bool showBoxArt;
     bool animateDsiIcons;
     int sysRegion;

--- a/settings/arm9/source/language.cpp
+++ b/settings/arm9/source/language.cpp
@@ -25,6 +25,7 @@ std::string STR_THEME = "STR_THEME";
 std::string STR_LASTPLAYEDROM = "STR_LASTPLAYEDROM";
 std::string STR_DSIMENUPPLOGO = "STR_DSIMENUPPLOGO";
 std::string STR_DIRECTORIES = "STR_DIRECTORIES";
+std::string STR_SHOW_HIDDEN = "STR_SHOW_HIDDEN";
 std::string STR_BOXART = "STR_BOXART";
 std::string STR_ANIMATEDSIICONS = "STR_ANIMATEDSIICONS";
 std::string STR_SYSREGION = "STR_SYSREGION";
@@ -47,6 +48,8 @@ std::string STR_DESCRIPTION_LASTPLAYEDROM_1 = "STR_DESCRIPTION_LASTPLAYEDROM_1";
 std::string STR_DESCRIPTION_DSIMENUPPLOGO_1 = "STR_DESCRIPTION_DSIMENUPPLOGO_1";
 
 std::string STR_DESCRIPTION_DIRECTORIES_1 = "STR_DESCRIPTION_DIRECTORIES_1";
+
+std::string STR_DESCRIPTION_SHOW_HIDDEN_1 = "STR_DESCRIPTION_SHOW_HIDDEN_1";
 
 std::string STR_DESCRIPTION_BOXART_1 = "STR_DESCRIPTION_BOXART_1";
 
@@ -257,6 +260,7 @@ void langInit(void)
 	STR_LASTPLAYEDROM = ConvertFromUTF8(languageini.GetString("LANGUAGE", "LASTPLAYEDROM", "Last played ROM on startup."));
 	STR_DSIMENUPPLOGO = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DSIMENUPPLOGO", "TWLMenu++ Splash Screen"));
 	STR_DIRECTORIES = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DIRECTORIES", "Directories/Folders"));
+	STR_SHOW_HIDDEN = ConvertFromUTF8(languageini.GetString("LANGUAGE", "SHOW_HIDDEN", "Show hidden files"));
 	STR_BOXART = ConvertFromUTF8(languageini.GetString("LANGUAGE", "BOXART", "Box art/Game covers"));
 	STR_ANIMATEDSIICONS = ConvertFromUTF8(languageini.GetString("LANGUAGE", "ANIMATEDSIICONS", "Animate DSi icons"));
 	STR_SYSREGION = ConvertFromUTF8(languageini.GetString("LANGUAGE", "SYSREGION", "SysNAND Region"));
@@ -279,6 +283,8 @@ void langInit(void)
 	STR_DESCRIPTION_DSIMENUPPLOGO_1 = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_DSIMENUPPLOGO_1", "The logo will be shown when you start TWiLight Menu++."));
 
 	STR_DESCRIPTION_DIRECTORIES_1 = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_DIRECTORIES_1", "If you're in a folder where most of your games are, it is safe to hide directories/folders."));
+
+	STR_DESCRIPTION_SHOW_HIDDEN_1 = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_SHOW_HIDDEN_1", "If turned on, whether an app is set to hidden or not will be ignored and it will be displayed anyways."));
 
 	STR_DESCRIPTION_BOXART_1 = ConvertFromUTF8(languageini.GetString("LANGUAGE", "DESCRIPTION_BOXART_1", "Displayed in the top screen of the DSi/3DS theme."));
 

--- a/settings/arm9/source/language.h
+++ b/settings/arm9/source/language.h
@@ -18,6 +18,7 @@ extern std::string STR_THEME;
 extern std::string STR_LASTPLAYEDROM;
 extern std::string STR_DSIMENUPPLOGO;
 extern std::string STR_DIRECTORIES;
+extern std::string STR_SHOW_HIDDEN;
 extern std::string STR_BOXART;
 extern std::string STR_ANIMATEDSIICONS;
 extern std::string STR_SYSREGION;
@@ -40,6 +41,8 @@ extern std::string STR_DESCRIPTION_LASTPLAYEDROM_1;
 extern std::string STR_DESCRIPTION_DSIMENUPPLOGO_1;
 
 extern std::string STR_DESCRIPTION_DIRECTORIES_1;
+
+extern std::string STR_DESCRIPTION_SHOW_HIDDEN_1;
 
 extern std::string STR_DESCRIPTION_BOXART_1;
 

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -458,6 +458,7 @@ int main(int argc, char **argv)
 				{0, 1, 2, 3})
 
 		.option(STR_DIRECTORIES, STR_DESCRIPTION_DIRECTORIES_1, Option::Bool(&ms().showDirectories), {STR_SHOW, STR_HIDE}, {true, false})
+		.option(STR_SHOW_HIDDEN, STR_DESCRIPTION_SHOW_HIDDEN_1, Option::Bool(&ms().showHidden), {STR_SHOW, STR_HIDE}, {true, false})
 		.option(STR_BOXART, STR_DESCRIPTION_BOXART_1, Option::Bool(&ms().showBoxArt), {STR_SHOW, STR_HIDE}, {true, false})
 		.option(STR_ANIMATEDSIICONS, STR_DESCRIPTION_ANIMATEDSIICONS_1, Option::Bool(&ms().animateDsiIcons), {STR_YES, STR_NO}, {true, false})
 		.option(STR_12_HOUR_CLOCK, STR_DESCRIPTION_12_HOUR_CLOCK, Option::Bool(&ms().show12hrClock), {STR_YES, STR_NO}, {true, false})

--- a/settings/nitrofiles/languages/english.ini
+++ b/settings/nitrofiles/languages/english.ini
@@ -14,6 +14,7 @@ DSIMENUPPLOGO = TWLMenu++ Splash Screen
 SRLOADERLOGO = SRLoader Splash Screen
 DSISIONXLOGO = DSiMenu++ Splash Screen
 DIRECTORIES = Directories/folders
+SHOW_HIDDEN = Show hidden files
 BOXART = Box art/Game covers
 ANIMATEDSIICONS = Animate DSi icons
 SYSTEMSETTINGS = System Settings
@@ -34,6 +35,8 @@ DESCRIPTION_SRLOADERLOGO_1 = The logo will be shown when you start SRLoader.
 DESCRIPTION_DSISIONXLOGO_1 = The logo will be shown when you start DSiMenu++.
 
 DESCRIPTION_DIRECTORIES_1 = If you are in a folder where most of your games are, it is safe to hide directories/folders.
+
+DESCRIPTION_SHOW_HIDDEN_1 = If turned on, whether an app is set to hidden or not will be ignored and it will be displayed anyways.
 
 DESCRIPTION_BOXART_1 = Displayed in the top screen of the DSi/3DS theme.
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This adds the ability to hide files and folders on the DSi and 3DS themes (This fixes #212 )
   - I currently have it work by pressing `Y` on the Delete dialog (So `X` and then `Y`)
- This also adds an option in settings to show said hidden files/folders so that you're able to unhide them if you no longer want them to be hidden
   - *(NOTE: I didn't do translations for languages other than English)*
- Since your able to hide the `Back` folder this fixes #205 

#### Where have you tested it?

DSi (J) with the latest TWiLight, Hiya, and Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using latest devkitPro, devkitARM, and EasyGL2D.  

_(Do not edit after this point)_
- [ ]  This PR is fully documented.
- [ ]  This PR has been tested before sending.
- [ ]  This PR follows C style and convention.