### PR TITLE
Fix Guru error when boot via Memory pit

### DIFF
--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -716,7 +716,8 @@ int main(int argc, char **argv)
 	}
 
 	if (ms().dsiWareExploit == 0) {
-		remove("sd:/_nds/nds-bootstrap/srBackendId.bin");
+		if (access("sd:/_nds/nds-bootstrap/srBackendId.bin", F_OK) == 0)
+			remove("sd:/_nds/nds-bootstrap/srBackendId.bin");
 	}
 
 	runGraphicIrq();


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

_Fix Guru error when boot via some DSiWareHax (or only Memory Pit?)._

#### Where have you tested it?

_Tested it on my DSi console._

*** 
#### Pull Request status
- [√]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
