### PR TITLE
Fix Acekard Theme Bugs

### DIFF
--- a/romsel_aktheme/arm9/source/common/tonccpy.c
+++ b/romsel_aktheme/arm9/source/common/tonccpy.c
@@ -1,0 +1,136 @@
+#include "common/tonccpy.h"
+//# tonccpy.c
+
+//! VRAM-safe cpy.
+/*! This version mimics memcpy in functionality, with 
+    the benefit of working for VRAM as well. It is also 
+    slightly faster than the original memcpy, but faster 
+    implementations can be made.
+    \param dst  Destination pointer.
+    \param src  Source pointer.
+    \param size Fill-length in bytes.
+    \note   The pointers and size need not be word-aligned.
+*/
+void tonccpy(void *dst, const void *src, uint size)
+{
+    if(size==0 || dst==NULL || src==NULL)
+        return;
+
+    uint count;
+    u16 *dst16;     // hword destination
+    u8  *src8;      // byte source
+
+    // Ideal case: copy by 4x words. Leaves tail for later.
+    if( ((u32)src|(u32)dst)%4==0 && size>=4)
+    {
+        u32 *src32= (u32*)src, *dst32= (u32*)dst;
+
+        count= size/4;
+        uint tmp= count&3;
+        count /= 4;
+
+        // Duff's Device, good friend!
+        switch(tmp) {
+            do {    *dst32++ = *src32++;
+        case 3:     *dst32++ = *src32++;
+        case 2:     *dst32++ = *src32++;
+        case 1:     *dst32++ = *src32++;
+        case 0:     ; } while(count--);
+        }
+
+        // Check for tail
+        size &= 3;
+        if(size == 0)
+            return;
+
+        src8= (u8*)src32;
+        dst16= (u16*)dst32;
+    }
+    else        // Unaligned.
+    {
+        uint dstOfs= (u32)dst&1;
+        src8= (u8*)src;
+        dst16= (u16*)(dst-dstOfs);
+
+        // Head: 1 byte.
+        if(dstOfs != 0)
+        {
+            *dst16= (*dst16 & 0xFF) | *src8++<<8;
+            dst16++;
+            if(--size==0)
+                return;
+        }
+    }
+
+    // Unaligned main: copy by 2x byte.
+    count= size/2;
+    while(count--)
+    {
+        *dst16++ = src8[0] | src8[1]<<8;
+        src8 += 2;
+    }
+
+    // Tail: 1 byte.
+    if(size&1)
+        *dst16= (*dst16 &~ 0xFF) | *src8;
+}
+//# toncset.c
+
+//! VRAM-safe memset, internal routine.
+/*! This version mimics memset in functionality, with 
+    the benefit of working for VRAM as well. It is also 
+    slightly faster than the original memset.
+    \param dst  Destination pointer.
+    \param fill Word to fill with.
+    \param size Fill-length in bytes.
+    \note   The \a dst pointer and \a size need not be 
+        word-aligned. In the case of unaligned fills, \a fill 
+        will be masked off to match the situation.
+*/
+void __toncset(void *dst, u32 fill, uint size)
+{
+    if(size==0 || dst==NULL)
+        return;
+
+    uint left= (u32)dst&3;
+    u32 *dst32= (u32*)(dst-left);
+    u32 count, mask;
+
+    // Unaligned head.
+    if(left != 0)
+    {
+        // Adjust for very small stint.
+        if(left+size<4)
+        {
+            mask= BIT_MASK(size*8)<<(left*8);   
+            *dst32= (*dst32 &~ mask) | (fill & mask);
+            return;
+        }
+
+        mask= BIT_MASK(left*8);
+        *dst32= (*dst32 & mask) | (fill&~mask);
+        dst32++;
+        size -= 4-left;
+    }
+
+    // Main stint.
+    count= size/4;
+    uint tmp= count&3;
+    count /= 4;
+
+    switch(tmp) {
+        do {    *dst32++ = fill;
+    case 3:     *dst32++ = fill;
+    case 2:     *dst32++ = fill;
+    case 1:     *dst32++ = fill;
+    case 0:     ; } while(count--);
+    }
+
+    // Tail
+    size &= 3;
+    if(size)
+    {
+        mask= BIT_MASK(size*8);
+        *dst32= (*dst32 &~ mask) | (fill & mask);
+    }
+}

--- a/romsel_aktheme/arm9/source/common/tonccpy.h
+++ b/romsel_aktheme/arm9/source/common/tonccpy.h
@@ -1,0 +1,43 @@
+//# Stuff you may not have yet.
+
+#ifndef TONCCPY_H
+#define TONCCPY_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <nds.h>
+
+typedef unsigned int uint;
+#define BIT_MASK(len)       ( (1<<(len))-1 )
+static inline u32 quad8(u8 x)   {   x |= x<<8; return x | x<<16;    }
+
+
+//# Declarations and inlines.
+
+void tonccpy(void *dst, const void *src, uint size);
+
+void __toncset(void *dst, u32 fill, uint size);
+static inline void toncset(void *dst, u8 src, uint size);
+static inline void toncset16(void *dst, u16 src, uint size);
+static inline void toncset32(void *dst, u32 src, uint size);
+
+
+//! VRAM-safe memset, byte version. Size in bytes.
+static inline void toncset(void *dst, u8 src, uint size)
+{   __toncset(dst, quad8(src), size);               }
+
+//! VRAM-safe memset, halfword version. Size in hwords.
+static inline void toncset16(void *dst, u16 src, uint size)
+{   __toncset(dst, src|src<<16, size*2);            }
+
+//! VRAM-safe memset, word version. Size in words.
+static inline void toncset32(void *dst, u32 src, uint size)
+{   __toncset(dst, src, size*4);                    }
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/romsel_aktheme/arm9/source/dsrom.cpp
+++ b/romsel_aktheme/arm9/source/dsrom.cpp
@@ -34,13 +34,15 @@
 #include "icon_bg_bin.h"
 #include "gamecode.h"
 
