### PR TITLE
DSi Theme: Allow preventing hiding/deleting ROMs

### DIFF
--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
@@ -51,6 +51,7 @@ DSiMenuPlusPlusSettings::DSiMenuPlusPlusSettings()
     showBoxArt = true;
     cacheBoxArt = true;
     animateDsiIcons = true;
+    preventDeletion = false;
     sysRegion = -1;
     launcherApp = -1;
     secondaryAccess = false;
@@ -173,6 +174,7 @@ void DSiMenuPlusPlusSettings::loadSettings()
     showBoxArt = settingsini.GetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
     cacheBoxArt = settingsini.GetInt("SRLOADER", "CACHE_BOX_ART", cacheBoxArt);
     animateDsiIcons = settingsini.GetInt("SRLOADER", "ANIMATE_DSI_ICONS", animateDsiIcons);
+    preventDeletion = settingsini.GetInt("SRLOADER", "PREVENT_ROM_DELETION", preventDeletion);
 	if (consoleModel < 2) {
 		sysRegion = settingsini.GetInt("SRLOADER", "SYS_REGION", sysRegion);
 		launcherApp = settingsini.GetInt("SRLOADER", "LAUNCHER_APP", launcherApp);

--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.h
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.h
@@ -159,6 +159,7 @@ class DSiMenuPlusPlusSettings
 	bool showSnes;
     bool showDirectories;
     bool showHidden;
+    bool preventDeletion;
     bool showBoxArt;
     bool cacheBoxArt;
     bool animateDsiIcons;

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -2960,7 +2960,7 @@ string browseForFile(const vector<string> extensionList) {
 				return "null";
 			}
 
-			if ((pressed & KEY_X) && bannerTextShown && showSTARTborder
+			if ((pressed & KEY_X) && !ms().preventDeletion && bannerTextShown && showSTARTborder
 			&& dirContents[scrn].at(CURPOS + PAGENUM * 40).name != "..") {
 				DirEntry *entry = &dirContents[scrn].at((PAGENUM * 40) + (CURPOS));
 				bool unHide = (FAT_getAttr(entry->name.c_str()) & ATTR_HIDDEN || (strncmp(entry->name.c_str(), ".", 1) == 0 && entry->name != ".."));

--- a/settings/arm9/source/common/dsimenusettings.cpp
+++ b/settings/arm9/source/common/dsimenusettings.cpp
@@ -148,6 +148,7 @@ void DSiMenuPlusPlusSettings::loadSettings()
     sortMethod = settingsini.GetInt("SRLOADER", "SORT_METHOD", sortMethod);
     showDirectories = settingsini.GetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);
     showHidden = settingsini.GetInt("SRLOADER", "SHOW_HIDDEN", showHidden);
+    preventDeletion = settingsini.GetInt("SRLOADER", "PREVENT_ROM_DELETION", preventDeletion);
     showBoxArt = settingsini.GetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
     cacheBoxArt = settingsini.GetInt("SRLOADER", "CACHE_BOX_ART", cacheBoxArt);
     animateDsiIcons = settingsini.GetInt("SRLOADER", "ANIMATE_DSI_ICONS", animateDsiIcons);
@@ -243,6 +244,7 @@ void DSiMenuPlusPlusSettings::saveSettings()
     settingsini.SetInt("SRLOADER", "SORT_METHOD", sortMethod);
     settingsini.SetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);
     settingsini.SetInt("SRLOADER", "SHOW_HIDDEN", showHidden);
+    settingsini.SetInt("SRLOADER", "PREVENT_ROM_DELETION", preventDeletion);
     settingsini.SetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
     settingsini.SetInt("SRLOADER", "CACHE_BOX_ART", cacheBoxArt);
     settingsini.SetInt("SRLOADER", "ANIMATE_DSI_ICONS", animateDsiIcons);

--- a/settings/arm9/source/common/dsimenusettings.h
+++ b/settings/arm9/source/common/dsimenusettings.h
@@ -153,6 +153,7 @@ class DSiMenuPlusPlusSettings
     int sortMethod;
     bool showDirectories;
     bool showHidden;
+    bool preventDeletion;
     bool showBoxArt;
     bool cacheBoxArt;
     bool animateDsiIcons;

--- a/settings/arm9/source/language.inl
+++ b/settings/arm9/source/language.inl
@@ -39,6 +39,7 @@ STRING(LAUNCHERAPP, "SysNAND Launcher")
 STRING(SYSTEMSETTINGS, "System Settings")
 STRING(REPLACEDSIMENU, "Replace DSi Menu")
 STRING(RESTOREDSIMENU, "Restore DSi Menu")
+STRING(PREVENT_ROM_DELETION, "Prevent ROM hiding and deletion")
 
 STRING(SHOW, "Show")
 STRING(HIDE, "Hide")
@@ -84,6 +85,8 @@ STRING(DESCRIPTION_SORT_METHOD, "Changes whether to sort alphabetically, by rece
 STRING(DESCRIPTION_DIRECTORIES_1, "If you're in a folder where most of your games are, it is safe to hide directories/folders.")
 
 STRING(DESCRIPTION_SHOW_HIDDEN_1, "If turned on, whether an app is set to hidden or not will be ignored and it will be displayed anyways.")
+
+STRING(DESCRIPTION_PREVENT_ROM_DELETION_1, "When turned on, ROM hiding/deletion is disabled. Also note this prevents un-hiding as well.")
 
 STRING(DESCRIPTION_SHOW_NDS, "Display Nintendo DS/DSi ROMs in the ROM list.")
 

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -520,6 +520,7 @@ int main(int argc, char **argv)
 		.option(STR_SORT_METHOD, STR_DESCRIPTION_SORT_METHOD, Option::Int(&ms().sortMethod), {STR_ALPHABETICAL, STR_RECENT, STR_MOST_PLAYED, STR_FILE_TYPE, STR_CUSTOM}, {0, 1, 2, 3, 4})
 		.option(STR_DIRECTORIES, STR_DESCRIPTION_DIRECTORIES_1, Option::Bool(&ms().showDirectories), {STR_SHOW, STR_HIDE}, {true, false})
 		.option(STR_SHOW_HIDDEN, STR_DESCRIPTION_SHOW_HIDDEN_1, Option::Bool(&ms().showHidden), {STR_SHOW, STR_HIDE}, {true, false})
+		.option(STR_PREVENT_ROM_DELETION, STR_DESCRIPTION_PREVENT_ROM_DELETION_1, Option::Bool(&ms().preventDeletion), {STR_YES, STR_NO}, {true, false})
 		.option(STR_BOXART, STR_DESCRIPTION_BOXART_1, Option::Bool(&ms().showBoxArt), {STR_SHOW, STR_HIDE}, {true, false});
 	if (isDSiMode()) {
 		guiPage.option(STR_BOXARTMEM, STR_DESCRIPTION_BOXARTMEM, Option::Bool(&ms().cacheBoxArt), {STR_YES, STR_NO}, {true, false});


### PR DESCRIPTION
Fixes #1031

<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Deletion/hiding of ROMS can now be disabled.

Note this __does__ work on all themes except the R4 and Wood UI themes.

#### Where have you tested it?

DSi

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
