### PR TITLE
Don't put files in TWiLightMenu folder for release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,8 +83,8 @@ jobs:
         # version.txt
         echo -e "TWiLight Menu++: $(git describe --tags)\nnds-bootstrap: $(jq --raw-output '.tag_name' nds-bootstrap.json)\n\nRocketRobz, ahezard" > 7zfile/version.txt
 
-        mv 7zfile/ TWiLightMenu/
-        7z a TWiLightMenu.7z TWiLightMenu/
+        cd 7zfile
+        7z a TWiLightMenu.7z .
         cp TWiLightMenu.7z $(Build.ArtifactStagingDirectory)/TWiLightMenu.7z
       condition: startsWith(variables['Build.SourceBranchName'], 'v')
       displayName: 'Pack 7z Package for release'
@@ -128,6 +128,7 @@ jobs:
           mv 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/
           cp TWiLightMenu.7z $(Build.ArtifactStagingDirectory)/TWiLightMenu_docker.7z
+        condition: not(startsWith(variables['Build.SourceBranchName'], 'v'))
         displayName: 'Pack 7z Package'
       - task: PublishBuildArtifacts@1
         displayName: "Publish build to Azure"


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This makes the release `.7z` files not have the files in a `TWiLightMenu` folder
- It also makes releases not have docker builds attached

#### Where have you tested it?

No where ;P

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.
