### PR TITLE
Correctly load photos less than 208 x 156

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -538,7 +538,7 @@ void vBlankHandler() {
 				movetimer++;
 			} else if (movetimer < 8) {
 				titleboxXpos[ms().secondaryDevice] -=
-				    (isScrolling ? titleboxXscrollspeed : titleboxXmovespeed[movetimer]);
+					(isScrolling ? titleboxXscrollspeed : titleboxXmovespeed[movetimer]);
 				if (movetimer == 0 || movetimer == 2 || movetimer == 4 || movetimer == 6)
 					titlewindowXpos[ms().secondaryDevice] -= 1;
 				movetimer++;
@@ -559,7 +559,7 @@ void vBlankHandler() {
 				movetimer++;
 			} else if (movetimer < 8) {
 				titleboxXpos[ms().secondaryDevice] +=
-				    (isScrolling ? titleboxXscrollspeed : titleboxXmovespeed[movetimer]);
+					(isScrolling ? titleboxXscrollspeed : titleboxXmovespeed[movetimer]);
 				if (movetimer == 0 || movetimer == 2 || movetimer == 4 || movetimer == 6)
 					titlewindowXpos[ms().secondaryDevice] += 1;
 				movetimer++;
@@ -679,7 +679,7 @@ void vBlankHandler() {
 		// 			launchDotY[i]++;
 		// 		}
 		// }
-		
+
 		if (movingApp != -1) {
 			if (movingAppIsDir) {
 				if (ms().theme == 1)
@@ -695,46 +695,46 @@ void vBlankHandler() {
 					} else {
 						glSprite(96,
 							 titleboxYpos - movingAppYpos +
-							     titleboxYposDropDown[movingApp % 5],
+								 titleboxYposDropDown[movingApp % 5],
 							 GL_FLIP_NONE, &tex().boxfullImage()[0]);
 					}
 				}
 				if (bnrSysSettings[movingApp])
 					glSprite(96,
 						 (titleboxYpos - 1) - movingAppYpos +
-						     titleboxYposDropDown[movingApp % 5],
+							 titleboxYposDropDown[movingApp % 5],
 						 GL_FLIP_NONE, &tex().settingsImage()[1]);
 				else if (bnrRomType[movingApp] == 9)
 					drawIconPLG(112, (titleboxYpos + 12) - movingAppYpos +
-							      titleboxYposDropDown[movingApp % 5]);
+								  titleboxYposDropDown[movingApp % 5]);
 				else if (bnrRomType[movingApp] == 8)
 					drawIconSNES(112, (titleboxYpos + 12) - movingAppYpos +
-							      titleboxYposDropDown[movingApp % 5]);
+								  titleboxYposDropDown[movingApp % 5]);
 				else if (bnrRomType[movingApp] == 7)
 					drawIconMD(112, (titleboxYpos + 12) - movingAppYpos +
-							    titleboxYposDropDown[movingApp % 5]);
+								titleboxYposDropDown[movingApp % 5]);
 				else if (bnrRomType[movingApp] == 6)
 					drawIconGG(112, (titleboxYpos + 12) - movingAppYpos +
-							    titleboxYposDropDown[movingApp % 5]);
+								titleboxYposDropDown[movingApp % 5]);
 				else if (bnrRomType[movingApp] == 5)
 					drawIconSMS(112, (titleboxYpos + 12) - movingAppYpos +
-							     titleboxYposDropDown[movingApp % 5]);
+								 titleboxYposDropDown[movingApp % 5]);
 				else if (bnrRomType[movingApp] == 4)
 					drawIconNES(112, (titleboxYpos + 12) - movingAppYpos +
-							     titleboxYposDropDown[movingApp % 5]);
+								 titleboxYposDropDown[movingApp % 5]);
 				else if (bnrRomType[movingApp] == 3)
 					drawIconGBC(112, (titleboxYpos + 12) - movingAppYpos +
-							     titleboxYposDropDown[movingApp % 5]);
+								 titleboxYposDropDown[movingApp % 5]);
 				else if (bnrRomType[movingApp] == 2)
 					drawIconGB(112, (titleboxYpos + 12) - movingAppYpos +
-							    titleboxYposDropDown[movingApp % 5]);
+								titleboxYposDropDown[movingApp % 5]);
 				else if (bnrRomType[movingApp] == 1)
 					drawIconGBA(112, (titleboxYpos + 12) - movingAppYpos +
-							    titleboxYposDropDown[movingApp % 5]);
+								titleboxYposDropDown[movingApp % 5]);
 				else
 					drawIcon(112,
 						 (titleboxYpos + 12) - movingAppYpos +
-						     titleboxYposDropDown[movingApp % 5],
+							 titleboxYposDropDown[movingApp % 5],
 						 -1);
 			}
 		}
