### PR TITLE
Do a shallow clone to speed up TWLBot Commit

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -129,7 +129,7 @@ jobs:
 
           git config --global user.email "flamekat54@aol.com"
           git config --global user.name "TWLBot"
-          git clone https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
+          git clone --depth 1 https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
           cd Builds/
           cp $(Build.ArtifactStagingDirectory)/build-devkitARM-latest/TWiLightMenu.7z TWiLightMenu.7z
           cp $(Build.ArtifactStagingDirectory)/build-devkitARM-Docker/TWiLightMenu_docker.7z TWiLightMenu_docker.7z


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

This makes Azure do
```
git clone --depth 1 https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
```
instead of
```
git clone https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
```
which should make the clone significantly faster.

#### Where have you tested it?

I tried cloning with `--depth 1` it it seemed to work, I think it should work fine on Azure, but haven't tested.

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  