+#include "common/tonccpy.h"
+
 static u32 arm9StartSig[4];
 
 DSRomInfo &DSRomInfo::operator=(const DSRomInfo &src)
 {
-    memcpy(&_banner, &src._banner, sizeof(_banner));
-    memcpy(&_saveInfo, &src._saveInfo, sizeof(_saveInfo));
-    memcpy(&_dsiIcon, &src._dsiIcon, sizeof(_dsiIcon));
+    tonccpy(&_banner, &src._banner, sizeof(_banner));
+    tonccpy(&_saveInfo, &src._saveInfo, sizeof(_saveInfo));
+    tonccpy(&_dsiIcon, &src._dsiIcon, sizeof(_dsiIcon));
 
     _isDSRom = src._isDSRom;
     _isHomebrew = src._isHomebrew;
@@ -71,7 +73,7 @@ bool DSRomInfo::loadDSRomInfo(const std::string &filename, bool loadBanner)
 		if (1 != fread(&header, 0x160, 1, f))
 		{
 			dbg_printf("read rom header fail\n");
-			memcpy(&_banner, unknown_nds_banner_bin, sizeof(_banner));
+			tonccpy(&_banner, unknown_nds_banner_bin, sizeof(_banner));
 			fclose(f);
 			return false;
 		}
@@ -82,7 +84,7 @@ bool DSRomInfo::loadDSRomInfo(const std::string &filename, bool loadBanner)
     if (crc != header.headerCRC16)
     {
         dbg_printf("%s rom header crc error\n", filename.c_str());
-        memcpy(&_banner, unknown_nds_banner_bin, sizeof(_banner));
+        tonccpy(&_banner, unknown_nds_banner_bin, sizeof(_banner));
         fclose(f);
         return true;
     }
@@ -137,8 +139,8 @@ bool DSRomInfo::loadDSRomInfo(const std::string &filename, bool loadBanner)
     }
 
     ///////// saveInfo /////////
-    memcpy(_saveInfo.gameTitle, header.gameTitle, 12);
-    memcpy(_saveInfo.gameCode, header.gameCode, 4);
+    tonccpy(_saveInfo.gameTitle, header.gameTitle, 12);
+    tonccpy(_saveInfo.gameCode, header.gameCode, 4);
     ///// SDK Version /////
 
     if (_isHomebrew == EFalse)
@@ -173,23 +175,23 @@ bool DSRomInfo::loadDSRomInfo(const std::string &filename, bool loadBanner)
                 dbg_printf("DSi Banner Found!");
                 _isBannerAnimated = ETrue;
                 fixBanner(&banner);
-                memcpy(_dsiIcon.icon_frames, banner.dsi_icon, sizeof(banner.dsi_icon));
-                memcpy(_dsiIcon.palette_frames, banner.dsi_palette, sizeof(banner.dsi_palette));
-                memcpy(_dsiIcon.sequence, banner.dsi_seq, sizeof(banner.dsi_seq));
+                tonccpy(_dsiIcon.icon_frames, banner.dsi_icon, sizeof(banner.dsi_icon));
+                tonccpy(_dsiIcon.palette_frames, banner.dsi_palette, sizeof(banner.dsi_palette));
+                tonccpy(_dsiIcon.sequence, banner.dsi_seq, sizeof(banner.dsi_seq));
 
                 
             }
-            memcpy(&_banner, &banner, sizeof(_banner));
+            tonccpy(&_banner, &banner, sizeof(_banner));
         }
         else
         {
-            memcpy(&_banner, nds_banner_bin, sizeof(_banner));
+            tonccpy(&_banner, nds_banner_bin, sizeof(_banner));
         }
     }
     else
     {
         //dbg_printf( "%s has no banner\n", filename );
-        memcpy(&_banner, nds_banner_bin, sizeof(_banner));
+        tonccpy(&_banner, nds_banner_bin, sizeof(_banner));
     }
 
     fclose(f);
@@ -424,9 +426,9 @@ bool DSRomInfo::loadGbaRomInfo(const std::string &filename)
         if (header.is96h == 0x96)
         {
             _isGbaRom = ETrue;
-            memcpy(_saveInfo.gameCode, header.gamecode, 4);
+            tonccpy(_saveInfo.gameCode, header.gamecode, 4);
             _romVersion = header.version;
-            memcpy(&_banner, gbarom_banner_bin, sizeof(tNDSBanner));
+            tonccpy(&_banner, gbarom_banner_bin, sizeof(tNDSBanner));
             return true;
         }
     }
