### PR TITLE
Don't freeze on invalid UTF-8 characters

### DIFF
--- a/manual/arm9/source/graphics/FontGraphic.cpp
+++ b/manual/arm9/source/graphics/FontGraphic.cpp
@@ -15,7 +15,6 @@
 
 int fontTextureID[2];
 
-
 int FontGraphic::load(int textureID, glImage *_font_sprite,
 				  const unsigned int numframes,
 				  const unsigned int *texcoords,
@@ -77,34 +76,40 @@ unsigned int FontGraphic::getSpriteIndex(const u16 letter) {
 	return spriteIndex;
 }
 
+char16_t FontGraphic::getCharacter(const char *&text) {
+	// UTF-8 handling
+	if((*text & 0x80) == 0) {
+		return getSpriteIndex(*text++);
+	} else if((*text & 0xE0) == 0xC0) {
+		char16_t c = ((*text++ & 0x1F) << 6);
+		if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else if((*text & 0xF0) == 0xE0) {
+		char16_t c = (*text++ & 0xF) << 12;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+		if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else if((*text & 0xF8) == 0xF0) {
+		char16_t c = (*text++ & 0x7) << 18;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+		if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else {
+		// Character isn't valid, return ?
+		text++;
+		return getSpriteIndex('?');
+	}
+}
+
 void FontGraphic::print(int x, int y, const char *text)
 {
-	unsigned short int fontChar = 0;
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
+		char16_t fontChar = getCharacter(text);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}
@@ -112,35 +117,11 @@ void FontGraphic::print(int x, int y, const char *text)
 
 int FontGraphic::calcWidth(const char *text)
 {
-	unsigned short int fontChar = 0;
 	int x = 0;
 
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
-		x += fontSprite[fontChar].width;
+		x += fontSprite[getCharacter(text)].width;
 	}
 	return x;
 }
@@ -153,68 +134,20 @@ void FontGraphic::print(int x, int y, int value)
 
 int FontGraphic::getCenteredX(const char *text)
 {
-	unsigned short int fontChar = 0;
 	int total_width = 0;
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
-		total_width += fontSprite[fontChar].width;
+		total_width += fontSprite[getCharacter(text)].width;
 	}
 	return (SCREEN_WIDTH - total_width) / 2;
 }
 
 void FontGraphic::printCentered(int y, const char *text)
 {
-	unsigned short int fontChar = 0;
-
 	int x = getCenteredX(text);
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
+		char16_t fontChar = getCharacter(text);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}

--- a/manual/arm9/source/graphics/FontGraphic.h
+++ b/manual/arm9/source/graphics/FontGraphic.h
@@ -21,6 +21,7 @@ private:
 	char buffer[256];
 	char buffer2[256];
 	unsigned int getSpriteIndex(const u16 letter);
+	char16_t getCharacter(const char *&text);
 
 public:
 

--- a/quickmenu/arm9/source/graphics/FontGraphic.cpp
+++ b/quickmenu/arm9/source/graphics/FontGraphic.cpp
@@ -15,7 +15,6 @@
 
 int fontTextureID[2];
 
-
 int FontGraphic::load(int textureID, glImage *_font_sprite,
 				  const unsigned int numframes,
 				  const unsigned int *texcoords,
@@ -77,34 +76,40 @@ unsigned int FontGraphic::getSpriteIndex(const u16 letter) {
 	return spriteIndex;
 }
 
+char16_t FontGraphic::getCharacter(const char *&text) {
+	// UTF-8 handling
+	if((*text & 0x80) == 0) {
+		return getSpriteIndex(*text++);
+	} else if((*text & 0xE0) == 0xC0) {
+		char16_t c = ((*text++ & 0x1F) << 6);
+		if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else if((*text & 0xF0) == 0xE0) {
+		char16_t c = (*text++ & 0xF) << 12;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+		if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else if((*text & 0xF8) == 0xF0) {
+		char16_t c = (*text++ & 0x7) << 18;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+		if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else {
+		// Character isn't valid, return ?
+		text++;
+		return getSpriteIndex('?');
+	}
+}
+
 void FontGraphic::print(int x, int y, const char *text)
 {
-	unsigned short int fontChar = 0;
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
+		char16_t fontChar = getCharacter(text);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}
@@ -112,35 +117,11 @@ void FontGraphic::print(int x, int y, const char *text)
 
 int FontGraphic::calcWidth(const char *text)
 {
-	unsigned short int fontChar = 0;
 	int x = 0;
 
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
-		x += fontSprite[fontChar].width;
+		x += fontSprite[getCharacter(text)].width;
 	}
 	return x;
 }
@@ -153,68 +134,20 @@ void FontGraphic::print(int x, int y, int value)
 
 int FontGraphic::getCenteredX(const char *text)
 {
-	unsigned short int fontChar = 0;
 	int total_width = 0;
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
-		total_width += fontSprite[fontChar].width;
+		total_width += fontSprite[getCharacter(text)].width;
 	}
 	return (SCREEN_WIDTH - total_width) / 2;
 }
 
 void FontGraphic::printCentered(int y, const char *text)
 {
-	unsigned short int fontChar = 0;
-
 	int x = getCenteredX(text);
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
+		char16_t fontChar = getCharacter(text);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}

--- a/quickmenu/arm9/source/graphics/FontGraphic.h
+++ b/quickmenu/arm9/source/graphics/FontGraphic.h
@@ -21,6 +21,7 @@ private:
 	char buffer[256];
 	char buffer2[256];
 	unsigned int getSpriteIndex(const u16 letter);
+	char16_t getCharacter(const char *&text);
 
 public:
 

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
@@ -15,7 +15,6 @@
 
 int fontTextureID[2];
 
-
 int FontGraphic::load(int textureID, glImage *_font_sprite,
 				  const unsigned int numframes,
 				  const unsigned int *texcoords,
@@ -77,34 +76,40 @@ unsigned int FontGraphic::getSpriteIndex(const u16 letter) {
 	return spriteIndex;
 }
 
+char16_t FontGraphic::getCharacter(const char *&text) {
+	// UTF-8 handling
+	if((*text & 0x80) == 0) {
+		return getSpriteIndex(*text++);
+	} else if((*text & 0xE0) == 0xC0) {
+		char16_t c = ((*text++ & 0x1F) << 6);
+		if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else if((*text & 0xF0) == 0xE0) {
+		char16_t c = (*text++ & 0xF) << 12;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+		if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else if((*text & 0xF8) == 0xF0) {
+		char16_t c = (*text++ & 0x7) << 18;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
+		if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
+		if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
+
+		return getSpriteIndex(c);
+	} else {
+		// Character isn't valid, return ?
+		text++;
+		return getSpriteIndex('?');
+	}
+}
+
 void FontGraphic::print(int x, int y, const char *text)
 {
-	unsigned short int fontChar = 0;
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
+		char16_t fontChar = getCharacter(text);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}
@@ -112,35 +117,11 @@ void FontGraphic::print(int x, int y, const char *text)
 
 int FontGraphic::calcWidth(const char *text)
 {
-	unsigned short int fontChar = 0;
 	int x = 0;
 
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
-		x += fontSprite[fontChar].width;
+		x += fontSprite[getCharacter(text)].width;
 	}
 	return x;
 }
@@ -153,68 +134,20 @@ void FontGraphic::print(int x, int y, int value)
 
 int FontGraphic::getCenteredX(const char *text)
 {
-	unsigned short int fontChar = 0;
 	int total_width = 0;
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
-		total_width += fontSprite[fontChar].width;
+		total_width += fontSprite[getCharacter(text)].width;
 	}
 	return (SCREEN_WIDTH - total_width) / 2;
 }
 
 void FontGraphic::printCentered(int y, const char *text)
 {
-	unsigned short int fontChar = 0;
-
 	int x = getCenteredX(text);
 	while (*text)
 	{
-		// UTF-8 handling
-		if((*text & 0x80) == 0) {
-			fontChar = getSpriteIndex(*text++);
-		} else if((*text & 0xE0) == 0xC0) {
-			char16_t c = ((*text++ & 0x1F) << 6);
-			if((*text & 0xC0) == 0x80) c |= *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF0) == 0xE0) {
-			char16_t c = (*text++ & 0xF) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		} else if((*text & 0xF8) == 0xF0) {
-			char16_t c = (*text++ & 0x7) << 18;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 12;
-			if((*text & 0xC0) == 0x80) c |= (*text++ & 0x3F) << 6;
-			if((*text & 0xC0) == 0x80) c |=  *text++ & 0x3F;
-
-			fontChar = getSpriteIndex(c);
-		}
-
+		char16_t fontChar = getCharacter(text);
 		glSprite(x, y, GL_FLIP_NONE, &fontSprite[fontChar]);
 		x += fontSprite[fontChar].width;
 	}

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
@@ -21,6 +21,7 @@ private:
 	char buffer[256];
 	char buffer2[256];
 	unsigned int getSpriteIndex(const u16 letter);
+	char16_t getCharacter(const char *&text);
 
 public:
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Invalid UTF-8 character (Such as the usrcheat.dat's EUC_JP) will now be replaced by ?? instead of freezing
  - I may add conversion from EUC_JP to UTF-8 later for the cheats, that'll be annoying though so not gonna do it now

#### Where have you tested it?

- DSi (K) with the latest TWiLight & Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
