### PR TITLE
Update Japanese translation (ak theme)

### DIFF
--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -242,12 +242,12 @@ bool MainList::enterDir(const std::string &dirName)
         {
             if (!flashcardFound() && sdFound())
             {
-                addDirEntry("SLOT-1 Card", "", SPATH_SLOT1, "slot1", nand_banner_bin);
+                addDirEntry(LANG("mainlist", "SLOT-1 Card"), "", SPATH_SLOT1, "slot1", nand_banner_bin);
             }
-            addDirEntry("System Menu", "", SPATH_SYSMENU, "sysmenu", sysmenu_banner_bin);
+            addDirEntry(LANG("mainlist", "System Menu"), "", SPATH_SYSMENU, "sysmenu", sysmenu_banner_bin);
         }
-        addDirEntry("Settings", "", SPATH_TITLEANDSETTINGS, "titleandsettings", settings_banner_bin);
-        addDirEntry("Manual", "", SPATH_MANUAL, "manual", manual_banner_bin);
+        addDirEntry(LANG("mainlist", "Settings"), "", SPATH_TITLEANDSETTINGS, "titleandsettings", settings_banner_bin);
+        addDirEntry(LANG("mainlist", "Manual"), "", SPATH_MANUAL, "manual", manual_banner_bin);
         _currentDir = SPATH_ROOT;
         directoryChanged();
         cwl();

