### PR TITLE
Write enabled cheats to 'cheatData.bin'

### DIFF
--- a/mainmenu/arm9/source/main.cpp
+++ b/mainmenu/arm9/source/main.cpp
@@ -2045,7 +2045,7 @@ int main(int argc, char **argv) {
 										fputs(codelist.getCheats().c_str(), cheatData);
 									}
 									fclose(cheatData);
-									truncate("test.bin",0x8000);
+									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);
 								}
 							}

--- a/mainmenu/arm9/source/main.cpp
+++ b/mainmenu/arm9/source/main.cpp
@@ -2030,21 +2030,14 @@ int main(int argc, char **argv) {
 								long cheatOffset; size_t cheatSize;
 								FILE* dat=fopen(sdFound() ? "sd:/_nds/TWiLightMenu/extras/usrcheat.dat" : "fat:/_nds/TWiLightMenu/extras/usrcheat.dat","rb");
 								if (dat) {
-									FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
-									static const int BUFFER_SIZE = 4096;
-									char buffer[BUFFER_SIZE];
-									memset(buffer, 0, sizeof(buffer));
-									for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
-										fwrite(buffer, 1, sizeof(buffer), cheatData);
-									}
-									fseek(cheatData, 0, SEEK_SET);
 									if (codelist.searchCheatData(dat, gameCode,
 												     crc32, cheatOffset,
 												     cheatSize)) {
+										FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
 										codelist.parse(path);
 										fputs(codelist.getCheats().c_str(), cheatData);
+										fclose(cheatData);
 									}
-									fclose(cheatData);
 									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);
 								}

--- a/mainmenu/arm9/source/main.cpp
+++ b/mainmenu/arm9/source/main.cpp
@@ -2029,13 +2029,23 @@ int main(int argc, char **argv) {
 							if(codelist.romData(path,gameCode,crc32)) {
 								long cheatOffset; size_t cheatSize;
 								FILE* dat=fopen(sdFound() ? "sd:/_nds/TWiLightMenu/extras/usrcheat.dat" : "fat:/_nds/TWiLightMenu/extras/usrcheat.dat","rb");
-								if(dat) {
-									if(codelist.searchCheatData(dat,gameCode,crc32,cheatOffset,cheatSize)) {
-										codelist.parse(path);
-										bootstrapini.SetString("NDS-BOOTSTRAP", "CHEAT_DATA", codelist.getCheats());
-									} else {
-										bootstrapini.SetString("NDS-BOOTSTRAP", "CHEAT_DATA", "");
+								if (dat) {
+									FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
+									static const int BUFFER_SIZE = 4096;
+									char buffer[BUFFER_SIZE];
+									memset(buffer, 0, sizeof(buffer));
+									for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
+										fwrite(buffer, 1, sizeof(buffer), cheatData);
 									}
+									fseek(cheatData, 0, SEEK_SET);
+									if (codelist.searchCheatData(dat, gameCode,
+												     crc32, cheatOffset,
+												     cheatSize)) {
+										codelist.parse(path);
+										fputs(codelist.getCheats().c_str(), cheatData);
+									}
+									fclose(cheatData);
+									truncate("test.bin",0x8000);
 									fclose(dat);
 								}
 							}

--- a/romsel_aktheme/arm9/source/common/bootstrapconfig.cpp
+++ b/romsel_aktheme/arm9/source/common/bootstrapconfig.cpp
@@ -161,7 +161,7 @@ BootstrapConfig &BootstrapConfig::speedBumpExclude()
 	static const char list2[][4] = {
 		"AEK",	// Age of Empires: The Age of Kings
 		"ALC",	// Animaniacs: Lights, Camera, Action!
-		"YAH",	// Assassin's Creed: Alta�r's Chronicles
+		"YAH",	// Assassin's Creed: Altaïr's Chronicles
 		//"ACV",	// Castlevania: Dawn of Sorrow	(fixed on nds-bootstrap side)
 		"A5P",	// Harry Potter and the Order of the Phoenix
 		"AR2",	// Kirarin * Revolution: Naasan to Issho
@@ -443,27 +443,23 @@ void BootstrapConfig::loadCheats()
         FILE* dat=fopen(SFN_CHEATS,"rb");
         if(dat)
         {
+					FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
+					static const int BUFFER_SIZE = 4096;
+					char buffer[BUFFER_SIZE];
+					memset(buffer, 0, sizeof(buffer));
+					for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
+						fwrite(buffer, 1, sizeof(buffer), cheatData);
+					}
           if(CheatWnd::searchCheatData(dat,gameCode,crc32,cheatOffset,cheatSize))
           {
+						fseek(cheatData, 0, SEEK_SET);
 						CheatWnd chtwnd((256)/2,(192)/2,100,100,NULL,_fullPath);
 
-						FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
-						static const int BUFFER_SIZE = 4096;
-						char buffer[BUFFER_SIZE];
-						memset(buffer, 0, sizeof(buffer));
-						for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
-							fwrite(buffer, 1, sizeof(buffer), cheatData);
-						}
-						fseek(cheatData, 0, SEEK_SET);
-						if (chtwnd.searchCheatData(dat, gameCode,
-												crc32, cheatOffset,
-												cheatSize)) {
-							chtwnd.parse(_fullPath);
-							fputs(chtwnd.getCheats().c_str(), cheatData);
-						}
-						fclose(cheatData);
-						truncate("test.bin",0x8000);
+						chtwnd.parse(_fullPath);
+						fputs(chtwnd.getCheats().c_str(), cheatData);
           }
+					fclose(cheatData);
+					truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
           fclose(dat);
         }
       }

