### PR TITLE
Fix show game title on akmenu if guiLanguage set to Chinese

### DIFF
--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -659,8 +659,16 @@ void MainList::updateInternalNames(void)
             {
                 if (_romInfoList[_firstVisibleRowId + ii].isDSRom())
                 {
-                    _rows[_firstVisibleRowId + ii][INTERNALNAME_COLUMN]
-                        .setText(unicode_to_local_string(_romInfoList[_firstVisibleRowId + ii].banner().titles[ms().getGuiLanguage()], 128, NULL));
+					if (ms().getGuiLanguage() == 6)
+					{
+					    _rows[_firstVisibleRowId + ii][INTERNALNAME_COLUMN]
+					        .setText(unicode_to_local_string(_romInfoList[_firstVisibleRowId + ii].banner().titles[1], 128, NULL));
+					}
+					else
+					{
+					    _rows[_firstVisibleRowId + ii][INTERNALNAME_COLUMN]
+					        .setText(unicode_to_local_string(_romInfoList[_firstVisibleRowId + ii].banner().titles[ms().getGuiLanguage()], 128, NULL));
+					}
                 }
                 else
                 {

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -480,9 +480,17 @@ void RomInfoWnd::setFileInfo(const std::string &fullName, const std::string &sho
 void RomInfoWnd::setRomInfo(const DSRomInfo &romInfo)
 {
     _romInfo = romInfo;
-
-    auto bannerTitle = _romInfo.banner().titles[ms().getGuiLanguage()];
-    _romInfoText = unicode_to_local_string(bannerTitle, 128, NULL);
+    
+	if (ms().getGuiLanguage() == 6)
+	{
+	    auto bannerTitle = _romInfo.banner().titles[1];
+		_romInfoText = unicode_to_local_string(bannerTitle, 128, NULL);
+	}
+	else
+	{
+	    auto bannerTitle = _romInfo.banner().titles[ms().getGuiLanguage()];
+		_romInfoText = unicode_to_local_string(bannerTitle, 128, NULL);
+	}
 
     _buttonGameSettings.hide();
 

--- a/romsel_aktheme/nitrofiles/language/lang_cn/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_cn/language.txt
@@ -1,10 +1,10 @@
-// Translation By R-YaTian
+﻿// Translation By R-YaTian
 [font]
 main = wenquanyi_9pt.pcf
 language = 1
 
 [start menu]
-Start = 菜单
+START = 菜单
 Copy = 复制
 Cut = 剪切
 Paste = 粘贴
@@ -19,6 +19,9 @@ More = 更多 ->
 Cheats = 金手指
 Back = <- 返回
 
+[mainlist]
+SD Card = SD/TF 卡
+
 [message box]
 yes = 是
 no = 否 
@@ -28,6 +31,8 @@ cancel = 取消
 [cheats]
 button = 金手指
 title = 金手指
+info = 信息
+deselect = 清除所有
 error_title = 错误
 error_text = 没有找到金手指文件。
 selectrom = 请选择.NDS 文件
@@ -453,11 +458,19 @@ Language = 语言
 CPU Frequency = CPU频率
 Off = 关闭
 On = 开启
-Sound Fix = 音效修正
-Async Prefetch = 异步预取
-Use Bootstrap = 使用Bootstrap
+Bootstrap File = Bootstrap文件
+Run in = 运行于
+DS mode = DS模式
+DSi mode = DSi模式
+DSi mode (Forced) = 强制DSi模式强制
+Boost VRAM = 增强VRAM
+Save number = 存档位置
+67MHz (NTR) = 67MHz(NTR)
+133MHz (TWL) = 133MHz
+RAM disk = 内存盘
 Direct Boot = 直接启动
-Per Game Settings = 单个游戏设置
+No Direct Boot = 非直接启动
+Per Game Settings = 游戏设置
 
 [game launch]
 ROM Start Error = 游戏启动错误

--- a/romsel_aktheme/nitrofiles/themes/zelda/uisettings.ini
+++ b/romsel_aktheme/nitrofiles/themes/zelda/uisettings.ini
@@ -25,6 +25,7 @@ y = 172
 w = 48
 h = 18
 textColor = 0x7FFF
+text = ini
 file = none
 
 [start menu]


### PR DESCRIPTION
Also update the Chinese language file for akmenu.
And the START button text will be show on akmenu.
This PR has been tested using the provided devkitPro, devkitARM.
And tested on my DSi console.