### PR TITLE
Fix crash in akmenu if no save is found

### DIFF
--- a/romsel_aktheme/arm9/source/tool/stringtool.cpp
+++ b/romsel_aktheme/arm9/source/tool/stringtool.cpp
@@ -43,13 +43,14 @@ std::string formatString( const char* fmt, ... )
     return str;
 }
 
-std::string replaceAll(std::string str, const std::string &from, const std::string &to)
+std::string replaceAll(const std::string str, const std::string &from, const std::string &to)
 {
 	size_t start_pos = 0;
+    std::string newStr = std::string(str);
 	while ((start_pos = str.find(from, start_pos)) != std::string::npos)
 	{
-		str.replace(start_pos, from.length(), to);
+		newStr.replace(start_pos, from.length(), to);
 		start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
 	}
-	return str;
+	return newStr;
 }

--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -289,7 +289,8 @@ bool MainList::enterDir(const std::string &dirName)
     cwl();
     if (dir)
     {
-
+        _currentDir = dirName;
+        
         while ((direntry = readdir(dir)) != NULL)
         {
             memset(lfnBuf, 0, sizeof(lfnBuf));
@@ -403,7 +404,6 @@ bool MainList::enterDir(const std::string &dirName)
                     rominfo.setExtIcon("unknown");
             }
         }
