### PR TITLE
akmenu: reorder tNDSCompactedBanner members to pack better

### DIFF
--- a/romsel_aktheme/arm9/source/dsrom.h
+++ b/romsel_aktheme/arm9/source/dsrom.h
@@ -39,10 +39,10 @@ typedef struct {
 } tDSiAnimatedIcon;
 
 typedef struct {
-  u16 crc;
   u8 icon[512];
-  u16 palette[16];
   u16 title[128];
+  u16 palette[16];
+  u16 crc;
 } tNDSCompactedBanner;
 
 class DSRomInfo


### PR DESCRIPTION
* just reorders the struct from largest to smallest for packing reasons