### PR TITLE
Fix using YSMenu to boot games on DSTT

### DIFF
--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -697,15 +697,16 @@ void loadGameOnFlashcard (const char* ndsPath, bool usePerGameSettings) {
 		fcrompathini.SetString("Dir Info", "fullName", path);
 		fcrompathini.SaveIniFile("fat:/_dstwo/autoboot.ini");
 		err = runNdsFile("fat:/_dstwo/autoboot.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram);
-	} /*else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
+	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0) {
+			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		path = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", path);
 		fcrompathini.SaveIniFile("fat:/TTMenu/YSMenu.ini");
+		*(VoidFn *)(0x2FFFD9C) = nullptr; // Set exception handler to nullptr
 		err = runNdsFile("fat:/YSMenu.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram);
-	}*/
+	}
 
 	char text[32];
 	snprintf(text, sizeof(text), "Start failed. Error %i", err);

--- a/romsel_aktheme/arm9/source/common/flashcardlaunch.cpp
+++ b/romsel_aktheme/arm9/source/common/flashcardlaunch.cpp
@@ -45,14 +45,15 @@ int loadGameOnFlashcard (std::string ndsPath, bool usePerGameSettings) {
 		launchPath = replaceAll(ndsPath.c_str(), FC_PREFIX_FAT, FC_PREFIX_FAT1);
 		config.option("Dir Info", "fullName", launchPath);
 		return config.launch(0, NULL, true, true, runNds_boostCpu, runNds_boostVram);
-	} /*else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
+	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
 		LoaderConfig config("fat:/YSMenu.nds", "fat:/TTMenu/YSMenu.ini");
 		launchPath = replaceAll(ndsPath.c_str(), FC_PREFIX_FAT, FC_PREFIX_SLASH);
 		config.option("YSMENU", "AUTO_BOOT", launchPath);
+		*(VoidFn *)(0x2FFFD9C) = nullptr; // Set exception handler to nullptr
 		return config.launch(0, NULL, true, true, runNds_boostCpu, runNds_boostVram);
-	}*/
+	}
 
 	return 100;
 }

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -417,15 +417,16 @@ void loadGameOnFlashcard (const char *ndsPath, bool usePerGameSettings) {
 		fcrompathini.SetString("Dir Info", "fullName", path);
 		fcrompathini.SaveIniFile("fat:/_dstwo/autoboot.ini");
 		err = runNdsFile("fat:/_dstwo/autoboot.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram);
-	} /*else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
+	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0) {
+			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		path = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", path);
 		fcrompathini.SaveIniFile("fat:/TTMenu/YSMenu.ini");
+		*(VoidFn *)(0x2FFFD9C) = nullptr; // Set exception handler to nullptr
 		err = runNdsFile("fat:/YSMenu.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram);
-	}*/
+	}
 
 	char text[64];
 	snprintf(text, sizeof(text), STR_START_FAILED_ERROR.c_str(), err);

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -730,15 +730,16 @@ void loadGameOnFlashcard (const char* ndsPath, bool usePerGameSettings) {
 		fcrompathini.SetString("Dir Info", "fullName", path);
 		fcrompathini.SaveIniFile("fat:/_dstwo/autoboot.ini");
 		err = runNdsFile("fat:/_dstwo/autoboot.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram);
-	} /*else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
+	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		path = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", path);
 		fcrompathini.SaveIniFile("fat:/TTMenu/YSMenu.ini");
+		*(VoidFn *)(0x2FFFD9C) = nullptr; // Set exception handler to nullptr
 		err = runNdsFile("fat:/YSMenu.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram);
-	}*/
+	}
 
 	char text[32];
 	snprintf (text, sizeof(text), "Start failed. Error %i", err);

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -28,6 +28,7 @@
 #include "bootsplash.h"
 #include "twlmenuppvideo.h"
 #include "consolemodelselect.h"
+#include "tool/stringtool.h"
 
 #include "sr_data_srllastran.h"			 // For rebooting into the game
 #include "common/systemdetails.h"
@@ -493,15 +494,16 @@ void lastRunROM()
 				fcrompathini.SetString("Dir Info", "fullName", path);
 				fcrompathini.SaveIniFile("fat:/_dstwo/autoboot.ini");
 				err = runNdsFile("fat:/_dstwo/autoboot.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram);
-			} /*else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
+			} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 					 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
-					 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0) {
+					 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
 				CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 				path = replaceAll(ms().romPath[ms().secondaryDevice], "fat:/", slashchar);
 				fcrompathini.SetString("YSMENU", "AUTO_BOOT", path);
 				fcrompathini.SaveIniFile("fat:/TTMenu/YSMenu.ini");
+				*(VoidFn *)(0x2FFFD9C) = nullptr; // Set exception handler to nullptr
 				err = runNdsFile("fat:/YSMenu.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram);
-			}*/
+			}
 		}
 	}
 	else if (ms().launchType[ms().secondaryDevice] == Launch::ESDFlashcardDirectLaunch)


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- I was experimenting a bit and realized it was setting the exception handler that broke YSMenu booting games, so this sets that to nullptr before launching YSMenu to fix using it instead of B4DS.
- **NOTE:** This does not add renaming the save file, if you want to be able to use the same save file between B4DS and YSMenu it'll need to be moved to the same folder as the rom for YSMenu, then to the saves folder for B4DS

#### Where have you tested it?

- DS (J) with DSTT, directly booting the latest TWiLight, then launching the game with RGF's latest YSMenu

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
