### PR TITLE
Directory typo fix

### DIFF
--- a/booter/Makefile
+++ b/booter/Makefile
@@ -125,7 +125,7 @@ all:	bootloader bootstub $(TARGET).nds
 dist:	all
 	@mkdir -p "../7zfile/DSi&3DS - SD card users"
 	@cp "$(TARGET).nds" "../7zfile/DSi&3DS - SD card users/BOOT.NDS"
-	@mkdir -p "../DSi - CFW users/SDNAND root/title/00030004/53524c41/content"
+	@mkdir -p "../7zfile/DSi - CFW users/SDNAND root/title/00030004/53524c41/content"
 	@cp "$(TARGET).nds" "../7zfile/DSi - CFW users/SDNAND root/title/00030004/53524c41/content/00000000.app"
 	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
 	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Quick directory fix in the /booter Makefile. Original line would point to just the upper-level directory instead of /7zfile.

#### Where have you tested it?

N/A (not necessary for such a change)

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.
