### PR TITLE
DSi/Settings: Make text overlapping work

### DIFF
--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -259,16 +259,16 @@ void CheatCodelist::drawCheatList(std::vector<CheatCodelist::cParsedItem>& list,
   }
 
   // Print the list
-  for(uint i=0;i<96/smallFontHeight() && i<list.size();i++) {
+  for(uint i=0;i<8 && i<list.size();i++) {
     if(list[screenPos+i]._flags&cParsedItem::EFolder) {
-      printSmall(false, 15+((screenPos+i == curPos) ? 5 : 0), 60+(i*smallFontHeight()), ">");
-      printSmall(false, 28+((screenPos+i == curPos) ? 4 : 0), 60+(i*smallFontHeight()), list[screenPos+i]._title);
+      printSmall(false, 15+((screenPos+i == curPos) ? 5 : 0), 60+(i*12), ">");
+      printSmall(false, 28+((screenPos+i == curPos) ? 4 : 0), 60+(i*12), list[screenPos+i]._title);
     } else {
       if(list[screenPos+i]._flags&cParsedItem::ESelected) {
-        printSmall(false, 13, 60+(i*smallFontHeight()), "x");
+        printSmall(false, 13, 60+(i*12), "x");
       }
-      printSmall(false, 21+((screenPos+i == curPos) ? 4 : 0), 60+(i*smallFontHeight()), "-");
-      printSmall(false, 28+((screenPos+i == curPos) ? 7 : 0), 60+(i*smallFontHeight()), list[screenPos+i]._title);
+      printSmall(false, 21+((screenPos+i == curPos) ? 4 : 0), 60+(i*12), "-");
+      printSmall(false, 28+((screenPos+i == curPos) ? 7 : 0), 60+(i*12), list[screenPos+i]._title);
     }
   }
 }
@@ -338,8 +338,8 @@ void CheatCodelist::selectCheats(std::string filename)
     // Scroll screen if needed
     if(cheatWnd_cursorPosition < cheatWnd_screenPosition) {
       cheatWnd_screenPosition = cheatWnd_cursorPosition;
-    } else if(cheatWnd_cursorPosition > cheatWnd_screenPosition + (96/smallFontHeight()) - 1) {
-      cheatWnd_screenPosition = cheatWnd_cursorPosition - (96/smallFontHeight()) + 1;
+    } else if(cheatWnd_cursorPosition > cheatWnd_screenPosition + 8 - 1) {
+      cheatWnd_screenPosition = cheatWnd_cursorPosition - 8 + 1;
     }
 
     clearText();
@@ -371,10 +371,10 @@ void CheatCodelist::selectCheats(std::string filename)
       }
     } else if(held & KEY_LEFT) {
       snd().playSelect();
-      cheatWnd_cursorPosition -= (cheatWnd_cursorPosition > (96/smallFontHeight()) ? (96/smallFontHeight()) : cheatWnd_cursorPosition);
+      cheatWnd_cursorPosition -= (cheatWnd_cursorPosition > 8 ? 8 : cheatWnd_cursorPosition);
     } else if(held & KEY_RIGHT) {
       snd().playSelect();
-      cheatWnd_cursorPosition += (cheatWnd_cursorPosition < (int)(currentList.size()-(96/smallFontHeight())) ? (96/smallFontHeight()) : currentList.size()-cheatWnd_cursorPosition-1);
+      cheatWnd_cursorPosition += (cheatWnd_cursorPosition < (int)(currentList.size()-8) ? 8 : currentList.size()-cheatWnd_cursorPosition-1);
     } else if(pressed & KEY_A) {
       (ms().theme == 4) ? snd().playLaunch() : snd().playSelect();
       if(currentList[cheatWnd_cursorPosition]._flags&cParsedItem::EFolder) {

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
@@ -93,9 +93,6 @@ FontGraphic::FontGraphic(const std::string &path, const std::string &fallback) {
 		}
 		fclose(file);
 		questionMark = getCharIndex('?');
-
-		// Allocate character buffer
-		characterBuffer = std::vector<u8>(tileWidth * tileHeight);
 	}
 }
 
