### PR TITLE
Make separate 7z's for DSi, 3DS, and FC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
           AUTH_HEADER="Authorization: token ${{ secrets.TWLBOT_TOKEN }}"
           CONTENT_TYPE="Content-Type: application/json"
           API_URL="https://api.github.com/repos/TWLBot/Builds/releases"
-          RELEASE_INFO="{\"tag_name\": \"v${{ steps.commit.outputs.current_date }}\", \"name\": \"TWiLightMenu | $COMMIT_TAG\", \"body\": \"$COMMIT_MESSAGE\", "prerelease": true}"
+          RELEASE_INFO="{\"tag_name\": \"v${{ steps.commit.outputs.current_date }}\", \"name\": \"TWiLightMenu | $COMMIT_TAG\", \"body\": \"$COMMIT_MESSAGE\", \"prerelease\": true}"
 
           RESPONSE=$(curl -XPOST -H "$AUTH_HEADER" -H "$CONTENT_TYPE" "$API_URL" -d "$RELEASE_INFO")
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,35 @@ jobs:
       - name: "Pack 7z Package for nightly"
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
-          mv 7zfile/ TWiLightMenu/
+          cp 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/
 
+          # DSi 7z
+          mv TWiLightMenu/DSi\ -\ CFW users/SDNAND\ root/* TWiLightMenu
+          rm -rf TWiLightMenu/DSi\ -\ CFW users
+          cp -r TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users/* TWiLightMenu
+          rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
+          7z a TWiLightMenu-DSi.7z
+
+          # 3DS 7z
+          rm -rf TWiLightMenu
+          cp 7zfile/ TWiLightMenu/
+          mv TWiLightMenu/3DS - CFW users/* TWiLightMenu
+          rm -rf TWiLightMenu/3DS - CFW users
+          cp -r TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users/* TWiLightMenu
+          rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
+          7z a TWiLightMenu-3DS.7z
+
+          # Flashcard 7z
+          rm -rf TWiLightMenu
+          cp 7zfile/ TWiLightMenu/
+          mv TWiLightMenu/Flashcard users/* TWiLightMenu
+          rm -rf TWiLightMenu/Flashcard users
+          7z a TWiLightMenu-Flashcard.7z
+
           # Delete themes, AP patches, and widescreen patches for lite
+          rm -rf TWiLightMenu
+          cp 7zfile/ TWiLightMenu/
           rm -r TWiLightMenu/_nds/TWiLightMenu/*menu/
           rm -r TWiLightMenu/_nds/TWiLightMenu/apfix/
           rm -r TWiLightMenu/3DS\ -\ CFW\ users/_nds/TWiLightMenu/widescreen/
@@ -72,6 +97,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags') }}
         run: |
           mkdir 7zfile/_nds/TWiLightMenu/boxart/
+          mkdir 7zfile/_nds/TWiLightMenu/extras/
           mkdir 7zfile/_nds/TWiLightMenu/gamesettings/
 
           # nds-bootstrap
@@ -103,10 +129,42 @@ jobs:
           # Really dumb hidden file that for some reason fixes the releases
           touch 7zfile/.ignoreme
 
-          cd 7zfile
+          # Main 7z
+          cp 7zfile TWiLightMenu
+          cd TWiLightMenu
           7z a TWiLightMenu.7z .
           mkdir -p ~/artifacts
-          cp TWiLightMenu.7z ~/artifacts
+          mv TWiLightMenu.7z ~/artifacts
+
+          # DSi 7z
+          mv DSi\ -\ CFW users/SDNAND\ root/* .
+          rm -rf DSi\ -\ CFW users
+          cp -r DSi\&3DS\ -\ SD\ card\ users/* .
+          rm -rf DSi\&3DS\ -\ SD\ card\ users
+          7z a TWiLightMenu-DSi.7z
+          mv TWiLightMenu-DSi.7z ~/artifacts
+
+          # 3DS 7z
+          cd ..
+          rm -rf TWiLightMenu
+          cp 7zfile/ TWiLightMenu/
+          cd TWiLightMenu
+          mv 3DS - CFW users/SDNAND\ root/* .
+          rm -rf 3DS - CFW users
+          cp -r DSi\&3DS\ -\ SD\ card\ users/* .
+          rm -rf DSi\&3DS\ -\ SD\ card\ users
+          7z a TWiLightMenu-3DS.7z
+          mv TWiLightMenu-3DS.7z ~/artifacts
+
+          # Flashcard 7z
+          cd ..
+          rm -rf TWiLightMenu
+          cp 7zfile/ TWiLightMenu/
+          cd TWiLightMenu
+          mv Flashcard users/* .
+          rm -rf Flashcard users
+          7z a TWiLightMenu-Flashcard.7z
+          mv TWiLightMenu-Flashcard.7z ~/artifacts
       - name: "Publish build to GH Actions"
         uses: actions/upload-artifact@v2
         with:
@@ -160,7 +218,7 @@ jobs:
           git stage .
           git commit -m "TWiLightMenu | $COMMIT_TAG"
           git tag v$CURRENT_DATE
-          git push origin v$CURRENT_DATE
+          git push origin v$CURRENT_DATE master
           echo "::set-output name=twlbot_commit::$(git log --format=%H -1)"
       - name: Release to TWLBot/Builds
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,42 +59,49 @@ jobs:
         run: |
           cp -r 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/
+          mkdir -p ~/artifacts
           mv TWiLightMenu.7z ~/artifacts
 
           # DSi 7z
-          mv TWiLightMenu/DSi\ -\ CFW users/SDNAND\ root/* TWiLightMenu
-          rm -rf TWiLightMenu/DSi\ -\ CFW users
+          mv TWiLightMenu/DSi\ -\ CFW\ users/* TWiLightMenu
+          rm -rf TWiLightMenu/DSi\ -\ CFW\ users
           cp -r TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users/* TWiLightMenu
           rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
-          7z a TWiLightMenu-DSi.7z
+          rm -rf TWiLightMenu/3DS\ -\ CFW\ users
+          rm -rf TWiLightMenu/Flashcard\ users
+          7z a TWiLightMenu-DSi.7z TWiLightMenu
           mv TWiLightMenu-DSi.7z ~/artifacts
 
           # 3DS 7z
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
-          mv TWiLightMenu/3DS - CFW users/* TWiLightMenu
-          rm -rf TWiLightMenu/3DS - CFW users
+          mv TWiLightMenu/3DS\ -\ CFW\ users/* TWiLightMenu
+          rm -rf TWiLightMenu/3DS\ -\ CFW\ users
           cp -r TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users/* TWiLightMenu
           rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
-          7z a TWiLightMenu-3DS.7z
+          rm -rf TWiLightMenu/DSi\ -\ CFW\ users
+          rm -rf TWiLightMenu/Flashcard\ users
+          7z a TWiLightMenu-3DS.7z TWiLightMenu
           mv TWiLightMenu-3DS.7z ~/artifacts
 
           # Flashcard 7z
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
-          mv TWiLightMenu/Flashcard users/* TWiLightMenu
-          rm -rf TWiLightMenu/Flashcard users
-          7z a TWiLightMenu-Flashcard.7z
+          mv TWiLightMenu/Flashcard\ users/* TWiLightMenu
+          rm -rf TWiLightMenu/Flashcard\ users
+          rm -rf TWiLightMenu/3DS\ -\ CFW\ users
+          rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
+          rm -rf TWiLightMenu/DSi\ -\ CFW\ users
+          7z a TWiLightMenu-Flashcard.7z TWiLightMenu
           mv TWiLightMenu-Flashcard.7z ~/artifacts
 
           # Delete themes, AP patches, and widescreen patches for lite
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
-          rm -r TWiLightMenu/_nds/TWiLightMenu/*menu/
-          rm -r TWiLightMenu/_nds/TWiLightMenu/apfix/
-          rm -r TWiLightMenu/3DS\ -\ CFW\ users/_nds/TWiLightMenu/widescreen/
+          rm -rf TWiLightMenu/_nds/TWiLightMenu/*menu/
+          rm -rf TWiLightMenu/_nds/TWiLightMenu/apfix/
+          rm -rf TWiLightMenu/3DS\ -\ CFW\ users/_nds/TWiLightMenu/widescreen/
           7z a TWiLightMenu-Lite.7z TWiLightMenu/
-          mkdir -p ~/artifacts
           mv TWiLightMenu-Lite.7z ~/artifacts
       - name: "Pack 7z Package for release"
         if: ${{ startsWith(github.ref, 'refs/tags') }}
@@ -138,8 +145,8 @@ jobs:
           mv TWiLightMenu.7z ~/artifacts
 
           # DSi 7z
-          mv DSi\ -\ CFW users/SDNAND\ root/* .
-          rm -rf DSi\ -\ CFW users
+          mv DSi\ -\ CFW\ users/* .
+          rm -rf DSi\ -\ CFW\ users
           cp -r DSi\&3DS\ -\ SD\ card\ users/* .
           rm -rf DSi\&3DS\ -\ SD\ card\ users
           7z a TWiLightMenu-DSi.7z
@@ -150,8 +157,8 @@ jobs:
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
           cd TWiLightMenu
-          mv 3DS - CFW users/SDNAND\ root/* .
-          rm -rf 3DS - CFW users
+          mv 3DS\ -\ CFW\ users/* .
+          rm -rf 3DS\ -\ CFW\ users
           cp -r DSi\&3DS\ -\ SD\ card\ users/* .
           rm -rf DSi\&3DS\ -\ SD\ card\ users
           7z a TWiLightMenu-3DS.7z
@@ -162,8 +169,8 @@ jobs:
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
           cd TWiLightMenu
-          mv Flashcard users/* .
-          rm -rf Flashcard users
+          mv Flashcard\ users/* .
+          rm -rf Flashcard\ users
           7z a TWiLightMenu-Flashcard.7z
           mv TWiLightMenu-Flashcard.7z ~/artifacts
       - name: "Publish build to GH Actions"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           mv TWiLightMenu.7z ~/artifacts
 
           # DSi 7z
-          mv TWiLightMenu/DSi\ -\ CFW\ users/* TWiLightMenu
+          cp -r TWiLightMenu/DSi\ -\ CFW\ users/* TWiLightMenu
           rm -rf TWiLightMenu/DSi\ -\ CFW\ users
           cp -r TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users/* TWiLightMenu
           rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
@@ -75,7 +75,7 @@ jobs:
           # 3DS 7z
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
-          mv TWiLightMenu/3DS\ -\ CFW\ users/* TWiLightMenu
+          cp -r TWiLightMenu/3DS\ -\ CFW\ users/* TWiLightMenu
           rm -rf TWiLightMenu/3DS\ -\ CFW\ users
           cp -r TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users/* TWiLightMenu
           rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
@@ -87,7 +87,7 @@ jobs:
           # Flashcard 7z
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
-          mv TWiLightMenu/Flashcard\ users/* TWiLightMenu
+          cp -r TWiLightMenu/Flashcard\ users/* TWiLightMenu
           rm -rf TWiLightMenu/Flashcard\ users
           rm -rf TWiLightMenu/3DS\ -\ CFW\ users
           rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
@@ -145,7 +145,7 @@ jobs:
           mv TWiLightMenu.7z ~/artifacts
 
           # DSi 7z
-          mv DSi\ -\ CFW\ users/* .
+          cp -r DSi\ -\ CFW\ users/* .
           rm -rf DSi\ -\ CFW\ users
           cp -r DSi\&3DS\ -\ SD\ card\ users/* .
           rm -rf DSi\&3DS\ -\ SD\ card\ users
@@ -157,7 +157,7 @@ jobs:
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
           cd TWiLightMenu
-          mv 3DS\ -\ CFW\ users/* .
+          cp -r 3DS\ -\ CFW\ users/* .
           rm -rf 3DS\ -\ CFW\ users
           cp -r DSi\&3DS\ -\ SD\ card\ users/* .
           rm -rf DSi\&3DS\ -\ SD\ card\ users
@@ -169,7 +169,7 @@ jobs:
           rm -rf TWiLightMenu
           cp -r 7zfile/ TWiLightMenu/
           cd TWiLightMenu
-          mv Flashcard\ users/* .
+          cp -r Flashcard\ users/* .
           rm -rf Flashcard\ users
           7z a TWiLightMenu-Flashcard.7z
           mv TWiLightMenu-Flashcard.7z ~/artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,8 +57,9 @@ jobs:
       - name: "Pack 7z Package for nightly"
         if: ${{ !startsWith(github.ref, 'refs/tags') }}
         run: |
-          cp 7zfile/ TWiLightMenu/
+          cp -r 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/
+          mv TWiLightMenu.7z ~/artifacts
 
           # DSi 7z
           mv TWiLightMenu/DSi\ -\ CFW users/SDNAND\ root/* TWiLightMenu
@@ -66,48 +67,50 @@ jobs:
           cp -r TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users/* TWiLightMenu
           rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
           7z a TWiLightMenu-DSi.7z
+          mv TWiLightMenu-DSi.7z ~/artifacts
 
           # 3DS 7z
           rm -rf TWiLightMenu
-          cp 7zfile/ TWiLightMenu/
+          cp -r 7zfile/ TWiLightMenu/
           mv TWiLightMenu/3DS - CFW users/* TWiLightMenu
           rm -rf TWiLightMenu/3DS - CFW users
           cp -r TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users/* TWiLightMenu
           rm -rf TWiLightMenu/DSi\&3DS\ -\ SD\ card\ users
           7z a TWiLightMenu-3DS.7z
+          mv TWiLightMenu-3DS.7z ~/artifacts
 
           # Flashcard 7z
           rm -rf TWiLightMenu
-          cp 7zfile/ TWiLightMenu/
+          cp -r 7zfile/ TWiLightMenu/
           mv TWiLightMenu/Flashcard users/* TWiLightMenu
           rm -rf TWiLightMenu/Flashcard users
           7z a TWiLightMenu-Flashcard.7z
+          mv TWiLightMenu-Flashcard.7z ~/artifacts
 
           # Delete themes, AP patches, and widescreen patches for lite
           rm -rf TWiLightMenu
-          cp 7zfile/ TWiLightMenu/
+          cp -r 7zfile/ TWiLightMenu/
           rm -r TWiLightMenu/_nds/TWiLightMenu/*menu/
           rm -r TWiLightMenu/_nds/TWiLightMenu/apfix/
           rm -r TWiLightMenu/3DS\ -\ CFW\ users/_nds/TWiLightMenu/widescreen/
           7z a TWiLightMenu-Lite.7z TWiLightMenu/
           mkdir -p ~/artifacts
-          cp TWiLightMenu.7z ~/artifacts
-          cp TWiLightMenu-Lite.7z ~/artifacts
+          mv TWiLightMenu-Lite.7z ~/artifacts
       - name: "Pack 7z Package for release"
         if: ${{ startsWith(github.ref, 'refs/tags') }}
         run: |
-          mkdir 7zfile/_nds/TWiLightMenu/boxart/
-          mkdir 7zfile/_nds/TWiLightMenu/extras/
-          mkdir 7zfile/_nds/TWiLightMenu/gamesettings/
+          mkdir -p 7zfile/_nds/TWiLightMenu/boxart/
+          mkdir -p 7zfile/_nds/TWiLightMenu/extras/
+          mkdir -p 7zfile/_nds/TWiLightMenu/gamesettings/
 
           # nds-bootstrap
-          mkdir nds-bootstrap
+          mkdir -p nds-bootstrap
           cd nds-bootstrap
           curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/repos/ahezard/nds-bootstrap/releases/latest -o nds-bootstrap.json
           curl -L $(jq --raw-output '.assets[0].browser_download_url' nds-bootstrap.json) -o nds-bootstrap.7z
           7z x nds-bootstrap.7z
           mv nds-bootstrap.* ..
-          mkdir TWiLightMenu
+          mkdir -p TWiLightMenu
           mv release-bootstrap.ver TWiLightMenu
           cd ..
           curl -L https://github.com/TWLBot/Builds/blob/master/nds-bootstrap.7z?raw=true -o nds-bootstrap.7z
@@ -118,8 +121,6 @@ jobs:
           mv nds-bootstrap/b4ds-nightly.nds 7zfile/Flashcard\ users/_nds/
           mv nds-bootstrap/nds-bootstrap-release.nds 7zfile/_nds/
           mv nds-bootstrap/nds-bootstrap-nightly.nds 7zfile/_nds/
-          # Permissions are hecked up by Docker
-          sudo mkdir 7zfile/DSi\&3DS\ -\ SD\ card\ users/_nds
           mv nds-bootstrap/nds-bootstrap-hb-release.nds 7zfile/DSi\&3DS\ -\ SD\ card\ users/_nds/
           mv nds-bootstrap/nds-bootstrap-hb-nightly.nds 7zfile/DSi\&3DS\ -\ SD\ card\ users/_nds/
 
@@ -130,7 +131,7 @@ jobs:
           touch 7zfile/.ignoreme
 
           # Main 7z
-          cp 7zfile TWiLightMenu
+          cp -r 7zfile TWiLightMenu
           cd TWiLightMenu
           7z a TWiLightMenu.7z .
           mkdir -p ~/artifacts
@@ -147,7 +148,7 @@ jobs:
           # 3DS 7z
           cd ..
           rm -rf TWiLightMenu
-          cp 7zfile/ TWiLightMenu/
+          cp -r 7zfile/ TWiLightMenu/
           cd TWiLightMenu
           mv 3DS - CFW users/SDNAND\ root/* .
           rm -rf 3DS - CFW users
@@ -159,7 +160,7 @@ jobs:
           # Flashcard 7z
           cd ..
           rm -rf TWiLightMenu
-          cp 7zfile/ TWiLightMenu/
+          cp -r 7zfile/ TWiLightMenu/
           cd TWiLightMenu
           mv Flashcard users/* .
           rm -rf Flashcard users

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,8 @@ jobs:
           rm -rf DSi\ -\ CFW\ users
           cp -r DSi\&3DS\ -\ SD\ card\ users/* .
           rm -rf DSi\&3DS\ -\ SD\ card\ users
+          rm -rf 3DS\ -\ CFW\ users
+          rm -rf Flashcard\ users
           7z a TWiLightMenu-DSi.7z
           mv TWiLightMenu-DSi.7z ~/artifacts
 
@@ -161,6 +163,8 @@ jobs:
           rm -rf 3DS\ -\ CFW\ users
           cp -r DSi\&3DS\ -\ SD\ card\ users/* .
           rm -rf DSi\&3DS\ -\ SD\ card\ users
+          rm -rf DSi\ -\ CFW\ users
+          rm -rf Flashcard\ users
           7z a TWiLightMenu-3DS.7z
           mv TWiLightMenu-3DS.7z ~/artifacts
 
@@ -171,6 +175,9 @@ jobs:
           cd TWiLightMenu
           cp -r Flashcard\ users/* .
           rm -rf Flashcard\ users
+          rm -rf 3DS\ -\ CFW\ users
+          rm -rf DSi\&3DS\ -\ SD\ card\ users
+          rm -rf DSi\ -\ CFW\ users
           7z a TWiLightMenu-Flashcard.7z
           mv TWiLightMenu-Flashcard.7z ~/artifacts
       - name: "Publish build to GH Actions"


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This adds generating separate 7z's for DSi, 3DS, and Flashcards to hopefully reduce confusion when installing
  - The old `TWiLightMenu.7z` (and `TWiLightMenu-Lite.7z` for nightlies) will still be generated exactly as it was so automatic tools won't break
- Also fixes `master` not being pushed resulting in all the TWLBot commits having a tag but not being assigned to any branch
- I think this should fix #918 
- Let me know if y'all have any suggestions for the 7z names, layout, etc.

#### Where have you tested it?

- On my fork, see an example release at Epicpkmn11/TWiLightMenu [vTEST.37](https://github.com/Epicpkmn11/TWiLightMenu/releases/tag/vTEST.37) and a nightly at TWLBot/Builds [v20200726-002526](https://github.com/TWLBot/Builds/releases/tag/v20200726-002526)

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