--- a/romsel_aktheme/arm9/source/common/bootstrapconfig.cpp
+++ b/romsel_aktheme/arm9/source/common/bootstrapconfig.cpp
@@ -443,23 +443,16 @@ void BootstrapConfig::loadCheats()
         FILE* dat=fopen(SFN_CHEATS,"rb");
         if(dat)
         {
-					FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
-					static const int BUFFER_SIZE = 4096;
-					char buffer[BUFFER_SIZE];
-					memset(buffer, 0, sizeof(buffer));
-					for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
-						fwrite(buffer, 1, sizeof(buffer), cheatData);
-					}
           if(CheatWnd::searchCheatData(dat,gameCode,crc32,cheatOffset,cheatSize))
           {
-						fseek(cheatData, 0, SEEK_SET);
 						CheatWnd chtwnd((256)/2,(192)/2,100,100,NULL,_fullPath);
 
 						chtwnd.parse(_fullPath);
+						FILE *cheatData = fopen(SFN_CHEAT_DATA, "wb");
 						fputs(chtwnd.getCheats().c_str(), cheatData);
+						fclose(cheatData);
           }
-					fclose(cheatData);
-					truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
+					truncate(SFN_CHEAT_DATA, 0x8000);
           fclose(dat);
         }
       }

--- a/romsel_aktheme/arm9/source/systemfilenames.h
+++ b/romsel_aktheme/arm9/source/systemfilenames.h
@@ -91,6 +91,7 @@
 #define SFN_ICONS_DIRECTORY         SFN_SYSTEM_DIR"icons/"
 
 #define SFN_CHEATS                  "/_nds/TWiLightMenu/extras/usrcheat.dat"
