### PR TITLE
Acekard Theme SystemFilenames Fixes

### DIFF
--- a/romsel_aktheme/arm9/source/main.cpp
+++ b/romsel_aktheme/arm9/source/main.cpp
@@ -116,17 +116,22 @@ int main(int argc, char **argv)
 	// consoleDemoInit();
 	// printf("Ok...");
 	// stop();
-
+	nocashMessage("begin");
 	defaultExceptionHandler();
+	nocashMessage("except init");
 	sys().initFilesystem();
+	nocashMessage("fs init");
 	sys().initArm7RegStatuses();
+	nocashMessage("arm7 init");
 	ms().loadSettings();
+	nocashMessage("settings init");
 
 	// init basic system
 	sysSetBusOwners(BUS_OWNER_ARM9, BUS_OWNER_ARM9);
 
 
-	sfn().uiDirectory();
+	sfn().initFilenames();
+	nocashMessage("sfn init");
 	irq().init();
 
 	gdi().init();

--- a/romsel_aktheme/arm9/source/systemfilenames.cpp
+++ b/romsel_aktheme/arm9/source/systemfilenames.cpp
@@ -5,27 +5,29 @@
 #include "tool/stringtool.h"
 #include "common/dsimenusettings.h"
 
-SystemFilenames::SystemFilenames()
+void SystemFilenames::initFilenames()
 {
     std::string systemDirectory = formatString(SFN_SYSTEM_UI_DIRECTORY "%s", ms().ak_theme.c_str());
-    if (!sys().useNitroFS())
-    {
-        // nocashMessage("NNONITROFS");
-        // nocashMessage(systemDirectory.c_str());
-        _uiDirectory = systemDirectory;
-    }
-    else
-    {
-        if (access((systemDirectory + "/uisettings.ini").c_str(), F_OK) == 0)
+        if (!sys().useNitroFS())
         {
-            // nocashMessage("NITROFSOK");
-            // nocashMessage(systemDirectory.c_str());
+            nocashMessage("NNONITROFS");
+            nocashMessage(systemDirectory.c_str());
+            nocashMessage(ms().ak_theme.c_str());
             _uiDirectory = systemDirectory;
         }
         else
-        {  
-            cwl();
-            _uiDirectory = SFN_FALLBACK_UI_DIRECTORY;
+        {
+            if (access((systemDirectory + "/uisettings.ini").c_str(), F_OK) == 0)
+            {
+                nocashMessage("NITROFSOK");
+                nocashMessage(systemDirectory.c_str());
+                _uiDirectory = systemDirectory;
+            }
+            else
+            {  
+                cwl();
+                nocashMessage(SFN_FALLBACK_UI_DIRECTORY);
+                _uiDirectory = SFN_FALLBACK_UI_DIRECTORY;
+            }
         }
-    }
 }

--- a/romsel_aktheme/arm9/source/systemfilenames.h
+++ b/romsel_aktheme/arm9/source/systemfilenames.h
@@ -98,9 +98,11 @@ class SystemFilenames
     private:
         std::string _uiDirectory;
     public:
-        SystemFilenames();
+        SystemFilenames() {}
         
         ~SystemFilenames(){}
+
+        void initFilenames();
     public: 
         inline const std::string& uiDirectory() { return _uiDirectory; }
   

--- a/romsel_aktheme/arm9/source/ui/listview.cpp
+++ b/romsel_aktheme/arm9/source/ui/listview.cpp
@@ -57,6 +57,7 @@ ListView::ListView(s32 x, s32 y, u32 w, u32 h, Window *parent, const std::string
     _engine = GE_MAIN;
     _scrollSpeed = scrollSpeed;
     _touchMovedAfterTouchDown = false;
+    _barPic = createBMP15FromFile(SFN_LIST_BAR_BG);
 }
 
 void ListView::arangeColumnsSize()
@@ -126,7 +127,6 @@ void ListView::draw()
     drawText();
 }
 