--- a/romsel_aktheme/arm9/source/windows/rominfownd.cpp
+++ b/romsel_aktheme/arm9/source/windows/rominfownd.cpp
@@ -271,8 +271,8 @@ void RomInfoWnd::pressGameSettings(void)
     {
 
         _values.push_back(LANG("game settings", "Default"));
-        _values.push_back(LANG("game settings", "No Direct Boot"));
-        _values.push_back(LANG("game settings", "Direct Boot"));
+        _values.push_back(LANG("game settings", "No"));
+        _values.push_back(LANG("game settings", "Yes"));
 
         settingWnd.addSettingItem(LANG("game settings", "Direct Boot"), _values, settingsIni.directBoot + 1);
         _values.clear();

--- a/romsel_aktheme/nitrofiles/language/lang_en/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_en/language.txt
@@ -7,15 +7,8 @@ Copy = Copy
 Cut = Cut
 Paste = Paste
 Delete = Delete
-Save Type = Save Type
-Patches = Patches
 Setting = Settings Menu
 Info = Properties
-Help = Help
-More = More ->
-3in1 = 3in1/FAS1
-Cheats = Cheats
-Back = <- Back
 
 [message box]
 yes = Yes
@@ -25,19 +18,11 @@ cancel = Cancel
 
 [cheats]
 button = Cheats
+Cancel = Cancel
+deselect = Deselect all
+info = Info
 title = Cheats Menu
-error_title = Error
-error_text = Cheat file was not found.
-selectrom = Please select a .NDS file
-noxml = Cheat DB file not found
-ccexists = .CC exists, Generate new one?
-nonefound = No Cheats found in DB
-xmlselect = Select Cheat Database:
 confirm = Confirm
-confirm_rebuild = Rebuild .CC file?
-invalid cheatdb = Invalid Cheat Database
-Rebuild = Rebuild
-Sel. DB = Sel. DB
 
 [progress window]
 processing save = Processing... Do not power off!
@@ -489,23 +474,35 @@ title = Clone
 text = It may not be a genuine Acekard.\n Please contact your vender or\n      access our website:\n\n      www.acekard.com\n
 
 [game settings]
-Default = Default
-System = System
 Japanese = Japanese
 English = English
 French = French
 German = German
 Italian = Italian
 Spanish = Spanish
-Language = Language
+133MHz (TWL) = 133MHz (TWL)
+67MHz (NTR) = 67MHz (NTR)
+Auto = Auto
+Boost VRAM = Boost VRAM
+Bootstrap File = Bootstrap File
 CPU Frequency = CPU Frequency
+Default = Default
+Direct Boot = Direct Boot
+DS mode = DS mode
+DSi mode = DSi mode
+DSi mode (Forced) = DSi mode (Forced)
+Heap Shrink = Heap Shrink
+Language = Language
+Nightly = Nightly
 Off = Off
 On = On
-Sound Fix = Sound Fix
-Async Prefetch = Async Prefetch
-Use Bootstrap = Use Bootstrap
-Direct Boot = Direct Boot
 Per Game Settings = Per Game Settings
+RAM disk = RAM Disk
+Release = Release
+Run in = Run in
+Save number = Save Number
+System = System
+Use Bootstrap = Use Bootstrap
 
 [game launch]
 ROM Start Error = ROM Start Error
@@ -527,4 +524,14 @@ Unlaunch Error = Unlaunch Error
 unlaunch boot = Boot DSiWare with Unlaunch
 
 unlaunch instructions = After saving, please re-start this menu to transfer your save data back.
+
+[mainlist]
+Manual = Manual
+microSD Card = microSD Card
+SD Card = SD Card
+Settings = Settings
+SLOT-1 Card = SLOT-1 Card
+SLOT-1 microSD Card = SLOT-1 microSD Card
+System Menu = System Menu
+
 [end]

--- a/romsel_aktheme/nitrofiles/language/lang_jp/language.txt
+++ b/romsel_aktheme/nitrofiles/language/lang_jp/language.txt
@@ -8,38 +8,23 @@ Copy = コピー
 Cut = 切り取り
 Paste = 貼り付け
 Delete = 削除
-Save Type = セーブタイプ設定
-Patches = オプション
-Setting = システム設定
+Setting = 設定メニュー
 Info = ファイル詳細
-Help = ヘルプ
-More = 次のページ ->
-3in1 = 3in1拡張設定
-Cheats = チート設定
-Back = <- 後ろの
 
 [message box]
 yes = はい
 no = いいえ
-ok = 決定
+ok = OK
 cancel = 取消し
 
 [cheats]
 button = チート
-title = チートメニュー
-error_title = エラー
-error_text = チートコードが登録されていません
-selectrom = NDSファイルを選択してください
-noxml = チートDBを見つけられません
-nonefound = このタイトルのチートコードは未登録です
-xmlselect = チートDB選択
-confirm_rebuild = 現在のファイルを削除し再構築します宜しいですか？
-confirm = 確認
 Cancel = 取消し
-confirm_rebuild = .CCファイルを再建しますか?
+deselect = すべての選択を解除
+info = 説明
 invalid cheatdb = このチートDBは無効です
 Rebuild = リビルド
-Sel. DB = DB選択
+title = チートメニュー
 
 [progress window]
 processing save = 作業中につき電源を切らないで下さい
@@ -404,29 +389,41 @@ title = エラー
 memory allocation error = メモリ割り当てエラー
 
 [game settings]
-Default = Default
-System = System
-Japanese = Japanese
-English = 日本語
-French = French
-German = German
-Italian = Italian
-Spanish = Spanish
-Language = Language
+Japanese = 日本語
+English = 英語
+French = フランス語
+German = ドイツ語
+Italian = イタリア語
+Spanish = スペイン語
+133MHz (TWL) = 133MHz (TWL)
+67MHz (NTR) = 67MHz (NTR)
+Auto = 自動
+Boost VRAM = VRAMを押し上げる
+Bootstrap File = Bootstrapファイル
 CPU Frequency = CPU 周波数
-Off = 使用
-On = 不使用
-Sound Fix = サウンドFIX
-Async Prefetch = アシンクロナスプリフェッチ
-Use Bootstrap =　Bootstrapでブート
-Direct Boot = 直接ROMをブートします
+Default = デフォルト
+Direct Boot = ROMを直接ブートします
+DS mode = DSモード
+DSi mode = DSiモード
+DSi mode (Forced) = DSiモード（強制）
+Heap Shrink = ヒープを縮む
+Language = 言語
+Nightly = ナイトリー
+Off = オフ
+On = オン
 Per Game Settings = ゲーム設定
+RAM disk = RAMディスク
+Release = リリース
+Run in = 実行モード
+Save number = セーブの番号
+System = 本体
+Use Bootstrap =　Bootstrapでブート
 
 [game launch]
 ROM Start Error = このROMは起動ことができませんでした。
 error = エラー %i
 Please wait = 少々お待ちください。
-NDS Bootstrap Error = Bootstrapエラー
+NDS Bootstrap Error = NDS Bootstrapエラー
 GBARunner2 Error = GBARunner2エラー
 SNES Error = スーパーファミコンRAMディスクエラー
 SNES Error Message = 「sd:/_nds/TWiLightMenu/emulators/」のスーパーファミコンRAMディスクが見つかりませんでした。
@@ -439,5 +436,15 @@ Preparing Unlaunch Boot = DSiWare起動の準備中です.
 Unlaunch Error = Unlaunchエラー
 unlaunch boot = DSiWare起動の説明
 
-unlaunch instructions = After saving, please re-start this menu to transfer your save data back.
+unlaunch instructions = セーブして後、このメニューを再起動してセーブデータを転送してください。
+
+[mainlist]
+Manual = 説明書
+microSD Card = microSDカード
+SD Card = SDカード
+Settings = 本体設定
+SLOT-1 Card = SLOT-1カード
+SLOT-1 microSD Card = SLOT-1 microSDカード
+System Menu = 本体メニュー
+
 [end]


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- I believe every used string in the ak menu should be translated with this
- I also added a few strings to English that were missing
- And made the mainlist strings translatable on the code side
- And updated the Direct Boot to only use "Direct Boot" as a title with the options "Default", "Off", and "On"
- I removed some unused strings from Japanese and English, but I didn't touch other languages and only removed unused strings from the areas I added to, I didn't remove other unused strings
  - (I cared about changing English since if we add crowdin or so English will be the base and will need to contain every string)

#### Where have you tested it?

- DSi (K) with the latest TWiLight & Unlaunch
- DS Lite (J) with the latest TWiLight & DSTT

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