@@ -528,5 +530,5 @@ void DSRomInfo::setExtIcon(const std::string &aValue)
 void DSRomInfo::setBanner(const std::string &anExtIcon, const u8 *aBanner)
 {
     setExtIcon(anExtIcon);
-    memcpy(&banner(), aBanner, sizeof(tNDSBanner));
+    tonccpy(&banner(), aBanner, sizeof(tNDSBanner));
 }

--- a/romsel_aktheme/arm9/source/dsrom.h
+++ b/romsel_aktheme/arm9/source/dsrom.h
@@ -26,7 +26,8 @@
 #include "saveinfo.h"
 #include "drawing/gdi.h"
 #include "common/ndsheader.h"
-
+#include "common/tonccpy.h"
+#include "unknown_banner_bin.h"
 
 typedef struct {
   u8 icon_frames[8][512];
@@ -73,10 +74,10 @@ public:
   _extIcon(-1), 
   _romVersion(0)
   {
-    //memcpy(&_banner,unknown_banner_bin,unknown_banner_bin_size);
-    memset(&_banner, 0, sizeof(_banner));
-    memset(&_saveInfo, 0, sizeof(_saveInfo));
-    memset(&_dsiIcon, 0, sizeof(_dsiIcon));
+    tonccpy(&_banner,unknown_banner_bin,unknown_banner_bin_size);
+    // toncset(&_banner, 0, sizeof(_banner));
+    toncset(&_saveInfo, 0, sizeof(_saveInfo));
+    toncset(&_dsiIcon, 0, sizeof(_dsiIcon));
     // memset(&_dsiPalette, 0, sizeof(_dsiPalette));
     // memset(&_dsiIcon, 0, sizeof(_dsiIcon));
 

--- a/romsel_aktheme/arm9/source/dsrom.h
+++ b/romsel_aktheme/arm9/source/dsrom.h
@@ -28,6 +28,9 @@
 #include "common/ndsheader.h"
 #include "common/tonccpy.h"
 #include "unknown_banner_bin.h"
+#include <memory>
+
+using std::unique_ptr;
 
 typedef struct {
   u8 icon_frames[8][512];
@@ -57,7 +60,7 @@ private:
   std::string _fileName;
   s32 _extIcon;
   u8 _romVersion;
-  tDSiAnimatedIcon _dsiIcon;
+  unique_ptr<tDSiAnimatedIcon> _dsiIcon;
   
 
 private:
@@ -74,14 +77,16 @@ public:
   _extIcon(-1), 
   _romVersion(0)
   {
-    tonccpy(&_banner,unknown_banner_bin,unknown_banner_bin_size);
-    // toncset(&_banner, 0, sizeof(_banner));
+    toncset(&_banner, 0, sizeof(_banner));
     toncset(&_saveInfo, 0, sizeof(_saveInfo));
-    toncset(&_dsiIcon, 0, sizeof(_dsiIcon));
+    // toncset(&_dsiIcon, 0, sizeof(_dsiIcon));
     // memset(&_dsiPalette, 0, sizeof(_dsiPalette));
     // memset(&_dsiIcon, 0, sizeof(_dsiIcon));
 
   }
+
+  DSRomInfo(const DSRomInfo&);
+  virtual ~DSRomInfo() { }
 
 public:
   void drawDSRomIcon(u8 x, u8 y, GRAPHICS_ENGINE engine);
@@ -91,7 +96,7 @@ public:
   void drawDSiAnimatedRomIconMem(void *mem, u8 frame, u8 palette, bool flipH, bool flipV);
 
   tNDSBanner &banner(void);
-  tDSiAnimatedIcon &animatedIcon(void);
+  const tDSiAnimatedIcon &animatedIcon(void);
   SAVE_INFO_EX &saveInfo(void);
   u8 version(void);
   void setExtIcon(const std::string &aValue);

--- a/romsel_aktheme/arm9/source/gamecode.h
+++ b/romsel_aktheme/arm9/source/gamecode.h
@@ -19,10 +19,12 @@
 #ifndef __GAMECODE_H__
 #define __GAMECODE_H__
 
+#include "common/tonccpy.h"
+
 inline u32 gamecode(const char *aGameCode)
 {
     u32 gameCode;
-    memcpy(&gameCode, aGameCode, sizeof(gameCode));
+    tonccpy(&gameCode, aGameCode, sizeof(gameCode));
     return gameCode;
 }
 

--- a/romsel_aktheme/arm9/source/time/datetime.cpp
+++ b/romsel_aktheme/arm9/source/time/datetime.cpp
@@ -20,7 +20,7 @@
 
 #include <string.h> //memset
 #include "datetime.h"
-
+#include "common/tonccpy.h"
 const char * DateTime::weekdayStrings[]= { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
 
 void DateTime::FillTimeParts(void)
@@ -28,7 +28,7 @@ void DateTime::FillTimeParts(void)
   time_t epochTime;
   if(time(&epochTime)==(time_t)-1)
   {
-    memset(&iTimeParts,0,sizeof(iTimeParts));
+    toncset(&iTimeParts,0,sizeof(iTimeParts));
   }
   else
   {

--- a/romsel_aktheme/arm9/source/tool/dbgtool.h
+++ b/romsel_aktheme/arm9/source/tool/dbgtool.h
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
-//#define DEBUG
+#define DEBUG
 
 #ifdef DEBUG
 static inline int dbg_printf( const char* format, ... )
@@ -39,8 +39,8 @@ static inline int dbg_printf( const char* format, ... )
 }
 #else
 #define dbg_printf(...)
+#define nocashMessage(...)
 #endif//DEBUG
-
 
 #ifdef DEBUG
 static inline void _cwl(const char *file,int line)

--- a/romsel_aktheme/arm9/source/tool/dbgtool.h
+++ b/romsel_aktheme/arm9/source/tool/dbgtool.h
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 
-#define DEBUG
+// #define DEBUG
 
 #ifdef DEBUG
 static inline int dbg_printf( const char* format, ... )

--- a/romsel_aktheme/arm9/source/ui/listview.cpp
+++ b/romsel_aktheme/arm9/source/ui/listview.cpp
@@ -85,38 +85,29 @@ bool ListView::insertColumn(size_t index, const std::string &text, u8 width)
     return true;
 }
 
-bool ListView::insertRow(size_t index, const std::vector<std::string> &texts)
+bool ListView::appendRow(const std::vector<std::string>&& texts)
 {
+    nocashMessage("listview:90");
     size_t columnCount = _columns.size();
-    if (0 == columnCount || index > _rows.size())
+    if (0 == columnCount)
         return false;
     if (0 == texts.size())
         return false;
-
-    _rows.insert(_rows.begin() + index, itemVector());
-    for (size_t col = 0; col < columnCount; ++col)
+    nocashMessage("listview:96");
+    itemVector row;
+    nocashMessage("listview:99");
+    for (size_t col = 0; col < columnCount; col++)
     {
-        std::string itemText;
-        if (col >= texts.size())
-            itemText = "Empty"; // Ĭ���ַ���
-        else
-            itemText = texts[col];
-
+        nocashMessage(texts[col].c_str());
         ListItem aItem;
-        aItem.setText(itemText);
-
-        _rows[index].insert(_rows[index].begin() + col, aItem);
+        aItem.setText(col < texts.size() ? texts[col] : "Empty");
+        row.emplace_back(std::move(aItem));
     }
+    _rows.emplace_back(std::move(row));
+    nocashMessage("listview:106");
     //if( _visibleRowCount > _rows.size() ) _visibleRowCount = _rows.size();
 
     return true;
-}
-
-void ListView::removeRow(size_t index)
-{
-    if (index >= _rows.size())
-        return;
-    _rows.erase(_rows.begin() + index);
 }
 
 void ListView::removeAllRows()
@@ -333,8 +324,11 @@ bool ListView::processTouchMessage(const TouchMessage &msg)
             {
                 if (selectedRowId() == rbp)
                 {
+                    cwl();
                     onSelectedRowClicked(rbp);
+                    cwl();
                     selectedRowClicked(rbp);
+                    cwl();
                 }
             }
         }

--- a/romsel_aktheme/arm9/source/ui/listview.cpp
+++ b/romsel_aktheme/arm9/source/ui/listview.cpp
@@ -126,6 +126,7 @@ void ListView::draw()
     drawText();
 }
 
+const BMP15 _barPic = createBMP15FromFile(SFN_LIST_BAR_BG);
 void ListView::drawSelectionBar()
 {
     //if( _touchMovedAfterTouchDown )
@@ -147,8 +148,6 @@ void ListView::drawSelectionBar()
 
     if(_showSelectionBarBg)
     {
-        BMP15 _barPic = createBMP15FromFile(SFN_LIST_BAR_BG);
-
         gdi().maskBlt(_barPic.buffer(), x, y, _barPic.width(), _barPic.height(), GE_MAIN);
     }
 }

--- a/romsel_aktheme/arm9/source/ui/listview.h
+++ b/romsel_aktheme/arm9/source/ui/listview.h
@@ -85,9 +85,7 @@ class ListView : public Window
 
     bool insertColumn(size_t index, const std::string &text, u8 width);
 
-    bool insertRow(size_t index, const std::vector<std::string> &text);
-
-    void removeRow(size_t index); // return id of the item next to the removed item
+    bool appendRow(const std::vector<std::string> &&text);
 
     void removeAllRows();
 

--- a/romsel_aktheme/arm9/source/userinput.cpp
+++ b/romsel_aktheme/arm9/source/userinput.cpp
@@ -36,7 +36,7 @@ void initInput()
 {
     lastInputTime = 0;
     idleMs = 0;
-    keysSetRepeat(30, 1);
+    keysSetRepeat(25, 2);
 }
 
 INPUT &updateInput()

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
@@ -150,7 +150,7 @@ bool CheatWnd::process(const akui::Message& msg)
 bool CheatWnd::processKeyMessage(const KeyMessage& msg)
 {
   bool ret=false;
-  if(msg.id()==Message::keyDown)
+  if(msg.id() == Message::keyDown)
   {
     switch(msg.keyCode())
     {
@@ -164,8 +164,8 @@ bool CheatWnd::processKeyMessage(const KeyMessage& msg)
         break;
       case KeyMessage::UI_KEY_LEFT:
         {
-          size_t ii=_List.selectedRowId();
-          while(--ii>0)
+          size_t ii = _List.selectedRowId();
+          while(ii-- > 0)
           {
             if(_data[_indexes[ii]]._flags&cParsedItem::EFolder) break;
           }
@@ -176,7 +176,7 @@ bool CheatWnd::processKeyMessage(const KeyMessage& msg)
       case KeyMessage::UI_KEY_RIGHT:
         {
           size_t ii=_List.selectedRowId(),top=_List.getRowCount();
-          while(++ii<top)
+          while(++ii < top)
           {
             if(_data[_indexes[ii]]._flags&cParsedItem::EFolder) break;
           }

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
@@ -487,7 +487,7 @@ void CheatWnd::generateList(void)
     std::vector<std::string> row;
     row.push_back("");
     row.push_back((*itr)._title);
-    _List.insertRow(_List.getRowCount(),row);
+    _List.appendRow(std::move(row));
     _indexes.push_back(itr-_data.begin());
     u32 flags=(*itr)._flags;
     ++itr;

--- a/romsel_aktheme/arm9/source/windows/dsiiconsequence.cpp
+++ b/romsel_aktheme/arm9/source/windows/dsiiconsequence.cpp
@@ -1,5 +1,6 @@
 #include "dsiiconsequence.h"
 #include <nds.h>
+#include "common/tonccpy.h"
 
 DSiIconSequence::DSiIconSequence()
 {
@@ -58,11 +59,11 @@ int IconSequenceManager::allocate_sequence(u8 *gameTid, u16 *sequence)
 
     size_t index = _dsiIconSequence.size() - 1;
 
-    memset(seq()._dsiIconSequence[index].gameTid(), 0, SIZE_GAMETID);
-    memset(seq()._dsiIconSequence[index].sequence(), 0, SIZE_SEQUENCE);
+    toncset(seq()._dsiIconSequence[index].gameTid(), 0, SIZE_GAMETID);
+    toncset(seq()._dsiIconSequence[index].sequence(), 0, SIZE_SEQUENCE);
 
-    memcpy(seq()._dsiIconSequence[index].gameTid(), gameTid, SIZE_GAMETID);
-    memcpy(seq()._dsiIconSequence[index].sequence(), sequence, SIZE_SEQUENCE);
+    tonccpy(seq()._dsiIconSequence[index].gameTid(), gameTid, SIZE_GAMETID);
+    tonccpy(seq()._dsiIconSequence[index].sequence(), sequence, SIZE_SEQUENCE);
 
     seq()._dsiIconSequence[index].reset();
     seq()._dsiIconSequence[index].show();

--- a/romsel_aktheme/arm9/source/windows/dsiiconsequence.cpp
+++ b/romsel_aktheme/arm9/source/windows/dsiiconsequence.cpp
@@ -73,11 +73,10 @@ int IconSequenceManager::allocate_sequence(u8 *gameTid, u16 *sequence)
 
 int IconSequenceManager::is_cached(u8 *gameTid)
 {
-    for (size_t i = 0; i < _dsiIconSequence.size(); i++)
-    {
-        if (memcmp(gameTid, _dsiIconSequence[i].gameTid(), SIZE_GAMETID) == 0)
+    for (auto it =  _dsiIconSequence.begin(); it !=  _dsiIconSequence.end(); ++it) {
+        if (memcmp(gameTid, it->gameTid(), SIZE_GAMETID) == 0)
         {
-            return i;
+            return std::distance(_dsiIconSequence.begin(), it);
         }
     }
     return -1;

--- a/romsel_aktheme/arm9/source/windows/dsiiconsequence.cpp
+++ b/romsel_aktheme/arm9/source/windows/dsiiconsequence.cpp
@@ -45,7 +45,7 @@ DSiIconSequence::~DSiIconSequence()
 {
 }
 
-int IconSequenceManager::allocate_sequence(u8 *gameTid, u16 *sequence)
+int IconSequenceManager::allocate_sequence(const u8 *gameTid, const u16 *sequence)
 {
 
     int cached;
@@ -72,7 +72,7 @@ int IconSequenceManager::allocate_sequence(u8 *gameTid, u16 *sequence)
     return index;
 }
 
-int IconSequenceManager::is_cached(u8 *gameTid)
+int IconSequenceManager::is_cached(const u8 *gameTid)
 {
     for (auto it =  _dsiIconSequence.begin(); it !=  _dsiIconSequence.end(); ++it) {
         if (memcmp(gameTid, it->gameTid(), SIZE_GAMETID) == 0)

--- a/romsel_aktheme/arm9/source/windows/dsiiconsequence.cpp
+++ b/romsel_aktheme/arm9/source/windows/dsiiconsequence.cpp
@@ -4,8 +4,8 @@
 
 DSiIconSequence::DSiIconSequence()
 {
-    memset(_gameTid, 0, sizeof(_gameTid));
-    memset(_sequence, 0, sizeof(_sequence));
+    toncset(_gameTid, 0, sizeof(_gameTid));
+    toncset(_sequence, 0, sizeof(_sequence));
     _flipH = false;
     _flipV = false;
     _currentSequenceIndex = 0;

--- a/romsel_aktheme/arm9/source/windows/dsiiconsequence.h
+++ b/romsel_aktheme/arm9/source/windows/dsiiconsequence.h
@@ -83,8 +83,8 @@ class IconSequenceManager
 
     }
 
-    int allocate_sequence(u8* gameTid, u16 *sequence);
-    int is_cached(u8* gameTid);
+    int allocate_sequence(const u8* gameTid, const u16 *sequence);
+    int is_cached(const u8* gameTid);
 
     ~IconSequenceManager(){}
 };

--- a/romsel_aktheme/arm9/source/windows/dsiiconsequence.h
+++ b/romsel_aktheme/arm9/source/windows/dsiiconsequence.h
@@ -1,8 +1,6 @@
 /*
-    zoomingicon.h
-    Copyright (C) 2007 Acekard, www.acekard.com
-    Copyright (C) 2007-2009 somebody
-    Copyright (C) 2009 yellow wood goblin
+    dsiiconsequence.h
+    Copyright (C) 2016-2019 chyyran 
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -66,6 +66,7 @@ MainList::MainList(s32 x, s32 y, u32 w, u32 h, Window *parent, const std::string
     _activeIconScale = 1;
     _activeIcon.hide();
     _activeIcon.update();
+    setupExtnames();
     animationManager().addAnimation(&_activeIcon);
     seq();
     dbg_printf("_activeIcon.init\n");
@@ -133,6 +134,49 @@ static bool extnameFilter(const std::vector<std::string> &extNames, std::string 
         }
     }
     return false;
+}
+
+void MainList::setupExtnames() 
+{
+    if (ms().showNds)
+    {
+        _extnameFilter.emplace_back(std::string(".nds"));
+        _extnameFilter.emplace_back(std::string(".ids"));
+        _extnameFilter.emplace_back(std::string(".dsi"));
+        _extnameFilter.emplace_back(std::string(".argv"));
+    }
+	if (memcmp(io_dldi_data->friendlyName, "DSTWO(Slot-1)", 0xD) == 0) {
+		_extnameFilter.emplace_back(std::string(".plg"));
+	}
+    if (ms().showRvid)
+    {
+		_extnameFilter.emplace_back(std::string(".rvid"));
+	}
+    _extnameFilter.emplace_back(std::string(".gba"));
+    if (ms().showGb)
+    {
+        _extnameFilter.emplace_back(std::string(".gb"));
+        _extnameFilter.emplace_back(std::string(".gbc"));
+    }
+    if (ms().showNes)
+    {
+        _extnameFilter.emplace_back(std::string(".nes"));
+        _extnameFilter.emplace_back(std::string(".fds"));
+    }
+    if (ms().showSmsGg)
+    {
+        _extnameFilter.emplace_back(std::string(".sms"));
+        _extnameFilter.emplace_back(std::string(".gg"));
+    }
+    if (ms().showMd)
+    {
+        _extnameFilter.emplace_back(std::string(".gen"));
+    }
+    if (ms().showSnes)
+    {
+        _extnameFilter.emplace_back(std::string(".smc"));
+        _extnameFilter.emplace_back(std::string(".sfc"));
+    }
 }
 
 void MainList::addDirEntry(const std::string row1,
@@ -240,54 +284,7 @@ bool MainList::enterDir(const std::string &dirName)
     cwl();
     removeAllRows();
     _romInfoList.clear();
-
-    std::vector<std::string> extNames;
-
-    if (_showAllFiles || ms().showNds)
-    {
-        extNames.emplace_back(std::string(".nds"));
-        extNames.emplace_back(std::string(".ids"));
-        extNames.emplace_back(std::string(".dsi"));
-        extNames.emplace_back(std::string(".argv"));
-    }
-	if (_showAllFiles || memcmp(io_dldi_data->friendlyName, "DSTWO(Slot-1)", 0xD) == 0) {
-		extNames.emplace_back(std::string(".plg"));
-	}
-    if (_showAllFiles || ms().showRvid)
-    {
-		extNames.emplace_back(std::string(".rvid"));
-	}
-    extNames.emplace_back(std::string(".gba"));
-    if (_showAllFiles || ms().showGb)
-    {
-        extNames.emplace_back(std::string(".gb"));
-        extNames.emplace_back(std::string(".gbc"));
-    }
-    if (_showAllFiles || ms().showNes)
-    {
-        extNames.emplace_back(std::string(".nes"));
-        extNames.emplace_back(std::string(".fds"));
-    }
-    if (_showAllFiles || ms().showSmsGg)
-    {
-        extNames.emplace_back(std::string(".sms"));
-        extNames.emplace_back(std::string(".gg"));
-    }
-    if (_showAllFiles || ms().showMd)
-    {
-        extNames.emplace_back(std::string(".gen"));
-    }
-    if (_showAllFiles || ms().showSnes)
-    {
-        extNames.emplace_back(std::string(".smc"));
-        extNames.emplace_back(std::string(".sfc"));
-    }
-
-    if (_showAllFiles)
-        extNames.clear();
-    std::vector<std::string> savNames;
-    savNames.emplace_back(std::string(".sav"));
-
+ 
     struct stat st;
     dirent *direntry;
     std::string extName;
@@ -322,7 +319,7 @@ bool MainList::enterDir(const std::string &dirName)
             dbg_printf("%s: %s %s\n", (st.st_mode & S_IFDIR ? " DIR" : "FILE"), lfnBuf, extName.c_str());
             cwl();
             bool showThis = (st.st_mode & S_IFDIR) ? ((lfn != "." && lfn != ".." && lfn != "_nds" && lfn != "saves") && ms().showDirectories) // directory filter
-                                                   : extnameFilter(extNames, extName);                                                                                                                // extension name filter
+                                                   : extnameFilter(_showAllFiles ? std::vector<std::string>() : _extnameFilter, extName);                                                                                                                // extension name filter
             showThis = showThis && (_showAllFiles || (strncmp(".", direntry->d_name, 1)));                                                                                                           // Hide dotfiles
             cwl();
             nocashMessage("mainlist:322");

--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -203,7 +203,8 @@ bool MainList::enterDir(const std::string &dirName)
     }
     cwl();
 
-    if (dirName == "^*::")
+    // Only compare first 4 characters
+    if (!strncmp(dirName.c_str(), "^*::", 4))
     {
         dbg_printf("Special directory entered");
         _currentDir = dirName;

--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -186,7 +186,6 @@ void MainList::addDirEntry(const std::string row1,
     const std::string path, const std::string &bannerKey, const u8 *banner)
 {
     nocashMessage("mainlist:140");
-    DSRomInfo rominfo;
 
     std::vector<std::string> a_row;
     a_row.reserve(4);
@@ -203,14 +202,15 @@ void MainList::addDirEntry(const std::string row1,
     nocashMessage(a_row[3].c_str());
     nocashMessage("mainlist:158");
 
-    if (!bannerKey.empty())
-    {
-        rominfo.setBanner(bannerKey, banner);
-    }
-
     appendRow(std::move(a_row));
     nocashMessage("mainlist:157");
-    _romInfoList.push_back(rominfo);
+
+    DSRomInfo romInfo;
+    if (!bannerKey.empty())
+    {
+        romInfo.setBanner(bannerKey, banner);
+    }
+    _romInfoList.emplace_back(std::move(romInfo));
 }
 
 bool MainList::enterDir(const std::string &dirName)
@@ -302,7 +302,7 @@ bool MainList::enterDir(const std::string &dirName)
         
         while ((direntry = readdir(dir)) != NULL)
         {
-            memset(lfnBuf, 0, sizeof(lfnBuf));
+            toncset(lfnBuf, 0, sizeof(lfnBuf));
             snprintf(lfnBuf, sizeof(lfnBuf), "%s/%s", _currentDir.c_str(), direntry->d_name);
             stat(lfnBuf, &st);
             std::string lfn(direntry->d_name);
@@ -373,7 +373,7 @@ bool MainList::enterDir(const std::string &dirName)
                 //else if (".launcharg" == extName || ".argv" == extName)
                 else if (".argv" == extName)
                 {
-                    tonccpy(&rominfo.banner(), unknown_banner_bin, sizeof(tNDSBanner));
+                    // tonccpy(&rominfo.banner(), unknown_banner_bin, sizeof(tNDSBanner));
                     rominfo.MayBeArgv(filename);
                     allowUnknown = true;
                 }

--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -57,6 +57,8 @@
 #include "language.h"
 #include "unicode.h"
 
+#include "common/tonccpy.h"
+
 using namespace akui;
 
 MainList::MainList(s32 x, s32 y, u32 w, u32 h, Window *parent, const std::string &text)
@@ -371,7 +373,7 @@ bool MainList::enterDir(const std::string &dirName)
                 //else if (".launcharg" == extName || ".argv" == extName)
                 else if (".argv" == extName)
                 {
-                    memcpy(&rominfo.banner(), unknown_banner_bin, sizeof(tNDSBanner));
+                    tonccpy(&rominfo.banner(), unknown_banner_bin, sizeof(tNDSBanner));
                     rominfo.MayBeArgv(filename);
                     allowUnknown = true;
                 }
@@ -405,7 +407,7 @@ bool MainList::enterDir(const std::string &dirName)
                 }
                 else if (".nds" != extName && ".ids" != extName && ".dsi" != extName)
                 {
-                    memcpy(&rominfo.banner(), unknown_banner_bin, sizeof(tNDSBanner));
+                    tonccpy(&rominfo.banner(), unknown_banner_bin, sizeof(tNDSBanner));
                     allowUnknown = true;
                 }
                 else
@@ -617,7 +619,7 @@ void MainList::updateActiveIcon(bool updateContent)
             zeroMemory(backBuffer, 32 * 32 * 2);
             
             _romInfoList[_selectedRowId].drawDSRomIconMem(backBuffer);
-            memcpy(_activeIcon.buffer(), backBuffer, 32 * 32 * sizeof(u16));
+            tonccpy(_activeIcon.buffer(), backBuffer, 32 * 32 * sizeof(u16));
             _activeIcon.setBufferChanged();
 
             s32 itemX = _position.x;

--- a/romsel_aktheme/arm9/source/windows/mainlist.h
+++ b/romsel_aktheme/arm9/source/windows/mainlist.h
@@ -128,8 +128,6 @@ protected:
 
   std::string _currentDir;
 
-  std::vector<std::string> _extnameFilter;
-
   std::vector<DSRomInfo> _romInfoList;
 
   ZoomingIcon _activeIcon;
@@ -137,6 +135,11 @@ protected:
   float _activeIconScale;
 
   bool _showAllFiles;
+
+private:
+  void setupExtnames();
+  
+  std::vector<std::string> _extnameFilter;
 };
 
 #endif //_MAINLIST_H_

--- a/romsel_aktheme/arm9/source/windows/mainlist.h
+++ b/romsel_aktheme/arm9/source/windows/mainlist.h
@@ -71,7 +71,7 @@ public:
 public:
   int init();
 
-  void addDirEntry(int pos, const std::string row1, const std::string row2, const std::string path, const std::string &bannerKey, const u8 *banner);
+  void addDirEntry(const std::string row1, const std::string row2, const std::string path, const std::string &bannerKey, const u8 *banner);
 
   bool enterDir(const std::string &dirName);
 
@@ -94,8 +94,6 @@ public:
   VIEW_MODE getViewMode() { return _viewMode; }
 
   void arrangeIcons();
-
-  akui::Signal1<u32> selectedRowHeadClicked;
 
   akui::Signal0 directoryChanged;
 
@@ -121,8 +119,6 @@ protected:
   void updateInternalNames(void);
 
 protected:
-  void onSelectedRowClicked(u32 index);
-
   void onSelectChanged(u32 index);
 
   void onScrolled(u32 index);

--- a/romsel_aktheme/arm9/source/windows/mainwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.cpp
@@ -101,10 +101,6 @@ void MainWnd::init()
     _mainList->directoryChanged.connect(this, &MainWnd::onFolderChanged);
     _mainList->animateIcons.connect(this, &MainWnd::onAnimation);
 
-
-    // This is commented out to prevent a double call of the list select handler when the head (file icon) is clicked.
-    // _mainList->selectedRowHeadClicked.connect(this, &MainWnd::onMainListSelItemHeadClicked);
- 
     addChildWindow(_mainList);
     dbg_printf("mainlist %08x\n", _mainList);
 
@@ -444,9 +440,7 @@ bool MainWnd::processKeyMessage(const KeyMessage &msg)
 
 bool MainWnd::processTouchMessage(const TouchMessage &msg)
 {
-    bool ret = false;
-
-    return ret;
+    return false;
 }
 
 void MainWnd::onKeyYPressed()
@@ -461,6 +455,7 @@ void MainWnd::onMainListSelItemClicked(u32 index)
 
 void MainWnd::onKeyAPressed()
 {
+    cwl();
     launchSelected();
 }
 
@@ -816,11 +811,14 @@ void MainWnd::bootFile(const std::string &loader, const std::string &fullPath)
 
 void MainWnd::launchSelected()
 {
+    cwl();
     dbg_printf("Launch.");
     std::string fullPath = _mainList->getSelectedFullPath();
 
+    cwl();
     if (fullPath[fullPath.size() - 1] == '/')
     {
+        cwl();
         _mainList->enterDir(fullPath);
         return;
     }

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -31,6 +31,7 @@
 #include "language.h"
 #include "unicode.h"
 #include "ui/binaryfind.h"
+#include "common/tonccpy.h"
 
 using namespace akui;
 
@@ -521,7 +522,7 @@ void RomInfoWnd::onShow()
 void RomInfoWnd::addCode(void)
 {
     char gameCode[5];
-    memcpy(gameCode, _romInfo.saveInfo().gameCode, sizeof(_romInfo.saveInfo().gameCode));
+    tonccpy(gameCode, _romInfo.saveInfo().gameCode, sizeof(_romInfo.saveInfo().gameCode));
     gameCode[4] = 0;
     // if (_saveTypeText.length())
     //     _saveTypeText += ", ";

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -480,7 +480,7 @@ void RomInfoWnd::setFileInfo(const std::string &fullName, const std::string &sho
 
 void RomInfoWnd::setRomInfo(const DSRomInfo &romInfo)
 {
-    _romInfo = romInfo;
+    _romInfo = DSRomInfo(romInfo);
 
     auto bannerTitle = _romInfo.banner().titles[ms().getGuiLanguage()];
     _romInfoText = unicode_to_local_string(bannerTitle, 128, NULL);


### PR DESCRIPTION
#### What's changed?
* Switched to `tonccpy`/`toncset` for most usages of `memcpy`/`memset`
* Fix out of bounds dereference in cheat menu when selected index is 0 (fixes crash when pressing left on cheat menu)
* Only allocate space for `tDSiAnimatedBanner` if needed, and not for every `DSRomInfo` (hopefully fixes crashes when enumerating the root SD/SLOT-1 Flashcart directories multiple times)
* Only set up extname filter once (reduces allocations on `enterDir`)
* Rewrite `listview.cpp` row insertion code to be append only and make heavy use of move constructors to prevent unnecessary copies (hopefully fixes crashes when enumerating the root SD/SLOT-1 Flashcart directories multiple times)
* Changed key repeat delays to `(25, 2)` to be inline with DSi Theme

#### Where have you tested it?

* Nintendo DSi (Unlaunch 1.3)
* Nintendo DS Lite
*** 
#### Pull Request status
- [ ]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