-const BMP15 _barPic = createBMP15FromFile(SFN_LIST_BAR_BG);
 void ListView::drawSelectionBar()
 {
     //if( _touchMovedAfterTouchDown )

--- a/romsel_aktheme/arm9/source/ui/listview.h
+++ b/romsel_aktheme/arm9/source/ui/listview.h
@@ -161,6 +161,7 @@ class ListView : public Window
     void drawText();
 
   protected:
+    BMP15 _barPic;
     std::string _text;
     u16 _rowHeight;
     u16 _textColor;

--- a/romsel_aktheme/arm9/source/windows/batteryicon.cpp
+++ b/romsel_aktheme/arm9/source/windows/batteryicon.cpp
@@ -38,6 +38,13 @@ BatteryIcon::BatteryIcon() : Window(NULL, "batteryicon")
     } else {
         _engine = GE_MAIN;
     }
+    
+    _batteryCharge = createBMP15FromFile(SFN_BATTERY_CHARGE);
+    _battery1 = createBMP15FromFile(SFN_BATTERY1);
+    _battery2 = createBMP15FromFile(SFN_BATTERY2);
+    _battery3 = createBMP15FromFile(SFN_BATTERY3);
+    _battery4 = createBMP15FromFile(SFN_BATTERY4);
+
     _icon.init(1);
     _icon.setPosition(226, 174);
     _icon.setPriority(3);
@@ -58,29 +65,29 @@ void BatteryIcon::draw()
 
 		if (isDSiMode()) {
 			if (batteryLevel & BIT(7)) {
-				loadAppearance(SFN_BATTERY_CHARGE);
+				drawIcon(_batteryCharge);
 			} else if (batteryLevel == 0xF) {
-				loadAppearance(SFN_BATTERY4);
+				drawIcon(_battery4);
 			} else if (batteryLevel == 0xB) {
-				loadAppearance(SFN_BATTERY3);
+				drawIcon(_battery3);
 			} else if (batteryLevel == 0x7) {
-				loadAppearance(SFN_BATTERY2);
+				drawIcon(_battery2);
 			} else if (batteryLevel == 0x3 || batteryLevel == 0x1) {
-				loadAppearance(SFN_BATTERY1);
+				drawIcon(_battery1);
 			} else {
-				loadAppearance(SFN_BATTERY_CHARGE);
+				drawIcon(_batteryCharge);
 			}
 		} else {
 			if (batteryLevel & BIT(0)) {
-				loadAppearance(SFN_BATTERY1);
+				drawIcon(_battery1);
 			} else {
-				loadAppearance(SFN_BATTERY4);
+				drawIcon(_battery4);
 			}
 		}
     }
 }
 
-Window &BatteryIcon::loadAppearance(const std::string &aFileName)
+void BatteryIcon::drawIcon(BMP15 &icon)
 {
 
     CIniFile ini(SFN_UI_SETTINGS);
@@ -89,12 +96,9 @@ Window &BatteryIcon::loadAppearance(const std::string &aFileName)
     u16 y = ini.GetInt("battery icon", "y", 172);
     _icon.setPosition(x, y);
 
-    BMP15 icon = createBMP15FromFile(aFileName);
-
     if(ini.GetInt("battery icon", "screen", true)) {
         gdi().maskBlt(icon.buffer(), x, y, icon.width(), icon.height(), _engine);
     }
 
-    dbg_printf("cBatteryIcon::loadAppearance ok %d\n", icon.valid());
-    return *this;
+    dbg_printf("cBatteryIcon::drawIcon ok %d\n", icon.valid());
 }

--- a/romsel_aktheme/arm9/source/windows/batteryicon.h
+++ b/romsel_aktheme/arm9/source/windows/batteryicon.h
@@ -39,10 +39,17 @@ class BatteryIcon : public akui::Window
   public:
     void draw();
 
-    akui::Window &loadAppearance(const std::string &aFileName);
+    void drawIcon(BMP15 &icon);
 
+    akui::Window &loadAppearance(const std::string &aFileName) { return *this; }
 
   protected:
+    BMP15 _batteryCharge;
+    BMP15 _battery1;
+    BMP15 _battery2;
+    BMP15 _battery3;
+    BMP15 _battery4;
+
     bool _draw;
 
     float _lightTime;

