### PR TITLE
Put BOOT.NDS file in correct location in nightlies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all:	booter booter_fc quickmenu manual romsel_aktheme romsel_dsimenutheme romsel
 
 package: all
 	@mkdir -p "$(PACKAGE)"
-	@cp "booter/booter.nds" "$(PACKAGE)/BOOT.NDS"
+	@cp "booter/booter.nds" "$(PACKAGE)/DSi&3DS - SD card users/BOOT.NDS"
 	@cp "booter_fc/booter_fc.nds" "$(PACKAGE)/Flashcard users/BOOT.NDS"
 	@cp "booter_fc/booter_fc_cyclodsi.nds" "$(PACKAGE)/Flashcard users/BOOT_cyclodsi.NDS"
 
@@ -81,7 +81,7 @@ clean:
 	@$(MAKE) -C title clean
 
 	@echo clean package files
-	@rm -rf "$(PACKAGE)/BOOT.NDS"
+	@rm -rf "$(PACKAGE)/DSi&3DS - SD card users/BOOT.NDS"
 	@rm -rf "$(PACKAGE)/Flashcard users/BOOT.NDS"
 	@rm -rf "$(PACKAGE)/Flashcard users/BOOT_cyclodsi.NDS"
 	@rm -rf "$(PACKAGE)/DSi - CFW users/SDNAND root/title/00030015/53524c41/content/00000000.app"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,10 @@ jobs:
 
     - script: |
         rm -r 7zfile/_nds/TWiLightMenu/*menu/
+        # Clean .gitkeep files
+        rm -rf 7zfile/*/.gitkeep
+        rm -rf 7zfile/*/*/.gitkeep
+
         mv 7zfile/ TWiLightMenu/
         7z a TWiLightMenu.7z TWiLightMenu/
         rm -r TWiLightMenu/_nds/TWiLightMenu/widescreen/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,8 +67,9 @@ jobs:
         mkdir 7zfile/_nds/TWiLightMenu/boxart/
         mkdir 7zfile/_nds/TWiLightMenu/gamesettings/
 
-        mv 7zfile/BOOT.NDS 7zfile/DSi\&3DS\ -\ SD\ card\ users/
-        mv 7zfile/BOOT_FC.NDS 7zfile/Flashcard\ users/BOOT.NDS
+        # Clean .gitkeep files
+        rm -rf 7zfile/*/.gitkeep
+        rm -rf 7zfile/*/*/.gitkeep
 
         # nds-bootstrap
         mkdir nds-bootstrap


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This simply changes `make package` to directly put `BOOT.NDS` in `DSi&3DS - SD card users` instead of relying on Azure to move it to the correct location which was only being done for releases.

#### Where have you tested it?

- It puts the files in the correct locations on macOS 10.14, not tested on console since no code was changed.

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
