### PR TITLE
Fix non-escaped spaces in widescreen from lite 7z

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
         mv 7zfile/ TWiLightMenu/
         7z a TWiLightMenu.7z TWiLightMenu/
         rm -r TWiLightMenu/_nds/TWiLightMenu/apfix/
-        rm -r TWiLightMenu/3DS - CFW users/_nds/TWiLightMenu/widescreen/
+        rm -r TWiLightMenu/3DS\ -\ CFW\ users/_nds/TWiLightMenu/widescreen/
         7z a TWiLightMenu-Lite.7z TWiLightMenu/
         cp TWiLightMenu.7z $(Build.ArtifactStagingDirectory)/TWiLightMenu.7z
         cp TWiLightMenu-Lite.7z $(Build.ArtifactStagingDirectory)/TWiLightMenu-Lite.7z


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This is just a simple fix that the nightly lite 7z's still had their widescreen files due to some non-escaped spaces

#### Where have you tested it?

- bash v2.3.57 on macOS 10.14.6 (The copy worked, no code changes so no need to test on DS)

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