+#define SFN_CHEAT_DATA              "/_nds/nds-bootstrap/cheatData.bin"
 
 class SystemFilenames
 {

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1319,21 +1319,14 @@ int main(int argc, char **argv) {
 									: "fat:/_nds/TWiLightMenu/extras/usrcheat.dat",
 								    "rb");
 								if (dat) {
-									FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
-									static const int BUFFER_SIZE = 4096;
-									char buffer[BUFFER_SIZE];
-									toncset(buffer, 0, sizeof(buffer));
-									for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
-										fwrite(buffer, 1, sizeof(buffer), cheatData);
-									}
-									fseek(cheatData, 0, SEEK_SET);
 									if (codelist.searchCheatData(dat, gameCode,
 												     crc32, cheatOffset,
 												     cheatSize)) {
+										FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
 										codelist.parse(path);
 										fputs(codelist.getCheats().c_str(), cheatData);
+										fclose(cheatData);
 									}
-									fclose(cheatData);
 									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);
 								}

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1320,15 +1320,21 @@ int main(int argc, char **argv) {
 								    "rb");
 								if (dat) {
 									FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
+									static const int BUFFER_SIZE = 4096;
+									char buffer[4096];
+									toncset(buffer, 0, sizeof(buffer));
+									for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
+										fwrite(buffer, 1, sizeof(buffer), cheatData);
+									}
+									fseek(cheatData, 0, SEEK_SET);
 									if (codelist.searchCheatData(dat, gameCode,
 												     crc32, cheatOffset,
 												     cheatSize)) {
 										codelist.parse(path);
 										fputs(codelist.getCheats().c_str(), cheatData);
-									} else {
-										fputs("", cheatData);
 									}
 									fclose(cheatData);
+									truncate("test.bin",0x8000);
 									fclose(dat);
 								}
 							}

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1321,7 +1321,7 @@ int main(int argc, char **argv) {
 								if (dat) {
 									FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
 									static const int BUFFER_SIZE = 4096;
-									char buffer[4096];
+									char buffer[BUFFER_SIZE];
 									toncset(buffer, 0, sizeof(buffer));
 									for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
 										fwrite(buffer, 1, sizeof(buffer), cheatData);

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1319,18 +1319,16 @@ int main(int argc, char **argv) {
 									: "fat:/_nds/TWiLightMenu/extras/usrcheat.dat",
 								    "rb");
 								if (dat) {
+									FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
 									if (codelist.searchCheatData(dat, gameCode,
 												     crc32, cheatOffset,
 												     cheatSize)) {
 										codelist.parse(path);
-										bootstrapini.SetString(
-										    "NDS-BOOTSTRAP", "CHEAT_DATA",
-										    codelist.getCheats());
+										fputs(codelist.getCheats().c_str(), cheatData);
 									} else {
-										bootstrapini.SetString(
-											"NDS-BOOTSTRAP", "CHEAT_DATA",
-											"");
+										fputs("", cheatData);
 									}
+									fclose(cheatData);
 									fclose(dat);
 								}
 							}

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1334,7 +1334,7 @@ int main(int argc, char **argv) {
 										fputs(codelist.getCheats().c_str(), cheatData);
 									}
 									fclose(cheatData);
-									truncate("test.bin",0x8000);
+									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);
 								}
 							}

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1594,21 +1594,14 @@ int main(int argc, char **argv) {
 								long cheatOffset; size_t cheatSize;
 								FILE* dat=fopen(sdFound() ? "sd:/_nds/TWiLightMenu/extras/usrcheat.dat" : "fat:/_nds/TWiLightMenu/extras/usrcheat.dat","rb");
 								if (dat) {
-									FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
-									static const int BUFFER_SIZE = 4096;
-									char buffer[BUFFER_SIZE];
-									memset(buffer, 0, sizeof(buffer));
-									for (int i = 0x8000; i > 0; i -= BUFFER_SIZE) {
-										fwrite(buffer, 1, sizeof(buffer), cheatData);
-									}
-									fseek(cheatData, 0, SEEK_SET);
 									if (codelist.searchCheatData(dat, gameCode,
 												     crc32, cheatOffset,
 												     cheatSize)) {
+										FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
 										codelist.parse(path);
 										fputs(codelist.getCheats().c_str(), cheatData);
+										fclose(cheatData);
 									}
-									fclose(cheatData);
 									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);
 								}

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1609,7 +1609,7 @@ int main(int argc, char **argv) {
 										fputs(codelist.getCheats().c_str(), cheatData);
 									}
 									fclose(cheatData);
-									truncate("test.bin",0x8000);
+									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);
 								}
 							}


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This makes all of the themes and the quick menu write their enabled cheats to the 32kb (`0x8000` bytes) file `sd:/_nds/nds-bootstrap/cheatData.bin`

#### Where have you tested it?

DSi (J) with the latest Unlaunch and TWiLight Menu++

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
