### PR TITLE
Add direct access support for Acekard 2i with the banner of Deep Labyrinth

### DIFF
--- a/rungame/arm9/source/flashcard.cpp
+++ b/rungame/arm9/source/flashcard.cpp
@@ -150,7 +150,7 @@ TWL_CODE void twl_flashcardInit(void) {
 		} else*/ if (!memcmp(gamename, "QMATETRIAL", 9) || !memcmp(gamename, "R4DSULTRA", 9)) {
 			io_dldi_data = dldiLoadFromBin(r4idsn_sd_dldi);
 			fatMountSimple("fat", &io_dldi_data->ioInterface);
-		} else if (!memcmp(gameid, "ACEK", 4) || !memcmp(gameid, "YCEP", 4) || !memcmp(gameid, "AHZH", 4) || !memcmp(gameid, "CHPJ", 4)) {
+		} else if (!memcmp(gameid, "ACEK", 4) || !memcmp(gameid, "YCEP", 4) || !memcmp(gameid, "AHZH", 4) || !memcmp(gameid, "CHPJ", 4) || !memcmp(gameid, "ADLP", 4)) {
 			io_dldi_data = dldiLoadFromBin(ak2_sd_dldi);
 			fatMountSimple("fat", &io_dldi_data->ioInterface);
 		} /*else if (!memcmp(gameid, "ALXX", 4)) {

--- a/settings/arm9/source/common/flashcard.cpp
+++ b/settings/arm9/source/common/flashcard.cpp
@@ -113,7 +113,7 @@ TWL_CODE void twl_flashcardInit(void) {
 		} else*/ if (!memcmp(gamename, "QMATETRIAL", 9) || !memcmp(gamename, "R4DSULTRA", 9)) {
 			io_dldi_data = dldiLoadFromFile("nitro:/dldi/r4idsn_sd.dldi");
 			fatMountSimple("fat", &io_dldi_data->ioInterface);
-		} else if (!memcmp(gameid, "ACEK", 4) || !memcmp(gameid, "YCEP", 4) || !memcmp(gameid, "AHZH", 4) || !memcmp(gameid, "CHPJ", 4)) {
+		} else if (!memcmp(gameid, "ACEK", 4) || !memcmp(gameid, "YCEP", 4) || !memcmp(gameid, "AHZH", 4) || !memcmp(gameid, "CHPJ", 4) || !memcmp(gameid, "ADLP", 4)) {
 			io_dldi_data = dldiLoadFromFile("nitro:/dldi/ak2_sd.dldi");
 			fatMountSimple("fat", &io_dldi_data->ioInterface);
 		} /*else if (!memcmp(gameid, "ALXX", 4)) {

--- a/title/arm9/source/common/flashcard.cpp
+++ b/title/arm9/source/common/flashcard.cpp
@@ -113,7 +113,7 @@ TWL_CODE void twl_flashcardInit(void) {
 		} else*/ if (!memcmp(gamename, "QMATETRIAL", 9) || !memcmp(gamename, "R4DSULTRA", 9)) {
 			io_dldi_data = dldiLoadFromFile("nitro:/dldi/r4idsn_sd.dldi");
 			fatMountSimple("fat", &io_dldi_data->ioInterface);
-		} else if (!memcmp(gameid, "ACEK", 4) || !memcmp(gameid, "YCEP", 4) || !memcmp(gameid, "AHZH", 4) || !memcmp(gameid, "CHPJ", 4)) {
+		} else if (!memcmp(gameid, "ACEK", 4) || !memcmp(gameid, "YCEP", 4) || !memcmp(gameid, "AHZH", 4) || !memcmp(gameid, "CHPJ", 4) || !memcmp(gameid, "ADLP", 4)) {
 			io_dldi_data = dldiLoadFromFile("nitro:/dldi/ak2_sd.dldi");
 			fatMountSimple("fat", &io_dldi_data->ioInterface);
 		} /*else if (!memcmp(gameid, "ALXX", 4)) {


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Allows TWiLightMenu to recognize an Acekart 2i for direct access when Deep Labyrinth is set as it's banner. I prefer the Deep Labyrinth patch over the ones currently available because it works on DSi Firmware 1.4.4 and Horzes (which also supports 1.4.4) causes noticeably longer boot times when running the flashcard normally compared to Deep Labyrinth - for me at least.
#### Where have you tested it?

Tried running on my DSi through Unlaunch - worked fine (though #699 still causes issues for me - unrelated to this PR however)

*** 
#### Pull Request status
- [ ]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
