### PR TITLE
add a "lite" download, which excludes the widescreen and apfix folders

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,11 @@ jobs:
         rm -r 7zfile/_nds/TWiLightMenu/*menu/
         mv 7zfile/ TWiLightMenu/
         7z a TWiLightMenu.7z TWiLightMenu/
+        rm -r TWiLightMenu/_nds/TWiLightMenu/widescreen/
+        rm -r TWiLightMenu/_nds/TWiLightMenu/apfix/
+        7z a TWiLightMenu-Lite.7z TWiLightMenu/
         cp TWiLightMenu.7z $(Build.ArtifactStagingDirectory)/TWiLightMenu.7z
+        cp TWiLigtMenu-Lite.7z $(Build.ArtifactStagingDirectory)/TWiLightMenu-Lite.7z
       condition: not(startsWith(variables['Build.SourceBranchName'], 'v'))
       displayName: 'Pack 7z Package for nightly'
 
@@ -169,6 +173,7 @@ jobs:
           git clone --depth 1 https://$GITHUB_TOKEN@github.com/TWLBot/Builds.git
           cd Builds/
           cp $(Build.ArtifactStagingDirectory)/build-devkitARM-latest/TWiLightMenu.7z TWiLightMenu.7z
+          cp $(Build.ArtifactStagingDirectory)/build-devkitARM-latest/TWiLightMenu-Lite.7z TWiLightMenu-Lite.7z
           cp $(Build.ArtifactStagingDirectory)/build-devkitARM-Docker/TWiLightMenu_docker.7z TWiLightMenu_docker.7z
           git stage .
           git commit -m "TWiLightMenu | $(COMMIT_TAG)"


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
Added a "lite" download excluding apfix and widescreen folders, as including them makes the extraction super slow on 3ds
_Tell us what you've changed._

#### Where have you tested it?
nowhere :ultraXD:, but I'm 99% sure it will work
_Tell us where have you tested it._

*** 
#### Pull Request status
- [ ]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