@@ -797,35 +797,35 @@ void vBlankHandler() {
 								j--;
 							if (ms().theme == 1)
 								glSprite((j * 2496 / 39) + 128 -
-									     titleboxXpos[ms().secondaryDevice] +
-									     movingAppXFix,
+										 titleboxXpos[ms().secondaryDevice] +
+										 movingAppXFix,
 									 titleboxYpos, GL_FLIP_NONE,
 									 tex().folderImage());
 							else
 								glSprite((j * 2496 / 39) + 128 -
-									     titleboxXpos[ms().secondaryDevice] +
-									     movingAppXFix,
+										 titleboxXpos[ms().secondaryDevice] +
+										 movingAppXFix,
 									 (titleboxYpos - 3) +
-									     titleboxYposDropDown[i % 5],
+										 titleboxYposDropDown[i % 5],
 									 GL_FLIP_NONE, tex().folderImage());
 						} else {
 							if (ms().theme == 1)
 								glSprite(spawnedboxXpos -
-									     titleboxXpos[ms().secondaryDevice] +
-									     movecloseXpos,
+										 titleboxXpos[ms().secondaryDevice] +
+										 movecloseXpos,
 									 titleboxYpos, GL_FLIP_NONE,
 									 tex().folderImage());
 							else
 								glSprite(spawnedboxXpos -
-									     titleboxXpos[ms().secondaryDevice] +
-									     movecloseXpos,
+										 titleboxXpos[ms().secondaryDevice] +
+										 movecloseXpos,
 									 (titleboxYpos - 3) +
-									     titleboxYposDropDown[i % 5],
+										 titleboxYposDropDown[i % 5],
 									 GL_FLIP_NONE, tex().folderImage());
 						}
 					} else if (!applaunchprep ||
 						   CURPOS !=
-						       i) { // Only draw the icon if we're not launching the selcted app
+							   i) { // Only draw the icon if we're not launching the selcted app
 						if (movingApp != -1) {
 							int j = i;
 							if (i > movingApp - (PAGENUM * 40))
@@ -835,161 +835,161 @@ void vBlankHandler() {
 							if (!bnrSysSettings[i]) {
 								if (ms().theme == 1) {
 									glSprite(
-									    (j * 2496 / 39) + 128 -
+										(j * 2496 / 39) + 128 -
 										titleboxXpos[ms().secondaryDevice] +
 										movingAppXFix,
-									    titleboxYpos, GL_FLIP_NONE,
-									    tex().boxfullImage());
+										titleboxYpos, GL_FLIP_NONE,
+										tex().boxfullImage());
 								} else {
 									glSprite(
-									    (j * 2496 / 39) + 128 -
+										(j * 2496 / 39) + 128 -
 										titleboxXpos[ms().secondaryDevice] +
 										movingAppXFix,
-									    titleboxYpos + titleboxYposDropDown[i % 5],
-									    GL_FLIP_NONE, &tex().boxfullImage()[0]);
+										titleboxYpos + titleboxYposDropDown[i % 5],
+										GL_FLIP_NONE, &tex().boxfullImage()[0]);
 								}
 							}
 							if (bnrSysSettings[i])
 								glSprite((j * 2496 / 39) + 128 -
-									     titleboxXpos[ms().secondaryDevice] +
-									     movingAppXFix,
+										 titleboxXpos[ms().secondaryDevice] +
+										 movingAppXFix,
 									 (titleboxYpos - 1) +
-									     titleboxYposDropDown[i % 5],
+										 titleboxYposDropDown[i % 5],
 									 GL_FLIP_NONE, &tex().settingsImage()[1]);
 							else if (bnrRomType[i] == 9)
 								drawIconPLG((j * 2496 / 39) + 144 -
 										 titleboxXpos[ms().secondaryDevice] +
 										 movingAppXFix,
-									     (titleboxYpos + 12) +
+										 (titleboxYpos + 12) +
 										 titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 8)
 								drawIconSNES((j * 2496 / 39) + 144 -
 										 titleboxXpos[ms().secondaryDevice] +
 										 movingAppXFix,
-									     (titleboxYpos + 12) +
+										 (titleboxYpos + 12) +
 										 titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 7)
 								drawIconMD((j * 2496 / 39) + 144 -
-									       titleboxXpos[ms().secondaryDevice] +
-									       movingAppXFix,
+										   titleboxXpos[ms().secondaryDevice] +
+										   movingAppXFix,
 									   (titleboxYpos + 12) +
-									       titleboxYposDropDown[i % 5]);
+										   titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 6)
 								drawIconGG((j * 2496 / 39) + 144 -
-									       titleboxXpos[ms().secondaryDevice] +
-									       movingAppXFix,
+										   titleboxXpos[ms().secondaryDevice] +
+										   movingAppXFix,
 									   (titleboxYpos + 12) +
-									       titleboxYposDropDown[i % 5]);
+										   titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 5)
 								drawIconSMS((j * 2496 / 39) + 144 -
 										titleboxXpos[ms().secondaryDevice] +
 										movingAppXFix,
-									    (titleboxYpos + 12) +
+										(titleboxYpos + 12) +
 										titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 4)
 								drawIconNES((j * 2496 / 39) + 144 -
 										titleboxXpos[ms().secondaryDevice] +
 										movingAppXFix,
-									    (titleboxYpos + 12) +
+										(titleboxYpos + 12) +
 										titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 3)
 								drawIconGBC((j * 2496 / 39) + 144 -
 										titleboxXpos[ms().secondaryDevice] +
 										movingAppXFix,
-									    (titleboxYpos + 12) +
+										(titleboxYpos + 12) +
 										titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 2)
 								drawIconGB((j * 2496 / 39) + 144 -
-									       titleboxXpos[ms().secondaryDevice] +
-									       movingAppXFix,
+										   titleboxXpos[ms().secondaryDevice] +
+										   movingAppXFix,
 									   (titleboxYpos + 12) +
-									       titleboxYposDropDown[i % 5]);
+										   titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 1)
 								drawIconGBA((j * 2496 / 39) + 144 -
-									       titleboxXpos[ms().secondaryDevice] +
-									       movingAppXFix,
+										   titleboxXpos[ms().secondaryDevice] +
+										   movingAppXFix,
 									   (titleboxYpos + 12) +
-									       titleboxYposDropDown[i % 5]);
+										   titleboxYposDropDown[i % 5]);
 							else
 								drawIcon((j * 2496 / 39) + 144 -
-									     titleboxXpos[ms().secondaryDevice] +
-									     movingAppXFix,
+										 titleboxXpos[ms().secondaryDevice] +
+										 movingAppXFix,
 									 (titleboxYpos + 12) +
-									     titleboxYposDropDown[i % 5],
+										 titleboxYposDropDown[i % 5],
 									 i);
 						} else {
 							if (!bnrSysSettings[i]) {
 								if (ms().theme == 1) {
 									glSprite(spawnedboxXpos -
-										     titleboxXpos[ms().secondaryDevice],
+											 titleboxXpos[ms().secondaryDevice],
 										 titleboxYpos, GL_FLIP_NONE,
 										 tex().boxfullImage());
 								} else {
 									glSprite(
-									    spawnedboxXpos -
+										spawnedboxXpos -
 										titleboxXpos[ms().secondaryDevice] +
 										movecloseXpos,
-									    titleboxYpos + titleboxYposDropDown[i % 5],
-									    GL_FLIP_NONE, &tex().boxfullImage()[0]);
+										titleboxYpos + titleboxYposDropDown[i % 5],
+										GL_FLIP_NONE, &tex().boxfullImage()[0]);
 								}
 							}
 							if (bnrSysSettings[i])
 								glSprite(spawnedboxXpos -
-									     titleboxXpos[ms().secondaryDevice] +
-									     movecloseXpos,
+										 titleboxXpos[ms().secondaryDevice] +
+										 movecloseXpos,
 									 (titleboxYpos - 1) +
-									     titleboxYposDropDown[i % 5],
+										 titleboxYposDropDown[i % 5],
 									 GL_FLIP_NONE, &tex().settingsImage()[1]);
 							else if (bnrRomType[i] == 9)
 								drawIconPLG(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 8)
 								drawIconSNES(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 7)
 								drawIconMD(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 6)
 								drawIconGG(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 5)
 								drawIconSMS(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 4)
 								drawIconNES(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 3)
 								drawIconGBC(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 2)
 								drawIconGB(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else if (bnrRomType[i] == 1)
 								drawIconGBA(
-								    iconXpos - titleboxXpos[ms().secondaryDevice] +
+									iconXpos - titleboxXpos[ms().secondaryDevice] +
 									movecloseXpos,
-								    (titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
+									(titleboxYpos + 12) + titleboxYposDropDown[i % 5]);
 							else
 								drawIcon(iconXpos - titleboxXpos[ms().secondaryDevice] +
-									     movecloseXpos,
+										 movecloseXpos,
 									 (titleboxYpos + 12) +
-									     titleboxYposDropDown[i % 5],
+										 titleboxYposDropDown[i % 5],
 									 i);
 						}
 					}
