### PR TITLE
Include themes in full nighties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,11 @@ jobs:
       - name: "Pack 7z Package for nightly"
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
-          rm -r 7zfile/_nds/TWiLightMenu/*menu/
-
           mv 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/
+
+          # Delete themes, AP patches, and widescreen patches for lite
+          rm -r TWiLightMenu/_nds/TWiLightMenu/*menu/
           rm -r TWiLightMenu/_nds/TWiLightMenu/apfix/
           rm -r TWiLightMenu/3DS\ -\ CFW\ users/_nds/TWiLightMenu/widescreen/
           7z a TWiLightMenu-Lite.7z TWiLightMenu/


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This makes themes be included in full nightlies, since the lite builds exist if you want a faster install and they have been changing recently

#### Where have you tested it?

- Untested, but its just a CI change

*** 
#### Pull Request status
- [ ]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
