### PR TITLE
Use actual image size instead of preset sizes for box art

### DIFF
--- a/quickmenu/arm9/source/graphics/graphics.cpp
+++ b/quickmenu/arm9/source/graphics/graphics.cpp
@@ -367,8 +367,7 @@ void vBlankHandler()
 }
 
 void loadBoxArt(const char* filename) {
-	FILE* file = fopen(filename, "rb");
-	if (!file) {
+	if(access(filename, F_OK) != 0) {
 		switch (boxArtType) {
 			case 0:
 			default:
@@ -384,79 +383,28 @@ void loadBoxArt(const char* filename) {
 				filename = "nitro:/graphics/boxart_unknown3.png";
 				break;
 		}
-		file = fopen(filename, "rb");
 	}
 
-	if (file) {
-		extern bool extention(const std::string& filename, const char* ext);
+	std::vector<unsigned char> image;
+	uint imageXpos, imageYpos, imageWidth, imageHeight;
+	lodepng::decode(image, imageWidth, imageHeight, filename);
+	if(imageWidth > 256 || imageHeight > 192)	return;
 
-		int imageXpos = 0;
-		int imageWidth = 0;
-
-		switch (boxArtType) {
-			case 0:
-			default:
-				imageXpos = 64;
-				imageWidth = 128;
-				break;
-			case 1:
-				imageXpos = 70;
-				imageWidth = 115;
-				break;
-			case 2:
-				imageXpos = 86;
-				imageWidth = 84;
-				break;
-			case 3:
-				imageXpos = 49;
-				imageWidth = 158;
-				break;
-		}
-
-		// Start loading
-		if (extention(filename, ".png")) {
-			std::vector<unsigned char> image;
-			unsigned width, height;
-			lodepng::decode(image, width, height, filename);
-			for(unsigned i=0;i<image.size()/4;i++) {
-				bmpImageBuffer[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
-				if (colorMode == 1) {
-					bmpImageBuffer[i] = convertVramColorToGrayscale(bmpImageBuffer[i]);
-				}
-			}
-			u16* src = bmpImageBuffer;
-			int x = imageXpos;
-			int y = 40;
-			for (int i = 0; i < imageWidth * 115; i++) {
-				if (x >= imageXpos + imageWidth) {
-					x = imageXpos;
-					y++;
-				}
-				u16 val = *(src++);
-				BG_GFX_SUB[y*256+x] = val;
-				x++;
-			}
-		} else {
-			fseek(file, 0xe, SEEK_SET);
-			u8 pixelStart = (u8)fgetc(file) + 0xe;
-			fseek(file, pixelStart, SEEK_SET);
-			fread(bmpImageBuffer, 2, 0x7800, file);
-			u16* src = bmpImageBuffer;
-			int x = imageXpos;
-			int y = 40+114;
-			for (int i = 0; i < imageWidth * 115; i++) {
-				if (x >= imageXpos + imageWidth) {
-					x = imageXpos;
-					y--;
-				}
-				u16 val = *(src++);
-				BG_GFX_SUB[y*256+x] = convertToDsBmp(val);
-				x++;
-			}
+	for(uint i=0;i<image.size()/4;i++) {
+		bmpImageBuffer[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
+		if (colorMode == 1) {
+			bmpImageBuffer[i] = convertVramColorToGrayscale(bmpImageBuffer[i]);
 		}
 	}
 
-	fclose(file);
+	imageXpos = (256-imageWidth)/2;
+	imageYpos = (192-imageHeight)/2;
+	u16 *src = bmpImageBuffer;
+	for(uint y = 0; y < imageHeight; y++) {
+		for(uint x = 0; x < imageWidth; x++) {
+			BG_GFX_SUB[(y+imageYpos) * 256 + imageXpos + x] = *(src++);
+		}
+	}
 }
 
 void topBgLoad(void) {

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -679,8 +679,7 @@ TWL_CODE void ThemeTextures::loadBoxArtToMem(const char *filename, int num) {
 }
 
 void ThemeTextures::drawBoxArt(const char *filename) {
-	FILE *file = fopen(filename, "rb");
-	if (!file) {
+	if(access(filename, F_OK) != 0) {
 		switch (boxArtType[CURPOS]) {
 			case 0:
 			default:
@@ -696,80 +695,31 @@ void ThemeTextures::drawBoxArt(const char *filename) {
 				filename = "nitro:/graphics/boxart_unknown3.png";
 				break;
 		}
-		file = fopen(filename, "rb");
 	}
 
-	if (file) {
-		extern bool extention(const std::string& filename, const char* ext);
+	beginBgSubModify();
 
-		int imageXpos = 0;
-		int imageWidth = 0;
+	std::vector<unsigned char> image;
+	uint imageXpos, imageYpos, imageWidth, imageHeight;
+	lodepng::decode(image, imageWidth, imageHeight, filename);
+	if(imageWidth > 256 || imageHeight > 192)	return;
 
-		switch (boxArtType[CURPOS]) {
-			case 0:
-			default:
-				imageXpos = 64;
-				imageWidth = 128;
-				break;
-			case 1:
-				imageXpos = 70;
-				imageWidth = 115;
-				break;
-			case 2:
-				imageXpos = 86;
-				imageWidth = 84;
-				break;
-			case 3:
-				imageXpos = 49;
-				imageWidth = 158;
-				break;
+	for(uint i=0;i<image.size()/4;i++) {
+		_bmpImageBuffer[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
+		if (ms().colorMode == 1) {
+			_bmpImageBuffer[i] = convertVramColorToGrayscale(_bmpImageBuffer[i]);
 		}
-
-		// Start loading
-		beginBgSubModify();
-		if (extention(filename, ".png")) {
-			std::vector<unsigned char> image;
-			unsigned width, height;
-			lodepng::decode(image, width, height, filename);
-			for(unsigned i=0;i<image.size()/4;i++) {
-				_bmpImageBuffer[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
-				if (ms().colorMode == 1) {
-					_bmpImageBuffer[i] = convertVramColorToGrayscale(_bmpImageBuffer[i]);
-				}
-			}
-			u16 *src = _bmpImageBuffer;
-			int x = imageXpos;
-			int y = 40;
-			for (int i = 0; i < imageWidth * 115; i++) {
-				if (x >= imageXpos + imageWidth) {
-					x = imageXpos;
-					y++;
-				}
-				u16 val = *(src++);
-				_bgSubBuffer[y * 256 + x] = val;
-				x++;
-			}
-		} else {
-			fseek(file, 0xe, SEEK_SET);
-			u8 pixelStart = (u8)fgetc(file) + 0xe;
-			fseek(file, pixelStart, SEEK_SET);
-			fread(_bmpImageBuffer, 2, 0x7800, file);
-			u16 *src = _bmpImageBuffer;
-			int x = imageXpos;
-			int y = 40 + 114;
-			for (int i = 0; i < imageWidth * 115; i++) {
-				if (x >= imageXpos + imageWidth) {
-					x = imageXpos;
-					y--;
-				}
-				u16 val = *(src++);
-				_bgSubBuffer[y * 256 + x] = convertToDsBmp(val);
-				x++;
-			}
-		}
-		commitBgSubModify();
 	}
-	fclose(file);
+
+	imageXpos = (256-imageWidth)/2;
+	imageYpos = (192-imageHeight)/2;
+	u16 *src = _bmpImageBuffer;
+	for(uint y = 0; y < imageHeight; y++) {
+		for(uint x = 0; x < imageWidth; x++) {
+			_bgSubBuffer[(y+imageYpos) * 256 + imageXpos + x] = *(src++);
+		}
+	}
+	commitBgSubModify();
 }
 
 void ThemeTextures::drawBoxArtFromMem(int num) {
@@ -782,51 +732,28 @@ void ThemeTextures::drawBoxArtFromMem(int num) {
 		return;
 	}
 
-	int imageXpos = 0;
-	int imageWidth = 0;
-
-	switch (boxArtType[num]) {
-		case 0:
-		default:
-			imageXpos = 64;
-			imageWidth = 128;
-			break;
-		case 1:
-			imageXpos = 70;
-			imageWidth = 115;
-			break;
-		case 2:
-			imageXpos = 86;
-			imageWidth = 84;
-			break;
-		case 3:
-			imageXpos = 49;
-			imageWidth = 158;
-			break;
-	}
+	uint imageXpos, imageYpos, imageWidth, imageHeight;
 
 	// Start loading
 	beginBgSubModify();
 	std::vector<unsigned char> image;
-	unsigned width, height;
-	lodepng::decode(image, width, height, (unsigned char*)boxArtCache+(num*0xB000), 0xB000);
-	for(unsigned i=0;i<image.size()/4;i++) {
+	lodepng::decode(image, imageWidth, imageHeight, (unsigned char*)boxArtCache+(num*0xB000), 0xB000);
+	if(imageWidth > 256 || imageHeight > 192)	return;
+
+	for(uint i=0;i<image.size()/4;i++) {
 		_bmpImageBuffer[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
 		if (ms().colorMode == 1) {
 			_bmpImageBuffer[i] = convertVramColorToGrayscale(_bmpImageBuffer[i]);
 		}
 	}
+
+	imageXpos = (256-imageWidth)/2;
+	imageYpos = (192-imageHeight)/2;
 	u16 *src = _bmpImageBuffer;
-	int x = imageXpos;
-	int y = 40;
-	for (int i = 0; i < imageWidth * 115; i++) {
-		if (x >= imageXpos + imageWidth) {
-			x = imageXpos;
-			y++;
+	for(uint y = 0; y < imageHeight;y++) {
+		for(uint x = 0; x < imageWidth; x++) {
+			_bgSubBuffer[(y+imageYpos) * 256 + imageXpos + x] = *(src++);
 		}
-		u16 val = *(src++);
-		_bgSubBuffer[y * 256 + x] = val;
-		x++;
 	}
 	commitBgSubModify();
 }


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
- This makes the box art use the actual size of the image its drawing instead of a preset for that type of rom
- Any size from 0x0 to 256x192 should work and bigger are ignored (though you don't really want to go larger than the user photo picture)
- Both cache and non-cache modes are working for me (DSi), however I can't test on flashcard

#### Where have you tested it?

DSi (K) with latest TWiLight & Unlaunch.

Video: (Spirit Tracks is 100x100, Heart Gold is 256x192, ホワイト is 258x192 (too big, so skipped))
![out](https://user-images.githubusercontent.com/41608708/71760386-6eeeee80-2e82-11ea-85ea-f4e14b685ed3.gif)


*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