-        _currentDir = dirName;
     }
 
     directoryChanged();

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -481,7 +481,8 @@ void RomInfoWnd::setRomInfo(const DSRomInfo &romInfo)
 {
     _romInfo = romInfo;
 
-    _romInfoText = unicode_to_local_string(_romInfo.banner().titles[ms().getGuiLanguage()], 128, NULL);
+    auto bannerTitle = _romInfo.banner().titles[ms().getGuiLanguage()];
+    _romInfoText = unicode_to_local_string(bannerTitle, 128, NULL);
 
     _buttonGameSettings.hide();
 

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -2255,7 +2255,7 @@ string browseForFile(const vector<string> extensionList) {
 					clearText();
 					chdir(entry->name.c_str());
 					char buf[256];
-					ms().romfolder[ms().secondaryDevice] = getcwd(buf, 256);
+					ms().romfolder[ms().secondaryDevice] = std::string(getcwd(buf, 256));
 					ms().saveSettings();
 					settingsChanged = false;
 					return "null";
@@ -2711,7 +2711,7 @@ string browseForFile(const vector<string> extensionList) {
 				chdir("..");
 				char buf[256];
 
-				ms().romfolder[ms().secondaryDevice] = getcwd(buf, 256);
+				ms().romfolder[ms().secondaryDevice] = std::string(getcwd(buf, 256));
 				ms().saveSettings();
 				settingsChanged = false;
 				return "null";

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -87,6 +87,7 @@ char unlaunchDevicePath[256];
  * @param path Pathname to modify.
  */
 void RemoveTrailingSlashes(std::string &path) {
+	if (path.size() == 0) return;
 	while (!path.empty() && path[path.size() - 1] == '/') {
 		path.resize(path.size() - 1);
 	}
@@ -937,7 +938,7 @@ int main(int argc, char **argv) {
 
 			bool isArgv = false;
 			if (strcasecmp(filename.c_str() + filename.size() - 5, ".argv") == 0) {
-				ms().romPath = filePath + filename;
+				ms().romPath = std::string(filePath) + std::string(filename);
 
 				FILE *argfile = fopen(filename.c_str(), "rb");
 				char str[PATH_MAX], *pstr;
@@ -985,11 +986,11 @@ int main(int argc, char **argv) {
 				free(argarray.at(0));
 				argarray.at(0) = filePath;
 
-				ms().dsiWareSrlPath = argarray[0];
+				ms().dsiWareSrlPath = std::string(argarray[0]);
 				ms().dsiWarePubPath = ReplaceAll(argarray[0], typeToReplace, ".pub");
 				ms().dsiWarePrvPath = ReplaceAll(argarray[0], typeToReplace, ".prv");
 				if (!isArgv) {
-					ms().romPath = argarray[0];
+					ms().romPath = std::string(argarray[0]);
 				}
 				ms().launchType = Launch::EDSiWareLaunch;
 				ms().previousUsedDevice = ms().secondaryDevice;
@@ -1409,7 +1410,7 @@ int main(int argc, char **argv) {
 						}
 
 						if (!isArgv) {
-							ms().romPath = argarray[0];
+							ms().romPath = std::string(argarray[0]);
 						}
 						ms().launchType = Launch::ESDFlashcardLaunch; // 1
 						ms().previousUsedDevice = ms().secondaryDevice;
@@ -1440,7 +1441,7 @@ int main(int argc, char **argv) {
 						}
 						stop();
 					} else {
-						ms().romPath = argarray[0];
+						ms().romPath = std::string(argarray[0]);
 						ms().launchType = Launch::ESDFlashcardLaunch;
 						ms().previousUsedDevice = ms().secondaryDevice;
 						ms().saveSettings();
@@ -1448,7 +1449,7 @@ int main(int argc, char **argv) {
 					}
 				} else {
 					if (!isArgv) {
-						ms().romPath = argarray[0];
+						ms().romPath = std::string(argarray[0]);
 					}
 					ms().launchType = Launch::ESDFlashcardDirectLaunch;
 					ms().previousUsedDevice = ms().secondaryDevice;
@@ -1505,8 +1506,8 @@ int main(int argc, char **argv) {
 				RemoveTrailingSlashes(romfolderNoSlash);
 				char ROMpath[256];
 				snprintf(ROMpath, sizeof(ROMpath), "%s/%s", romfolderNoSlash.c_str(), filename.c_str());
-				ms().romPath = ROMpath;
-				ms().homebrewArg = ROMpath;
+				ms().romPath = std::string(ROMpath);
+				ms().homebrewArg = std::string(ROMpath);
 
 				if (gameboy) {
 					ms().launchType = Launch::EGameYobLaunch;
@@ -1571,7 +1572,7 @@ int main(int argc, char **argv) {
 				char ROMpath[256];
 				snprintf(ROMpath, sizeof(ROMpath), "%s/%s", romfolderNoSlash.c_str(), filename.c_str());
 				ms().homebrewBootstrap = true;
-				ms().romPath = ROMpath;
+				ms().romPath = std::string(ROMpath);
 				ms().launchType = Launch::ESDFlashcardLaunch; // 1
 				ms().previousUsedDevice = ms().secondaryDevice;
 				ms().saveSettings();

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -558,13 +558,14 @@ void doPause() {
 	scanKeys();
 }
 
-std::string ReplaceAll(std::string str, const std::string &from, const std::string &to) {
+std::string ReplaceAll(const std::string str, const std::string &from, const std::string &to) {
 	size_t start_pos = 0;
+	std::string newStr = std::string(str);
 	while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
-		str.replace(start_pos, from.length(), to);
+		newStr.replace(start_pos, from.length(), to);
 		start_pos += to.length(); // Handles case where 'to' is a substring of 'from'
 	}
-	return str;
+	return newStr;
 }
 
 void loadGameOnFlashcard(const char *ndsPath, std::string filename, bool usePerGameSettings) {
@@ -1244,18 +1245,13 @@ int main(int argc, char **argv) {
 							}
 							showProgressIcon = true;
 
-							static const int BUFFER_SIZE = 4096;
-							char buffer[BUFFER_SIZE];
-							toncset(buffer, 0, sizeof(buffer));
-
-							u32 fileSize = 0x40000; // 256KB
 							FILE *pFile = fopen("fat:/BTSTRP.TMP", "wb");
 							if (pFile) {
-								for (u32 i = fileSize; i > 0; i -= BUFFER_SIZE) {
-									fwrite(buffer, 1, sizeof(buffer), pFile);
-								}
+								fseek(pFile, 0x40000 - 1, SEEK_SET);
+								fputc('\0', pFile);
 								fclose(pFile);
 							}
+
 							showProgressIcon = false;
 							printLarge(false, 4, 20, "Done!");
 							for (int i = 0; i < 30; i++) {
@@ -1294,10 +1290,6 @@ int main(int argc, char **argv) {
 							}
 							showProgressIcon = true;
 
-							static const int BUFFER_SIZE = 4096;
-							char buffer[BUFFER_SIZE];
-							toncset(buffer, 0, sizeof(buffer));
-
 							int savesize = 524288; // 512KB (default size for most games)
 
 							// Set save size to 8KB for the following games
@@ -1332,9 +1324,8 @@ int main(int argc, char **argv) {
 
 							FILE *pFile = fopen(savepath.c_str(), "wb");
 							if (pFile) {
-								for (int i = savesize; i > 0; i -= BUFFER_SIZE) {
-									fwrite(buffer, 1, sizeof(buffer), pFile);
-								}
+								fseek(pFile, savesize - 1, SEEK_SET);
+								fputc('\0', pFile);
 								fclose(pFile);
 							}
 							showProgressIcon = false;


### PR DESCRIPTION
#### What's changed?

* Fixed a potential memory bug in `ReplaceAll` in both DSiMenu and AKmenu
* Remove need to allocate buffer when creating save files in DSiMenu and AKmenu
  * Fixes crash in AKMenu if no save is found.

#### Where have you tested it?
Nintendo DSi.

Only tested save-creation logic on AKMenu, since current DSiMenu master seems to have an unrelated bug where the ROM folder and ROM path aren't being set correctly (dkA r53), so I can't launch games through DSiMenu.

*** 
#### Pull Request status
- [ ]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