@@ -998,12 +998,12 @@ void vBlankHandler() {
 					if (movingApp != -1) {
 						if (ms().theme > 0) {
 							glSprite(((i - 1) * 2496 / 39) + 128 -
-								     titleboxXpos[ms().secondaryDevice] + movingAppXFix,
+									 titleboxXpos[ms().secondaryDevice] + movingAppXFix,
 								 titleboxYpos + titleboxYposDropDown[i % 5],
 								 GL_FLIP_NONE, tex().boxemptyImage());
 						} else {
 							glSprite(((i - 1) * 2496 / 39) + 128 -
-								     titleboxXpos[ms().secondaryDevice] + movingAppXFix,
+									 titleboxXpos[ms().secondaryDevice] + movingAppXFix,
 								 titleboxYpos + titleboxYposDropDown[i % 5],
 								 GL_FLIP_NONE, &tex().boxfullImage()[1]);
 						}
@@ -1014,7 +1014,7 @@ void vBlankHandler() {
 								 GL_FLIP_NONE, tex().boxemptyImage());
 						} else {
 							glSprite(spawnedboxXpos - titleboxXpos[ms().secondaryDevice] +
-								     movecloseXpos,
+									 movecloseXpos,
 								 titleboxYpos + titleboxYposDropDown[i % 5],
 								 GL_FLIP_NONE, &tex().boxfullImage()[1]);
 						}
@@ -1028,7 +1028,7 @@ void vBlankHandler() {
 			glSprite(spawnedboxXpos + 10 - titleboxXpos[ms().secondaryDevice], 81, GL_FLIP_H,
 				 tex().braceImage());
 		}
- 
+
 		if (movingApp != -1 && !ms().theme && showMovingArrow) {
 			if (movingArrowYdirection) {
 				movingArrowYpos += 0.33;
@@ -1109,9 +1109,9 @@ void vBlankHandler() {
 					drawIcon(112, 96 - titleboxYmovepos, CURPOS);
 			}
 			// Draw dots after selecting a game/app
-			
-			dots().drawAuto(); 
-		
+
+			dots().drawAuto();
+
 			titleboxYmovepos += 5;
 		}
 		if (showSTARTborder && displayGameIcons && (ms().theme < 4) && (!isScrolling || ms().theme == 1)) {
@@ -1127,7 +1127,7 @@ void vBlankHandler() {
 
 			if (ms().theme == 0) {
 				if (currentBg == 1 && ms().theme == 0 && needToPlayStopSound &&
-				    waitForNeedToPlayStopSound == 0) {
+					waitForNeedToPlayStopSound == 0) {
 					// mmEffectEx(&snd_stop);
 					snd().playStop();
 					waitForNeedToPlayStopSound = 1;
@@ -1183,8 +1183,8 @@ void vBlankHandler() {
 							 &tex().smallCartImage()[2]); // SD card
 					} else {
 						glSprite(
-						    32, (ms().theme == 4 ? 0 : dbox_Ypos) + selIconYpos, GL_FLIP_NONE,
-						    &tex().smallCartImage()[(REG_SCFG_MC == 0x11) ? 1
+							32, (ms().theme == 4 ? 0 : dbox_Ypos) + selIconYpos, GL_FLIP_NONE,
+							&tex().smallCartImage()[(REG_SCFG_MC == 0x11) ? 1
 												  : 0]); // Slot-1 card
 					}
 					selIconYpos += 28;
@@ -1200,7 +1200,7 @@ void vBlankHandler() {
 					 tex().manualImage()); // Manual
 			}
 		}
-		
+
 		// Show button_arrowPals (debug feature)
 		/*for (int i = 0; i < 16; i++) {
 				for (int i2 = 0; i2 < 16; i2++) {
@@ -1312,7 +1312,7 @@ void vBlankHandler() {
 	// }
 	// if (applaunchprep && ms().theme == 0)
 	// 	launchDotDoFrameChange = !launchDotDoFrameChange;
-	
+
 	bottomBgRefresh(); // Refresh the background image on vblank
 }
 
@@ -1336,7 +1336,7 @@ void loadPhotoList() {
 
 			photoDir = ent->d_name;
 			if (photoDir == ".." || photoDir == "..." || photoDir == "." || photoDir.substr(0, 2) == "._" ||
-			    photoDir.substr(photoDir.find_last_of(".") + 1) != "png")
+				photoDir.substr(photoDir.find_last_of(".") + 1) != "png")
 				continue;
 
 			// Reallocation here, but prevents our vector from being filled with garbage
@@ -1620,8 +1620,8 @@ void graphicsInit() {
 		//tex().load3DSTheme();
 		rocketVideo_videoYpos = tc().rotatingCubesRenderY();
 		loadRotatingCubes();
-	} 
-	
+	}
+
 	tex().drawTopBg();
 	if (ms().theme != 4) {
 		tex().drawProfileName();


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This makes the DSi theme use the photo's size so that photos up to 208 x 156 can all load correctly
  - It will center smaller ones with a black border
  - I could add scaling down / cropping, but there's probably not enough RAM for much bigger images anyways
- I also ran VS Code's convert to tabs and trim trailing whitespace on the file since it was bothering me and tabs were the main indentation of the file
-  Example of default at half scale ~~with a red smiley face I accidentally undid the mouth on~~:
![BMP_conversion_from_Evie113666](https://user-images.githubusercontent.com/41608708/75392923-a55d4e80-58b2-11ea-97b5-251a6f0521c1.png)


#### Where have you tested it?

- no$gba v3.0 (It should work on console, but I don't have a µSD adapter on me)

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
