### PR TITLE
Add proper UTF-8 handling

### DIFF
--- a/manual/arm9/source/graphics/FontGraphic.cpp
+++ b/manual/arm9/source/graphics/FontGraphic.cpp
@@ -56,9 +56,22 @@ int FontGraphic::load(int textureID, glImage *_font_sprite,
  */
 unsigned int FontGraphic::getSpriteIndex(const u16 letter) {
 	unsigned int spriteIndex = 0;
-	for (unsigned int i = 0; i < imageCount; i++) {
-		if (mapping[i] == letter) {
-			spriteIndex = i;
+	long int left = 0;
+	long int right = imageCount;
+	long int mid = 0;
+
+	while (left <= right)
+	{
+		mid = left + ((right - left) / 2);
+		if (mapping[mid] == letter) {
+			spriteIndex = mid;
+			break;
+		}
+
+		if (mapping[mid] < letter) {
+			left = mid + 1;
+		} else {
+			right = mid - 1;
 		}
 	}
 	return spriteIndex;
@@ -66,22 +79,25 @@ unsigned int FontGraphic::getSpriteIndex(const u16 letter) {
 
 void FontGraphic::print(int x, int y, const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) { // check if the lower bits is the signal bits.
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++; // LSB
-			highBits = *(unsigned char*) text++; // HSB
-			u16 assembled = (u16)(lowBits | highBits << 8);
-			
-			fontChar = getSpriteIndex(assembled);
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
-		
+
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}
@@ -89,20 +105,25 @@ void FontGraphic::print(int x, int y, const char *text)
 
 int FontGraphic::calcWidth(const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	int x = 0;
 
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
 		x += fontSprite[fontChar].width;
@@ -118,19 +139,24 @@ void FontGraphic::print(int x, int y, int value)
 
 int FontGraphic::getCenteredX(const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	int total_width = 0;
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
 		total_width += fontSprite[fontChar].width;
@@ -140,23 +166,27 @@ int FontGraphic::getCenteredX(const char *text)
 
 void FontGraphic::printCentered(int y, const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;	
+	unsigned short int fontChar = 0;
 
 	int x = getCenteredX(text);
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
-		fontChar = getSpriteIndex(*(unsigned char*) text++);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}

--- a/manual/arm9/source/graphics/FontGraphic.cpp
+++ b/manual/arm9/source/graphics/FontGraphic.cpp
@@ -93,7 +93,14 @@ void FontGraphic::print(int x, int y, const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -121,7 +128,14 @@ int FontGraphic::calcWidth(const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -154,7 +168,14 @@ int FontGraphic::getCenteredX(const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -182,7 +203,14 @@ void FontGraphic::printCentered(int y, const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}

--- a/manual/arm9/source/graphics/FontGraphic.h
+++ b/manual/arm9/source/graphics/FontGraphic.h
@@ -11,7 +11,6 @@
 #include "common/gl2d.h"
 #define FONT_SX 8
 #define FONT_SY 10
-#define UTF16_SIGNAL_BYTE  0x0F
 
 class FontGraphic
 {

--- a/quickmenu/arm9/source/graphics/FontGraphic.cpp
+++ b/quickmenu/arm9/source/graphics/FontGraphic.cpp
@@ -56,9 +56,22 @@ int FontGraphic::load(int textureID, glImage *_font_sprite,
  */
 unsigned int FontGraphic::getSpriteIndex(const u16 letter) {
 	unsigned int spriteIndex = 0;
-	for (unsigned int i = 0; i < imageCount; i++) {
-		if (mapping[i] == letter) {
-			spriteIndex = i;
+	long int left = 0;
+	long int right = imageCount;
+	long int mid = 0;
+
+	while (left <= right)
+	{
+		mid = left + ((right - left) / 2);
+		if (mapping[mid] == letter) {
+			spriteIndex = mid;
+			break;
+		}
+
+		if (mapping[mid] < letter) {
+			left = mid + 1;
+		} else {
+			right = mid - 1;
 		}
 	}
 	return spriteIndex;
@@ -66,22 +79,25 @@ unsigned int FontGraphic::getSpriteIndex(const u16 letter) {
 
 void FontGraphic::print(int x, int y, const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) { // check if the lower bits is the signal bits.
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++; // LSB
-			highBits = *(unsigned char*) text++; // HSB
-			u16 assembled = (u16)(lowBits | highBits << 8);
-			
-			fontChar = getSpriteIndex(assembled);
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
-		
+
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}
@@ -89,20 +105,25 @@ void FontGraphic::print(int x, int y, const char *text)
 
 int FontGraphic::calcWidth(const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	int x = 0;
 
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
 		x += fontSprite[fontChar].width;
@@ -118,19 +139,24 @@ void FontGraphic::print(int x, int y, int value)
 
 int FontGraphic::getCenteredX(const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	int total_width = 0;
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
 		total_width += fontSprite[fontChar].width;
@@ -140,23 +166,27 @@ int FontGraphic::getCenteredX(const char *text)
 
 void FontGraphic::printCentered(int y, const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;	
+	unsigned short int fontChar = 0;
 
 	int x = getCenteredX(text);
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
-		fontChar = getSpriteIndex(*(unsigned char*) text++);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}

--- a/quickmenu/arm9/source/graphics/FontGraphic.cpp
+++ b/quickmenu/arm9/source/graphics/FontGraphic.cpp
@@ -93,7 +93,14 @@ void FontGraphic::print(int x, int y, const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -121,7 +128,14 @@ int FontGraphic::calcWidth(const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -154,7 +168,14 @@ int FontGraphic::getCenteredX(const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -182,7 +203,14 @@ void FontGraphic::printCentered(int y, const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}

--- a/quickmenu/arm9/source/graphics/FontGraphic.h
+++ b/quickmenu/arm9/source/graphics/FontGraphic.h
@@ -11,7 +11,6 @@
 #include "common/gl2d.h"
 #define FONT_SX 8
 #define FONT_SY 10
-#define UTF16_SIGNAL_BYTE  0x0F
 
 class FontGraphic
 {

--- a/quickmenu/arm9/source/iconTitle.cpp
+++ b/quickmenu/arm9/source/iconTitle.cpp
@@ -1000,21 +1000,15 @@ void titleUpdate(bool isDir, const char* name)
 				titleToDisplay[bannerlines][charIndex] = 0;
 				bannerlines++;
 				charIndex = 0;
-			} else if (cachedTitle[i] <= 0x00FF) { // ASCII+Latin Extended Range is 0x0 to 0xFF.
-				// Handle ASCII here
-				titleToDisplay[bannerlines][charIndex] = cachedTitle[i];
-				charIndex++;
-			} else {
-				// We need to split U16 into two characters here.
-				char lowerBits = cachedTitle[i] & 0xFF;
- 				char higherBits = cachedTitle[i] >> 8;
-				// Since we have UTF16LE, assemble in FontGraphic the other way.
-				// We will need to peek in FontGraphic.cpp since the higher bit is significant.
-				titleToDisplay[bannerlines][charIndex] = UTF16_SIGNAL_BYTE; 
-				// 0x0F signal bit to treat the next two characters as UTF
-				titleToDisplay[bannerlines][charIndex+1] = lowerBits;
-				titleToDisplay[bannerlines][charIndex+2] = higherBits;
-				charIndex += 3;
+			} else if (cachedTitle[i] <= 0x007F) { // ASCII are one UTF-8 character
+				titleToDisplay[bannerlines][charIndex++] = cachedTitle[i];
+			} else if (cachedTitle[i] <= 0x07FF) { // 0x0080 - 0x07FF are two UTF-8 characters
+				titleToDisplay[bannerlines][charIndex++] = (0xC0 | ((cachedTitle[i] & 0x7C0) >> 6));
+				titleToDisplay[bannerlines][charIndex++] = (0x80 | (cachedTitle[i] & 0x03F));
+			} else { // 0x0800 - 0xFFFF take three UTF-8 characters, we don't need to handle higher as we're coming from single UTF-16 chars
+				titleToDisplay[bannerlines][charIndex++] = (0xE0 | ((cachedTitle[i] & 0xF000) >> 12));
+				titleToDisplay[bannerlines][charIndex++] = (0x80 | ((cachedTitle[i] & 0x0FC0) >> 6));
+				titleToDisplay[bannerlines][charIndex++] = (0x80 | (cachedTitle[i] & 0x003F));
 			}
 		}
 

--- a/romsel_dsimenutheme/arm9/source/buttontext.h
+++ b/romsel_dsimenutheme/arm9/source/buttontext.h
@@ -4,10 +4,10 @@
 
 #define BUTTON_A "\xEE\x80\x80"
 #define BUTTON_B "\xEE\x80\x81"
-#define BUTTON_X "\xEE\x80\x81"
-#define BUTTON_Y "\xEE\x80\x81"
-#define BUTTON_L "\xEE\x80\x81"
-#define BUTTON_R "\xEE\x80\x81"
+#define BUTTON_X "\xEE\x80\x82"
+#define BUTTON_Y "\xEE\x80\x83"
+#define BUTTON_L "\xEE\x80\x84"
+#define BUTTON_R "\xEE\x80\x85"
 
 #define BUTTON_RIGHT    "\xEE\x80\x99"
 #define BUTTON_LEFT     "\xEE\x80\x9A"

--- a/romsel_dsimenutheme/arm9/source/buttontext.h
+++ b/romsel_dsimenutheme/arm9/source/buttontext.h
@@ -2,16 +2,16 @@
 #ifndef __BUTTON_CHARS_H
 #define __BUTTON_CHARS_H
 
-#define BUTTON_A "\x0F\x00\xE0"
-#define BUTTON_B "\x0F\x01\xE0"
-#define BUTTON_X "\x0F\x02\xE0"
-#define BUTTON_Y "\x0F\x03\xE0"
-#define BUTTON_L "\x0F\x04\xE0"
-#define BUTTON_R "\x0F\x05\xE0"
+#define BUTTON_A "\xEE\x80\x80"
+#define BUTTON_B "\xEE\x80\x81"
+#define BUTTON_X "\xEE\x80\x81"
+#define BUTTON_Y "\xEE\x80\x81"
+#define BUTTON_L "\xEE\x80\x81"
+#define BUTTON_R "\xEE\x80\x81"
 
-#define BUTTON_RIGHT    "\x0F\x19\xE0"
-#define BUTTON_LEFT     "\x0F\x1A\xE0"
-#define BUTTON_UP       "\x0F\x1B\xE0"
-#define BUTTON_DOWN     "\x0F\x1C\xE0"
+#define BUTTON_RIGHT    "\xEE\x80\x99"
+#define BUTTON_LEFT     "\xEE\x80\x9A"
+#define BUTTON_UP       "\xEE\x80\x9B"
+#define BUTTON_DOWN     "\xEE\x80\x9C"
 
 #endif

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
@@ -93,7 +93,14 @@ void FontGraphic::print(int x, int y, const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -121,7 +128,14 @@ int FontGraphic::calcWidth(const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -154,7 +168,14 @@ int FontGraphic::getCenteredX(const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}
@@ -182,7 +203,14 @@ void FontGraphic::printCentered(int y, const char *text)
 		} else if((*text & 0xF0) == 0xE0) {
 			char16_t c = (*text++ & 0xF) << 12;
 			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF8) == 0xF0) {
+			char16_t c = (*text++ & 0x7) << 18;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
 
 			fontChar = getSpriteIndex(c);
 		}

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
@@ -79,19 +79,25 @@ unsigned int FontGraphic::getSpriteIndex(const u16 letter) {
 
 void FontGraphic::print(int x, int y, const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) { // check if the lower bits is the signal bits.
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++; // LSB
-			highBits = *(unsigned char*) text++; // HSB
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
+
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}
@@ -99,20 +105,25 @@ void FontGraphic::print(int x, int y, const char *text)
 
 int FontGraphic::calcWidth(const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	int x = 0;
 
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
 		x += fontSprite[fontChar].width;
@@ -128,19 +139,24 @@ void FontGraphic::print(int x, int y, int value)
 
 int FontGraphic::getCenteredX(const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;
+	unsigned short int fontChar = 0;
 	int total_width = 0;
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
 		total_width += fontSprite[fontChar].width;
@@ -150,23 +166,27 @@ int FontGraphic::getCenteredX(const char *text)
 
 void FontGraphic::printCentered(int y, const char *text)
 {
-	unsigned short int fontChar;
-	unsigned char lowBits;
-	unsigned char highBits;	
+	unsigned short int fontChar = 0;
 
 	int x = getCenteredX(text);
 	while (*text)
 	{
-		lowBits = *(unsigned char*) text++;
-		if (lowBits != UTF16_SIGNAL_BYTE) {
-			fontChar = getSpriteIndex(lowBits);
-		} else {
-			lowBits = *(unsigned char*) text++;
-			highBits = *(unsigned char*) text++;
-			fontChar = getSpriteIndex((u16)(lowBits | highBits << 8));
+		// UTF-8 handling
+		if((*text & 0x80) == 0) {
+			fontChar = getSpriteIndex(*text++);
+		} else if((*text & 0xE0) == 0xC0) {
+			char16_t c = ((*text++ & 0x1F) << 6);
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
+		} else if((*text & 0xF0) == 0xE0) {
+			char16_t c = (*text++ & 0xF) << 12;
+			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+			fontChar = getSpriteIndex(c);
 		}
 
-		fontChar = getSpriteIndex(*(unsigned char*) text++);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
@@ -11,7 +11,6 @@
 #include "common/gl2d.h"
 #define FONT_SX 8
 #define FONT_SY 10
-#define UTF16_SIGNAL_BYTE  0x0F
 
 class FontGraphic
 {

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -732,21 +732,15 @@ void titleUpdate(bool isDir, const char *name, int num) {
 				titleToDisplay[bannerlines][charIndex] = 0;
 				bannerlines++;
 				charIndex = 0;
-			} else if (cachedTitle[num][i] <= 0x00FF) { // ASCII+Latin Extended Range is 0x0 to 0xFF.
-				// Handle ASCII here
-				titleToDisplay[bannerlines][charIndex] = cachedTitle[num][i];
-				charIndex++;
-			} else {
-				// We need to split U16 into two characters here.
-				char lowerBits = cachedTitle[num][i] & 0xFF;
-				char higherBits = cachedTitle[num][i] >> 8;
-				// Since we have UTF16LE, assemble in FontGraphic the other way.
-				// We will need to peek in FontGraphic.cpp since the higher bit is significant.
-				titleToDisplay[bannerlines][charIndex] = UTF16_SIGNAL_BYTE;
-				// 0x0F signal bit to treat the next two characters as UTF
-				titleToDisplay[bannerlines][charIndex + 1] = lowerBits;
-				titleToDisplay[bannerlines][charIndex + 2] = higherBits;
-				charIndex += 3;
+			} else if (cachedTitle[num][i] <= 0x007F) { // ASCII are one UTF-8 character
+				titleToDisplay[bannerlines][charIndex++] = cachedTitle[num][i];
+			} else if (cachedTitle[num][i] <= 0x07FF) { // 0x0080 - 0x07FF are two UTF-8 characters
+				titleToDisplay[bannerlines][charIndex++] = (0xC0 | ((cachedTitle[num][i] & 0x7C0) >> 6));
+				titleToDisplay[bannerlines][charIndex++] = (0x80 | (cachedTitle[num][i] & 0x03F));
+			} else { // 0x0800 - 0xFFFF take three UTF-8 characters, we don't need to handle higher as we're coming from single UTF-16 chars
+				titleToDisplay[bannerlines][charIndex++] = (0xE0 | ((cachedTitle[num][i] & 0xF000) >> 12));
+				titleToDisplay[bannerlines][charIndex++] = (0x80 | ((cachedTitle[num][i] & 0x0FC0) >> 6));
+				titleToDisplay[bannerlines][charIndex++] = (0x80 | (cachedTitle[num][i] & 0x003F));
 			}
 		}
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This adds proper UTF-8 handling to the DSi-based, and R4 themes, quickmenu, and manual so that files with non ASCII names will show correctly. (If the font actually has the characters)
- Also changes the rom name conversion to convert to UTF-8 instead of hacky UTF-16 so that still works
- Fixes #814 

#### Where have you tested it?

DSi (J) with the latest TWiLight and Unlaunch.

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
