### PR TITLE
Make settings scroller based on the total position

### DIFF
--- a/settings/arm9/source/settingsgui.cpp
+++ b/settings/arm9/source/settingsgui.cpp
@@ -125,8 +125,8 @@ void SettingsGUI::draw()
         {
             printSmall(false, 4, 29 + (i - _topCursor) * 14, ">");
             // print scroller on the other side
-            printSmall(false, 252, 30 + (i - _topCursor) * 14, "|");
-            printSmall(false, 254, 30 + (i - _topCursor) * 14, "|");
+            printSmall(false, 252, 30 + (14 * 8 * ((float)_selectedOption / (_pages[_selectedPage].options().size() - 1))), "|");
+            printSmall(false, 254, 30 + (14 * 8 * ((float)_selectedOption / (_pages[_selectedPage].options().size() - 1))), "|");
         }
 
         int labelWidth = calcSmallFontWidth(_pages[_selectedPage].options()[i].labels()[selected].c_str());
@@ -190,8 +190,8 @@ void SettingsGUI::drawSub()
             printSmall(false, 4, 29 + (i - _subTopCursor) * 14, ">");
 
             // print scroller on the other side
-            printSmall(false, 252, 30 + (i - _subTopCursor) * 14, "|");
-            printSmall(false, 254, 30 + (i - _subTopCursor) * 14, "|");
+            printSmall(false, 252, 30 + (14 * 8 * ((float)_selectedOption / (_pages[_selectedPage].options().size() - 1))), "|");
+            printSmall(false, 254, 30 + (14 * 8 * ((float)_selectedOption / (_pages[_selectedPage].options().size() - 1))), "|");
         }
 
         printSmall(false, 12, 30 + (i - _subTopCursor) * 14, _subOption->labels()[i].c_str());


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This changes the settings scroller (on the right) to be based on the selection's position within that pages total items so that it will be at the bottom only when on the last item and the top only when on the first instead of simply mirroring the left cursor since it seems rather redundant to have both show the same thing
- *<sub>Wasn't sure if I should just add this to my other PR right now but their on completely different topics so I didn't</sub>*

#### Where have you tested it?

- DSi (K) with the latest TWiLight and Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
