### PR TITLE
Use `u32`s in `cheatData.bin` instead of just writing the text

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 <p align="center">
  <img src="https://github.com/RocketRobz/TWiLightMenu/blob/master/logo.png"><br>
- <span style="padding-right: 5px;">
-  <a href="https://travis-ci.org/RocketRobz/TWiLightMenu">
-   <img src="https://travis-ci.org/RocketRobz/TWiLightMenu.svg?branch=master">
   <span style="padding-right: 5px;">
     <a href="https://dev.azure.com/DS-Homebrew/Builds/_build?definitionId=6">
    <img src="https://dev.azure.com/DS-Homebrew/Builds/_apis/build/status/RocketRobz.TWiLightMenu?branchName=master" height="20">

--- a/mainmenu/arm9/source/cheat.cpp
+++ b/mainmenu/arm9/source/cheat.cpp
@@ -22,6 +22,9 @@
 #include "tool/dbgtool.h"
 #include "tool/stringtool.h"
 #include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <sstream>
 
 CheatCodelist::~CheatCodelist(void) {}
 
@@ -215,4 +218,21 @@ std::string CheatCodelist::getCheats()
   }
 	std::replace( cheats.begin(), cheats.end(), '\n', ' ');
   return cheats;
+}
+
+void writeCheatsToFile(std::string data, const char* path) {
+  std::fstream fs;
+  fs.open(path, std::ios::binary | std::fstream::out);
+  std::stringstream str;
+  u32 value;
+  while(1) {
+    str.clear();
+    str << data.substr(0, data.find(" "));
+    str >> std::hex >> value;
+    fs.write(reinterpret_cast<char*>(&value),sizeof(value));
+    data = data.substr(data.find(" ")+1);
+    if((int)data.find(" ") == -1) break;
+  }
+  fs.write("\0\0\0Ï", 4);
+  fs.close();
 }

--- a/mainmenu/arm9/source/cheat.h
+++ b/mainmenu/arm9/source/cheat.h
@@ -6,6 +6,8 @@
 #include <vector>
 #include <nds.h>
 
+void writeCheatsToFile(std::string data, const char* path);
+
 class CheatCodelist
 {
 public:

--- a/mainmenu/arm9/source/main.cpp
+++ b/mainmenu/arm9/source/main.cpp
@@ -2033,10 +2033,8 @@ int main(int argc, char **argv) {
 									if (codelist.searchCheatData(dat, gameCode,
 												     crc32, cheatOffset,
 												     cheatSize)) {
-										FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
 										codelist.parse(path);
-										fputs(codelist.getCheats().c_str(), cheatData);
-										fclose(cheatData);
+										writeCheatsToFile(codelist.getCheats(), sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin");
 									}
 									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);

--- a/romsel_aktheme/arm9/source/common/bootstrapconfig.cpp
+++ b/romsel_aktheme/arm9/source/common/bootstrapconfig.cpp
@@ -448,9 +448,7 @@ void BootstrapConfig::loadCheats()
 						CheatWnd chtwnd((256)/2,(192)/2,100,100,NULL,_fullPath);
 
 						chtwnd.parse(_fullPath);
-						FILE *cheatData = fopen(SFN_CHEAT_DATA, "wb");
-						fputs(chtwnd.getCheats().c_str(), cheatData);
-						fclose(cheatData);
+						chtwnd.writeCheatsToFile(chtwnd.getCheats(), SFN_CHEAT_DATA);
           }
 					truncate(SFN_CHEAT_DATA, 0x8000);
           fclose(dat);

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
@@ -26,7 +26,9 @@
 #include "gamecode.h"
 #include <sys/stat.h>
 #include <algorithm>
-// #include <elm.h>
+#include <iostream>
+#include <fstream>
+#include <sstream>
 
 using namespace akui;
 
@@ -526,4 +528,21 @@ std::string CheatWnd::getCheats()
   }
   std::replace( cheats.begin(), cheats.end(), '\n', ' ');
   return cheats;
+}
+
+void CheatWnd::writeCheatsToFile(std::string data, const char* path) {
+  std::fstream fs;
+  fs.open(path, std::ios::binary | std::fstream::out);
+  std::stringstream str;
+  u32 value;
+  while(1) {
+    str.clear();
+    str << data.substr(0, data.find(" "));
+    str >> std::hex >> value;
+    fs.write(reinterpret_cast<char*>(&value),sizeof(value));
+    data = data.substr(data.find(" ")+1);
+    if((int)data.find(" ") == -1) break;
+  }
+  fs.write("\0\0\0Ï", 4);
+  fs.close();
 }

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.h
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.h
@@ -33,6 +33,7 @@ class CheatWnd: public akui::Form
     bool parse(const std::string& aFileName);
     static bool searchCheatData(FILE* aDat,u32 gamecode,u32 crc32,long& aPos,size_t& aSize);
     static bool romData(const std::string& aFileName,u32& aGameCode,u32& aCrc32);
