### PR TITLE
DSi-based/R4: Repeat keys in per game settings

### DIFF
--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -334,8 +334,6 @@ void CheatCodelist::selectCheats(std::string filename)
   int mainListCurPos = -1, mainListScreenPos = -1,
       cheatWnd_cursorPosition = 0, cheatWnd_screenPosition = 0;
 
-  keysSetRepeat(25, 5); // Slow down key repeat
-
   while(cheatsFound) {
     // Scroll screen if needed
     if(cheatWnd_cursorPosition < cheatWnd_screenPosition) {
@@ -507,8 +505,6 @@ void CheatCodelist::selectCheats(std::string filename)
       }
     }
   }
-
-  keysSetRepeat(10, 2); // Reset key repeat
 }
 
 static void updateDB(u8 value,u32 offset,FILE* db)

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -431,20 +431,22 @@ void displayNowLoading(void) {
 	displayGameIcons = false;
 	fadeType = true; // Fade in from white
 	snd().updateStream();
+	std::string *msg;
 	if (isDSiMode() && memcmp(io_dldi_data->friendlyName, "CycloDS iEvolution", 18) == 0) {
-		printSmall(false, 0, 20, STR_TAKEWHILE_TURNOFF, Alignment::center);
+		msg = &STR_TAKEWHILE_TURNOFF;
 	} else if (REG_SCFG_EXT != 0 && ms().consoleModel >= 2) {
-		printSmall(false, 0, 20, STR_TAKEWHILE_PRESSHOME, Alignment::center);
+		msg = &STR_TAKEWHILE_PRESSHOME;
 	} else {
-		printSmall(false, 0, 20, STR_TAKEWHILE_CLOSELID, Alignment::center);
+		msg = &STR_TAKEWHILE_CLOSELID;
 	}
+	printSmall(false, 0, 20, *msg, Alignment::center);
 	printLarge(false, 0, 88, STR_NOW_LOADING, Alignment::center);
 	if (!sys().isRegularDS()) {
 		if (ms().theme == 4) {
 			if (ms().secondaryDevice) {
-				printSmall(false, 0, 48, STR_LOCATION_SLOT_1, Alignment::center);
+				printSmall(false, 0, 20 + calcSmallFontHeight(*msg), STR_LOCATION_SLOT_1, Alignment::center);
 			} else {
-				printSmall(false, 0, 48, ms().showMicroSd ? STR_LOCATION_MICRO_SD : STR_LOCATION_SD, Alignment::center);
+				printSmall(false, 0, 20 + calcSmallFontHeight(*msg), ms().showMicroSd ? STR_LOCATION_MICRO_SD : STR_LOCATION_SD, Alignment::center);
 			}
 		} else {
 			if (ms().secondaryDevice) {

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -230,7 +230,9 @@ void revertDonorRomText(void) {
 }
 
 void perGameSettings (std::string filename) {
-	int pressed = 0;
+	int pressed = 0, held = 0;
+
+	keysSetRepeat(25, 5); // Slow down key repeat
 
 	if (ms().theme == 5) {
 		displayGameIcons = false;
@@ -582,6 +584,7 @@ void perGameSettings (std::string filename) {
 		do {
 			scanKeys();
 			pressed = keysDown();
+			held = keysDownRepeat();
 			checkSdEject();
 			tex().drawVolumeImageCached();
 			tex().drawBatteryImageCached();
@@ -590,7 +593,7 @@ void perGameSettings (std::string filename) {
 			drawClockColon();
 			snd().updateStream();
 			swiWaitForVBlank();
-		} while (!pressed);
+		} while (!held);
 
 		if (!showPerGameSettings) {
 			if ((pressed & KEY_A) || (pressed & KEY_B)) {
@@ -598,7 +601,7 @@ void perGameSettings (std::string filename) {
 				break;
 			}
 		} else {
-			if (pressed & KEY_UP) {
+			if (held & KEY_UP) {
 				snd().playSelect();
 				revertDonorRomText();
 				perGameSettings_cursorPosition--;
@@ -609,7 +612,7 @@ void perGameSettings (std::string filename) {
 					firstPerGameOpShown--;
 				}
 			}
-			if (pressed & KEY_DOWN) {
+			if (held & KEY_DOWN) {
 				snd().playSelect();
 				revertDonorRomText();
 				perGameSettings_cursorPosition++;
@@ -621,7 +624,7 @@ void perGameSettings (std::string filename) {
 				}
 			}
 
-			if (pressed & KEY_LEFT) {
+			if (held & KEY_LEFT) {
 				switch (perGameOp[perGameSettings_cursorPosition]) {
 					case 0:
 						perGameSettings_language--;
@@ -672,7 +675,7 @@ void perGameSettings (std::string filename) {
 				}
 				(ms().theme == 4) ? snd().playLaunch() : snd().playSelect();
 				perGameSettingsChanged = true;
-			} else if ((pressed & KEY_A) || (pressed & KEY_RIGHT)) {
+			} else if ((pressed & KEY_A) || (held & KEY_RIGHT)) {
 				switch (perGameOp[perGameSettings_cursorPosition]) {
 					case 0:
 						perGameSettings_language++;
@@ -780,6 +783,8 @@ void perGameSettings (std::string filename) {
 	} else {
 		clearText();
 	}
+
+	keysSetRepeat(10, 2); // Reset key repeat
 }
 
 std::string getSavExtension(void) {

--- a/romsel_r4theme/arm9/source/cheat.cpp
+++ b/romsel_r4theme/arm9/source/cheat.cpp
@@ -310,8 +310,6 @@ void CheatCodelist::selectCheats(std::string filename)
   int mainListCurPos = -1, mainListScreenPos = -1,
       cheatWnd_cursorPosition = 0, cheatWnd_screenPosition = 0;
 
-  keysSetRepeat(25, 5); // Slow down key repeat
-
   while(cheatsFound) {
     clearText();
     titleUpdate(isDirectory, filename.c_str());
@@ -479,7 +477,6 @@ void CheatCodelist::selectCheats(std::string filename)
     }
   }
   dialogboxHeight = oldDialogboxHeight;
-  keysSetRepeat(10, 2); // Reset key repeat
 }
 
 static void updateDB(u8 value,u32 offset,FILE* db)

--- a/romsel_r4theme/arm9/source/perGameSettings.cpp
+++ b/romsel_r4theme/arm9/source/perGameSettings.cpp
@@ -214,7 +214,9 @@ void revertDonorRomText(void) {
 }
 
 void perGameSettings (std::string filename) {
-	int pressed = 0;
+	int pressed = 0, held = 0;
+
+	keysSetRepeat(25, 5); // Slow down key repeat
 
 	clearText();
 	
@@ -525,16 +527,17 @@ void perGameSettings (std::string filename) {
 		do {
 			scanKeys();
 			pressed = keysDown();
+			held = keysDownRepeat();
 			checkSdEject();
 			swiWaitForVBlank();
-		} while (!pressed);
+		} while (!held);
 
 		if (!showPerGameSettings) {
 			if ((pressed & KEY_A) || (pressed & KEY_B)) {
 				break;
 			}
 		} else {
-			if (pressed & KEY_UP) {
+			if (held & KEY_UP) {
 				revertDonorRomText();
 				perGameSettings_cursorPosition--;
 				if (perGameSettings_cursorPosition < 0) {
@@ -544,7 +547,7 @@ void perGameSettings (std::string filename) {
 					firstPerGameOpShown--;
 				}
 			}
-			if (pressed & KEY_DOWN) {
+			if (held & KEY_DOWN) {
 				revertDonorRomText();
 				perGameSettings_cursorPosition++;
 				if (perGameSettings_cursorPosition > perGameOps) {
@@ -555,7 +558,7 @@ void perGameSettings (std::string filename) {
 				}
 			}
 
-			if (pressed & KEY_LEFT) {
+			if (held & KEY_LEFT) {
 				switch (perGameOp[perGameSettings_cursorPosition]) {
 					case 0:
 						perGameSettings_language--;
@@ -605,7 +608,7 @@ void perGameSettings (std::string filename) {
 						break;
 				}
 				perGameSettingsChanged = true;
-			} else if ((pressed & KEY_A) || (pressed & KEY_RIGHT)) {
+			} else if ((pressed & KEY_A) || (held & KEY_RIGHT)) {
 				switch (perGameOp[perGameSettings_cursorPosition]) {
 					case 0:
 						perGameSettings_language++;
@@ -696,6 +699,7 @@ void perGameSettings (std::string filename) {
 	clearText();
 	showdialogbox = false;
 	dialogboxHeight = 0;
+	keysSetRepeat(10, 2); // Reset key repeat
 }
 
 std::string getSavExtension(void) {


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This makes per game settings use keysDownRepeat for Up/Down/Left/Right so you can just hold to go through several items
  - Fixes #955 (NightScript said vertical only, but I did horizontal too because some options have a lot that way too
- Also makes the Saturn theme's "Location: X" string's Y position vary with the if this freezes message above incase a translation needed three lines

#### Where have you tested it?

- DSi (K) with the latest TWiLight and Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
