### PR TITLE
More Acekard Theme Fixes

### DIFF
--- a/romsel_aktheme/arm9/source/dsrom.cpp
+++ b/romsel_aktheme/arm9/source/dsrom.cpp
@@ -204,12 +204,18 @@ bool DSRomInfo::loadDSRomInfo(const std::string &filename, bool loadBanner)
                 tonccpy(_dsiIcon->palette_frames, banner.dsi_palette, sizeof(banner.dsi_palette));
                 tonccpy(_dsiIcon->sequence, banner.dsi_seq, sizeof(banner.dsi_seq));
             }
-            tonccpy(&_banner, &banner, sizeof(_banner));
+
+            _banner.crc = ((tNDSBanner*)&banner)->crc;
+            tonccpy(_banner.icon, &banner.icon, sizeof(_banner.icon));
+            tonccpy(_banner.palette,&banner.palette, sizeof(_banner.palette));
+            tonccpy(_banner.title, &banner.titles[ms().getGuiLanguage()], sizeof(_banner.title));
         }
         else
         {
-            tonccpy(&_banner, nds_banner_bin, sizeof(_banner));
-        }
+            _banner.crc = ((tNDSBanner*)nds_banner_bin)->crc;
+            tonccpy(_banner.icon,((tNDSBanner*)nds_banner_bin)->icon, sizeof(_banner.icon));
+            tonccpy(_banner.palette,((tNDSBanner*)nds_banner_bin)->palette, sizeof(_banner.palette));
+            tonccpy(_banner.title, ((tNDSBanner*)nds_banner_bin)->titles[ms().getGuiLanguage()], sizeof(_banner.title));        }
     }
     else
     {
@@ -451,7 +457,11 @@ bool DSRomInfo::loadGbaRomInfo(const std::string &filename)
             _isGbaRom = ETrue;
             tonccpy(_saveInfo.gameCode, header.gamecode, 4);
             _romVersion = header.version;
-            tonccpy(&_banner, gbarom_banner_bin, sizeof(tNDSBanner));
+
+            _banner.crc = ((tNDSBanner*)gbarom_banner_bin)->crc;
+            tonccpy(_banner.icon,((tNDSBanner*)gbarom_banner_bin)->icon, sizeof(_banner.icon));
+            tonccpy(_banner.palette,((tNDSBanner*)gbarom_banner_bin)->palette, sizeof(_banner.palette));
+            tonccpy(_banner.title, ((tNDSBanner*)gbarom_banner_bin)->titles[ms().getGuiLanguage()], sizeof(_banner.title));
             return true;
         }
     }
@@ -485,10 +495,10 @@ void DSRomInfo::load(void)
         loadGbaRomInfo(_fileName);
 }
 
-tNDSBanner &DSRomInfo::banner(void)
+const tNDSCompactedBanner &DSRomInfo::banner(void)
 {
     load();
-    return (tNDSBanner &)_banner;
+    return (tNDSCompactedBanner &)_banner;
 }
 
 const tDSiAnimatedIcon &DSRomInfo::animatedIcon(void)
@@ -553,5 +563,8 @@ void DSRomInfo::setExtIcon(const std::string &aValue)
 void DSRomInfo::setBanner(const std::string &anExtIcon, const u8 *aBanner)
 {
     setExtIcon(anExtIcon);
-    tonccpy(&banner(), aBanner, sizeof(tNDSBanner));
+    _banner.crc = ((tNDSBanner*)aBanner)->crc;
+    tonccpy(_banner.icon,((tNDSBanner*)aBanner)->icon, sizeof(_banner.icon));
+    tonccpy(_banner.palette,((tNDSBanner*)aBanner)->palette, sizeof(_banner.palette));
+    tonccpy(_banner.title, ((tNDSBanner*)aBanner)->titles[ms().getGuiLanguage()], sizeof(_banner.title));
 }

--- a/romsel_aktheme/arm9/source/dsrom.cpp
+++ b/romsel_aktheme/arm9/source/dsrom.cpp
@@ -35,6 +35,7 @@
 #include "gamecode.h"
 
 #include "common/tonccpy.h"
+#include <memory>
 
 static u32 arm9StartSig[4];
 
