### PR TITLE
Check for GBA BIOS in sd:/_gba/

### DIFF
--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -1112,6 +1112,7 @@ int main(int argc, char **argv) {
 	
 	if ((access(secondaryDevice ? "fat:/bios.bin" : "sd:/bios.bin", F_OK) == 0)
 	|| (access(secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) == 0)) {
+	|| (access(secondaryDevice ? "fat:/_gba/bios.bin" : "sd:/_gba/bios.bin", F_OK) == 0)) {
 		gbaBiosFound = true;
 	}
 

--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -1111,7 +1111,7 @@ int main(int argc, char **argv) {
 	LoadSettings();
 	
 	if ((access(secondaryDevice ? "fat:/bios.bin" : "sd:/bios.bin", F_OK) == 0)
-	|| (access(secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) == 0)) {
+	|| (access(secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) == 0)
 	|| (access(secondaryDevice ? "fat:/_gba/bios.bin" : "sd:/_gba/bios.bin", F_OK) == 0)) {
 		gbaBiosFound = true;
 	}

--- a/romsel_aktheme/arm9/source/windows/mainwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.cpp
@@ -1143,7 +1143,7 @@ void MainWnd::bootGbaRunner(void)
 {
 	if (ms().useGbarunner) {
 	if ((access(ms().secondaryDevice ? "fat:/bios.bin" : "sd:/bios.bin", F_OK) != 0)
-	&& (access(ms().secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) != 0)) {
+	&& (access(ms().secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) != 0)
 	&& (access(ms().secondaryDevice ? "fat:/_gba/bios.bin" : "sd:/_gba/bios.bin", F_OK) != 0)) {
         messageBox(this, LANG("game launch", "GBARunner2 Error"), "BINF: bios.bin not found", MB_OK);
 		return;

--- a/romsel_aktheme/arm9/source/windows/mainwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.cpp
@@ -1144,6 +1144,7 @@ void MainWnd::bootGbaRunner(void)
 	if (ms().useGbarunner) {
 	if ((access(ms().secondaryDevice ? "fat:/bios.bin" : "sd:/bios.bin", F_OK) != 0)
 	&& (access(ms().secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) != 0)) {
+	&& (access(ms().secondaryDevice ? "fat:/_gba/bios.bin" : "sd:/_gba/bios.bin", F_OK) != 0)) {
         messageBox(this, LANG("game launch", "GBARunner2 Error"), "BINF: bios.bin not found", MB_OK);
 		return;
 	}

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -784,10 +784,10 @@ int main(int argc, char **argv) {
 
 	std::string filename;
 
-	if ((access("sd:/bios.bin", F_OK) == 0) || (access("sd:/gba/bios.bin", F_OK) == 0)) {
+	if ((access("sd:/bios.bin", F_OK) == 0) || (access("sd:/gba/bios.bin", F_OK) == 0) || (access("sd:/_gba/bios.bin", F_OK) == 0)) {
 		gbaBiosFound[0] = true;
 	}
-	if ((access("fat:/bios.bin", F_OK) == 0) || (access("fat:/gba/bios.bin", F_OK) == 0)) {
+	if ((access("fat:/bios.bin", F_OK) == 0) || (access("fat:/gba/bios.bin", F_OK) == 0) || (access("fat:/_gba/bios.bin", F_OK) == 0)) {
 		gbaBiosFound[1] = true;
 	}
 

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1265,6 +1265,7 @@ int main(int argc, char **argv) {
 						if (useGbarunner) {
 						if ((access(secondaryDevice ? "fat:/bios.bin" : "sd:/bios.bin", F_OK) != 0)
 						&& (access(secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) != 0)) {
+						&& (access(secondaryDevice ? "fat:/_gba/bios.bin" : "sd:/_gba/bios.bin", F_OK) != 0)) {
 							clearText();
 							dialogboxHeight = 1;
 							showdialogbox = true;

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1264,7 +1264,7 @@ int main(int argc, char **argv) {
 					case 2:
 						if (useGbarunner) {
 						if ((access(secondaryDevice ? "fat:/bios.bin" : "sd:/bios.bin", F_OK) != 0)
-						&& (access(secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) != 0)) {
+						&& (access(secondaryDevice ? "fat:/gba/bios.bin" : "sd:/gba/bios.bin", F_OK) != 0)
 						&& (access(secondaryDevice ? "fat:/_gba/bios.bin" : "sd:/_gba/bios.bin", F_OK) != 0)) {
 							clearText();
 							dialogboxHeight = 1;


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This makes it so that `sd:/_gba/bios.bin` is also a valid location for the GBA bios to match with the latest GBARunner2.

#### Where have you tested it?

DSi (J) with the latest TWiLight, Unlanch, and GBARunner2

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