+    void writeCheatsToFile(std::string data, const char* path);
   protected:
     void draw();
     bool process(const akui::Message& msg);

--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -508,6 +508,6 @@ void writeCheatsToFile(std::string data, const char* path) {
     data = data.substr(data.find(" ")+1);
     if((int)data.find(" ") == -1) break;
   }
-  fs.write("\0\0\0Ï", 8);
+  fs.write("\0\0\0Ï", 4);
   fs.close();
 }

--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -26,6 +26,9 @@
 #include "tool/stringtool.h"
 #include "sound.h"
 #include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <sstream>
 
 #include "ndsheaderbanner.h"
 #include "iconTitle.h"
@@ -490,4 +493,21 @@ void CheatCodelist::onGenerate(void)
     }
     fclose(db);
   }
+}
+
+void writeCheatsToFile(std::string data, const char* path) {
+  std::fstream fs;
+  fs.open(path, std::ios::binary | std::fstream::out);
+  std::stringstream str;
+  u32 value;
+  while(1) {
+    str.clear();
+    str << data.substr(0, data.find(" "));
+    str >> std::hex >> value;
+    fs.write(reinterpret_cast<char*>(&value),sizeof(value));
+    data = data.substr(data.find(" ")+1);
+    if((int)data.find(" ") == -1) break;
+  }
+  fs.write("\0\0\0Ï", 8);
+  fs.close();
 }

--- a/romsel_dsimenutheme/arm9/source/cheat.h
+++ b/romsel_dsimenutheme/arm9/source/cheat.h
@@ -6,6 +6,8 @@
 #include <vector>
 #include <nds.h>
 
+void writeCheatsToFile(std::string data, const char* path);
+
 class CheatCodelist
 {
 public:

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1322,10 +1322,8 @@ int main(int argc, char **argv) {
 									if (codelist.searchCheatData(dat, gameCode,
 												     crc32, cheatOffset,
 												     cheatSize)) {
-										FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
 										codelist.parse(path);
-										fputs(codelist.getCheats().c_str(), cheatData);
-										fclose(cheatData);
+										writeCheatsToFile(codelist.getCheats(), sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin");
 									}
 									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);

--- a/romsel_r4theme/arm9/source/cheat.cpp
+++ b/romsel_r4theme/arm9/source/cheat.cpp
@@ -23,6 +23,9 @@
 #include "tool/dbgtool.h"
 #include "tool/stringtool.h"
 #include <algorithm>
+#include <iostream>
+#include <fstream>
+#include <sstream>
 
 #include "ndsheaderbanner.h"
 #include "iconTitle.h"
@@ -472,4 +475,21 @@ void CheatCodelist::onGenerate(void)
     }
     fclose(db);
   }
+}
+
+void writeCheatsToFile(std::string data, const char* path) {
+  std::fstream fs;
+  fs.open(path, std::ios::binary | std::fstream::out);
+  std::stringstream str;
+  u32 value;
+  while(1) {
+    str.clear();
+    str << data.substr(0, data.find(" "));
+    str >> std::hex >> value;
+    fs.write(reinterpret_cast<char*>(&value),sizeof(value));
+    data = data.substr(data.find(" ")+1);
+    if((int)data.find(" ") == -1) break;
+  }
+  fs.write("\0\0\0Ï", 4);
+  fs.close();
 }

--- a/romsel_r4theme/arm9/source/cheat.h
+++ b/romsel_r4theme/arm9/source/cheat.h
@@ -6,6 +6,8 @@
 #include <vector>
 #include <nds.h>
 
+void writeCheatsToFile(std::string data, const char* path);
+
 class CheatCodelist
 {
 public:

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1597,10 +1597,8 @@ int main(int argc, char **argv) {
 									if (codelist.searchCheatData(dat, gameCode,
 												     crc32, cheatOffset,
 												     cheatSize)) {
-										FILE *cheatData = fopen(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", "wb");
 										codelist.parse(path);
-										fputs(codelist.getCheats().c_str(), cheatData);
-										fclose(cheatData);
+										writeCheatsToFile(codelist.getCheats(), sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin");
 									}
 									truncate(sdFound() ? "sd:/_nds/nds-bootstrap/cheatData.bin" : "fat:/_nds/nds-bootstrap/cheatData.bin", 0x8000);
 									fclose(dat);


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This makes `cheatData.bin` have `u32` values instead of simply writing the text.

#### Where have you tested it?

DSi (J) with latest TWiLight and Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