--- a/romsel_aktheme/arm9/source/windows/volumeicon.cpp
+++ b/romsel_aktheme/arm9/source/windows/volumeicon.cpp
@@ -38,6 +38,13 @@ VolumeIcon::VolumeIcon() : Window(NULL, "volumeicon")
     } else {
         _engine = GE_MAIN;
     }
+
+    _volIcon0 =  createBMP15FromFile(SFN_VOLUME0);
+    _volIcon1 =  createBMP15FromFile(SFN_VOLUME1);
+    _volIcon2 =  createBMP15FromFile(SFN_VOLUME2);
+    _volIcon3 =  createBMP15FromFile(SFN_VOLUME3);
+    _volIcon4 =  createBMP15FromFile(SFN_VOLUME4);
+
     _icon.init(1);
     _icon.setPosition(226, 174);
     _icon.setPriority(3);
@@ -58,20 +65,20 @@ void VolumeIcon::draw()
         u8 volumeLevel = sys().volumeStatus();
         
         if (volumeLevel >= 0x1C && volumeLevel < 0x20) {
-            loadAppearance(SFN_VOLUME4);
+            drawIcon(_volIcon4);
         } else if (volumeLevel >= 0x11 && volumeLevel < 0x1C) {
-            loadAppearance(SFN_VOLUME3);
+            drawIcon(_volIcon3);
         } else if (volumeLevel >= 0x07 && volumeLevel < 0x11) {
-            loadAppearance(SFN_VOLUME2);
+            drawIcon(_volIcon2);
         } else if (volumeLevel > 0x00 && volumeLevel < 0x07) {
-            loadAppearance(SFN_VOLUME1);
+            drawIcon(_volIcon1);
         } else {
-            loadAppearance(SFN_VOLUME0);
+            drawIcon(_volIcon0);
         }
     }
 }
 
-Window &VolumeIcon::loadAppearance(const std::string &aFileName)
+void VolumeIcon::drawIcon(const BMP15 &icon)
 {
 
     CIniFile ini(SFN_UI_SETTINGS);
@@ -79,8 +86,6 @@ Window &VolumeIcon::loadAppearance(const std::string &aFileName)
     u16 x = ini.GetInt("volume icon", "x", 238);
     u16 y = ini.GetInt("volume icon", "y", 172);
     _icon.setPosition(x, y);
-
-    BMP15 icon = createBMP15FromFile(aFileName);
 
     if(ini.GetInt("volume icon", "screen", true)) {
     gdi().maskBlt(icon.buffer(), x, y, icon.width(), icon.height(), _engine);
@@ -95,6 +100,5 @@ Window &VolumeIcon::loadAppearance(const std::string &aFileName)
 	    }
     }
 
-    dbg_printf("cVolumeIcon::loadAppearance ok %d\n", icon.valid());
-    return *this;
+    dbg_printf("cVolumeIcon::drawIcon ok %d\n", icon.valid());
 }

--- a/romsel_aktheme/arm9/source/windows/volumeicon.h
+++ b/romsel_aktheme/arm9/source/windows/volumeicon.h
@@ -41,8 +41,9 @@ class VolumeIcon : public akui::Window
 
     void drawBottom();
 
-    akui::Window &loadAppearance(const std::string &aFileName);
+    void drawIcon(const BMP15 &icon);
 
+    akui::Window& loadAppearance(const std::string &filename) { return *this; };
 
   protected:
     bool _draw;
@@ -51,6 +52,11 @@ class VolumeIcon : public akui::Window
 
     Sprite _icon;
 
+    BMP15 _volIcon0;
+    BMP15 _volIcon1;
+    BMP15 _volIcon2;
+    BMP15 _volIcon3;
+    BMP15 _volIcon4;
 };
 
 typedef singleton<VolumeIcon> volumeIcon_s;


### PR DESCRIPTION
* Properly delay loading of SystemFilenames to fix subthemes not loading
  * A change in `listview` caused `sfn` to load earlier than `ms` would, defaulting every theme to zelda.
* Make battery and volume icons only load once