@@ -184,20 +181,15 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 		}
 
 		u16 index = getCharIndex(c);
-		for(int i = 0; i < tileSize; i++) {
-			u8 tile = fontTiles[i + (index * tileSize)];
-			characterBuffer[(i * 4)]     = (tile >> 6 & 3);
-			characterBuffer[(i * 4) + 1] = (tile >> 4 & 3);
-			characterBuffer[(i * 4) + 2] = (tile >> 2 & 3);
-			characterBuffer[(i * 4) + 3] = (tile      & 3);
-		}
-
 		// No need to draw off screen chars
 		if(x >= 0 && x < 256) {
 			u8 *dst = textBuf[top] + x + fontWidths[(index * 3)];
 			for(int i = 0; i < tileHeight; i++) {
-				if(y + i >= 0 && y + i < 192)
-					tonccpy(dst + ((y + i) * 256), &characterBuffer[i * tileWidth], tileWidth);
+				for(int j = 0; j < tileWidth; j++) {
+					u8 px = fontTiles[(index * tileSize) + (i * tileWidth + j) / 4] >> ((3 - ((i * tileWidth + j) % 4)) * 2) & 3;
+					if(px)
+						dst[(y + i) * 256 + j] = px;
+				}
 			}
 		}
 

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
@@ -19,7 +19,6 @@ private:
 	std::vector<u8> fontTiles;
 	std::vector<u8> fontWidths;
 	std::vector<u16> fontMap;
-	std::vector<u8> characterBuffer;
 
 	u16 getCharIndex(char16_t c);
 

--- a/settings/arm9/source/graphics/FontGraphic.cpp
+++ b/settings/arm9/source/graphics/FontGraphic.cpp
@@ -93,9 +93,6 @@ FontGraphic::FontGraphic(const std::string &path, const std::string &fallback) {
 		}
 		fclose(file);
 		questionMark = getCharIndex('?');
-
-		// Allocate character buffer
-		characterBuffer = std::vector<u8>(tileWidth * tileHeight);
 	}
 }
 
@@ -184,20 +181,15 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 		}
 
 		u16 index = getCharIndex(c);
-		for(int i = 0; i < tileSize; i++) {
-			u8 tile = fontTiles[i + (index * tileSize)];
-			characterBuffer[(i * 4)]     = (tile >> 6 & 3);
-			characterBuffer[(i * 4) + 1] = (tile >> 4 & 3);
-			characterBuffer[(i * 4) + 2] = (tile >> 2 & 3);
-			characterBuffer[(i * 4) + 3] = (tile      & 3);
-		}
-
 		// No need to draw off screen chars
 		if(x >= 0 && x < 256) {
 			u8 *dst = textBuf[top] + x + fontWidths[(index * 3)];
 			for(int i = 0; i < tileHeight; i++) {
-				if(y + i >= 0 && y + i < 192)
-					tonccpy(dst + ((y + i) * 256), &characterBuffer[i * tileWidth], tileWidth);
+				for(int j = 0; j < tileWidth; j++) {
+					u8 px = fontTiles[(index * tileSize) + (i * tileWidth + j) / 4] >> ((3 - ((i * tileWidth + j) % 4)) * 2) & 3;
+					if(px)
+						dst[(y + i) * 256 + j] = px;
+				}
 			}
 		}
 

--- a/settings/arm9/source/graphics/FontGraphic.h
+++ b/settings/arm9/source/graphics/FontGraphic.h
@@ -19,7 +19,6 @@ private:
 	std::vector<u8> fontTiles;
 	std::vector<u8> fontWidths;
 	std::vector<u16> fontMap;
-	std::vector<u8> characterBuffer;
 
 	u16 getCharIndex(char16_t c);
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- I was completely missing an easy solution to this that doesn't seem to have a major speed downside (Just copy the text directly to the main buffer instead of an 8bpp buffer first) until chyyran pointed it out 🤦‍♀️
- Also makes the DSi themes' cheat menu show 8 entries again since that works now

#### Where have you tested it?

- DSi (K) with the latest TWiLight and Unlaunch
- DS Lite (J) with DSTT and the latest TWiLight

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