@@ -42,7 +43,10 @@ DSRomInfo &DSRomInfo::operator=(const DSRomInfo &src)
 {
     tonccpy(&_banner, &src._banner, sizeof(_banner));
     tonccpy(&_saveInfo, &src._saveInfo, sizeof(_saveInfo));
-    tonccpy(&_dsiIcon, &src._dsiIcon, sizeof(_dsiIcon));
+
+    _dsiIcon = std::make_unique<tDSiAnimatedIcon>();
+    tonccpy(_dsiIcon.get(), src._dsiIcon.get(), sizeof(tDSiAnimatedIcon));
+
 
     _isDSRom = src._isDSRom;
     _isHomebrew = src._isHomebrew;
@@ -67,8 +71,10 @@ DSRomInfo::DSRomInfo(const DSRomInfo &src)
 {
     tonccpy(&_banner, &src._banner, sizeof(_banner));
     tonccpy(&_saveInfo, &src._saveInfo, sizeof(_saveInfo));
-    tonccpy(&_dsiIcon, &src._dsiIcon, sizeof(_dsiIcon));
 
+    _dsiIcon = std::make_unique<tDSiAnimatedIcon>();
+    tonccpy(_dsiIcon.get(), src._dsiIcon.get(), sizeof(tDSiAnimatedIcon));
+    
     _isDSRom = src._isDSRom;
     _isHomebrew = src._isHomebrew;
     _isGbaRom = src._isGbaRom;

--- a/romsel_aktheme/arm9/source/dsrom.h
+++ b/romsel_aktheme/arm9/source/dsrom.h
@@ -38,6 +38,13 @@ typedef struct {
 	u16 sequence[64];
 } tDSiAnimatedIcon;
 
+typedef struct {
+  u16 crc;
+  u8 icon[512];
+  u16 palette[16];
+  u16 title[128];
+} tNDSCompactedBanner;
+
 class DSRomInfo
 {
 private:
@@ -49,7 +56,7 @@ private:
   };
 
 private:
-  tNDSBanner _banner;
+  tNDSCompactedBanner _banner;
   SAVE_INFO_EX _saveInfo;
   TBool _isDSRom;
   TBool _isHomebrew;
@@ -95,7 +102,7 @@ public:
   void drawDSRomIconMem(void *mem);
   void drawDSiAnimatedRomIconMem(void *mem, u8 frame, u8 palette, bool flipH, bool flipV);
 
-  tNDSBanner &banner(void);
+  const tNDSCompactedBanner &banner(void);
   const tDSiAnimatedIcon &animatedIcon(void);
   SAVE_INFO_EX &saveInfo(void);
   u8 version(void);

--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -407,7 +407,7 @@ bool MainList::enterDir(const std::string &dirName)
                 }
                 else if (".nds" != extName && ".ids" != extName && ".dsi" != extName)
                 {
-                    tonccpy(&rominfo.banner(), unknown_banner_bin, sizeof(tNDSBanner));
+                    rominfo.setBanner("", unknown_banner_bin);
                     allowUnknown = true;
                 }
                 else
@@ -661,7 +661,7 @@ void MainList::updateInternalNames(void)
                 if (_romInfoList[_firstVisibleRowId + ii].isDSRom())
                 {
                     _rows[_firstVisibleRowId + ii][INTERNALNAME_COLUMN]
-                        .setText(unicode_to_local_string(_romInfoList[_firstVisibleRowId + ii].banner().titles[ms().getGuiLanguage()], 128, NULL));
+                        .setText(unicode_to_local_string(_romInfoList[_firstVisibleRowId + ii].banner().title, 128, NULL));
                 }
                 else
                 {

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -480,9 +480,8 @@ void RomInfoWnd::setFileInfo(const std::string &fullName, const std::string &sho
 
 void RomInfoWnd::setRomInfo(const DSRomInfo &romInfo)
 {
-    _romInfo = DSRomInfo(romInfo);
-
-    auto bannerTitle = _romInfo.banner().titles[ms().getGuiLanguage()];
+    _romInfo = romInfo;
+    auto bannerTitle = _romInfo.banner().title;
     _romInfoText = unicode_to_local_string(bannerTitle, 128, NULL);
 
     _buttonGameSettings.hide();


### PR DESCRIPTION
* Properly copies DSi Animated Icon data in copy constructor
* Reduces size of `DSRomInfo` class to 952 bytes by discarding unused title strings when caching 