### PR TITLE
Fix cheat description crash

### DIFF
--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -438,7 +438,7 @@ void CheatCodelist::selectCheats(std::string filename)
     }
     if(pressed & KEY_Y) {
       if(currentList[cheatWnd_cursorPosition]._comment != "") {
-		(ms().theme == 4) ? snd().playLaunch() : snd().playSelect();
+        (ms().theme == 4) ? snd().playLaunch() : snd().playSelect();
         clearText();
         printLargeCentered(false, 30, "Cheats");
 
@@ -469,13 +469,12 @@ void CheatCodelist::selectCheats(std::string filename)
           _topText.push_back(temp);
         
         // Print comment
-        for(int i = 0; i < (int)_topText.size() || i < 2; i++) {
+        for(int i = 0; i < (int)_topText.size(); i++) {
           printSmallCentered(false, 60 + (i*12), _topText[i].c_str());
         }
 
         // Print 'Back' text
         printSmallCentered(false, 160, BUTTON_B" Back");
-
         while(1) {
           scanKeys();
           pressed = keysDown();
@@ -488,7 +487,7 @@ void CheatCodelist::selectCheats(std::string filename)
           snd().updateStream();
           swiWaitForVBlank();
           if(pressed & KEY_B) {
-		    snd().playBack();
+            snd().playBack();
             break;
           }
         }

--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -45,9 +45,9 @@ CheatCodelist::~CheatCodelist(void) {}
 
 inline u32 gamecode(const char *aGameCode)
 {
-    u32 gameCode;
-    tonccpy(&gameCode, aGameCode, sizeof(gameCode));
-    return gameCode;
+  u32 gameCode;
+  tonccpy(&gameCode, aGameCode, sizeof(gameCode));
+  return gameCode;
 }
 
 #define CRCPOLY 0xedb88320
@@ -296,7 +296,7 @@ void CheatCodelist::selectCheats(std::string filename)
       snd().updateStream();
       swiWaitForVBlank();
       if(pressed & KEY_B) {
-		snd().playBack();
+        snd().playBack();
         break;
       }
     }
@@ -369,22 +369,22 @@ void CheatCodelist::selectCheats(std::string filename)
   } while(!pressed && !held);
     if(held & KEY_UP) {
       if(cheatWnd_cursorPosition>0) {
-	    snd().playSelect();
+        snd().playSelect();
         cheatWnd_cursorPosition--;
       }
     } else if(held & KEY_DOWN) {
       if(cheatWnd_cursorPosition<((int)currentList.size()-1)) {
-	    snd().playSelect();
+        snd().playSelect();
         cheatWnd_cursorPosition++;
       }
     } else if(held & KEY_LEFT) {
-	  snd().playSelect();
+      snd().playSelect();
       cheatWnd_cursorPosition -= (cheatWnd_cursorPosition > 8 ? 8 : cheatWnd_cursorPosition);
     } else if(held & KEY_RIGHT) {
-	  snd().playSelect();
+     snd().playSelect();
       cheatWnd_cursorPosition += (cheatWnd_cursorPosition < (int)(currentList.size()-8) ? 8 : currentList.size()-cheatWnd_cursorPosition-1);
     } else if(pressed & KEY_A) {
-	  (ms().theme == 4) ? snd().playLaunch() : snd().playSelect();
+      (ms().theme == 4) ? snd().playLaunch() : snd().playSelect();
       if(currentList[cheatWnd_cursorPosition]._flags&cParsedItem::EFolder) {
         for(uint i=0;i<_data.size();i++) {
           if(_data[i]._title == currentList[cheatWnd_cursorPosition]._title) {
@@ -413,7 +413,7 @@ void CheatCodelist::selectCheats(std::string filename)
       }
     }
     if(pressed & KEY_B) {
-	  snd().playBack();
+      snd().playBack();
       if(mainListCurPos != -1) {
         currentList.clear();
         for(uint i=0;i<_data.size();i++) {
@@ -429,7 +429,7 @@ void CheatCodelist::selectCheats(std::string filename)
       }
     }
     if(pressed & KEY_X) {
-	  snd().playLaunch();
+      snd().playLaunch();
       clearText();
       printLargeCentered(false, 30, "Cheats");
       printSmallCentered(false, 100, "Saving...");

--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -238,24 +238,14 @@ std::string CheatCodelist::getCheats()
 void CheatCodelist::drawCheatList(std::vector<CheatCodelist::cParsedItem>& list, uint curPos, uint screenPos) {
   for(uint i=0;i<8 && i<list.size();i++) {
     if(list[screenPos+i]._flags&cParsedItem::EFolder) {
-      if(screenPos+i == curPos) {
-        printSmall(false, 20, 60+(i*12), ">");
-        printSmall(false, 32, 60+(i*12), list[screenPos+i]._title.c_str());
-      } else {
-        printSmall(false, 15, 60+(i*12), ">");
-        printSmall(false, 28, 60+(i*12), list[screenPos+i]._title.c_str());
-      }
+      printSmall(false, 15+((screenPos+i == curPos) ? 5 : 0), 60+(i*12), ">");
+      printSmall(false, 28+((screenPos+i == curPos) ? 4 : 0), 60+(i*12), list[screenPos+i]._title.c_str());
     } else {
       if(list[screenPos+i]._flags&cParsedItem::ESelected) {
         printSmall(false, 13, 60+(i*12), "x");
       }
-      if(screenPos+i == curPos) {
-        printSmall(false, 25, 60+(i*12), "-");
-        printSmall(false, 32, 60+(i*12), list[screenPos+i]._title.c_str());
-      } else {
-        printSmall(false, 21, 60+(i*12), "-");
-        printSmall(false, 28, 60+(i*12), list[screenPos+i]._title.c_str());
-      }
+      printSmall(false, 21+((screenPos+i == curPos) ? 4 : 0), 60+(i*12), "-");
+      printSmall(false, 28+((screenPos+i == curPos) ? 7 : 0), 60+(i*12), list[screenPos+i]._title.c_str());
     }
   }
 }

--- a/settings/arm9/source/settingsgui.cpp
+++ b/settings/arm9/source/settingsgui.cpp
@@ -205,7 +205,7 @@ void SettingsGUI::drawTopText()
 {
 	printSmall(true, 4, 0, "nds-bootstrap Ver:");
 	printSmall(true, 114, 0, bsVerText[ms().bootstrapFile]);
-    printSmall(true, 194, 174, VERTEXT);
+    printSmall(true, 256-calcSmallFontWidth(VERTEXT)-4, 174, VERTEXT);
     for (unsigned int i = 0; i < _topText.size(); i++)
     {
         printLargeCentered(true, 96 + (i * 16), _topText[i].c_str());


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes the romsel_dsimenutheme themes crashing when viewing some cheat descriptions
- Also fixes the positioning of the version number in settings

#### Where have you tested it?

DSi (K) with the latest TWiLight Menu++ / Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
