### PR TITLE
Cleanup make dist / package & move debug files from 7z's

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -150,6 +150,9 @@ jobs:
           echo "::set-output name=twlbot_commit::$(git log --format=%H -1)"
       - name: Release to TWLBot/Builds
         run: |
+          # Delete debug 7z
+          rm ${{ github.workspace }}/build/TWiLightMenu-debug-release.7z
+
           AUTH_HEADER="Authorization: token ${{ secrets.TWLBOT_TOKEN }}"
           CONTENT_TYPE="Content-Type: application/json"
           API_URL="https://api.github.com/repos/TWLBot/Builds/releases"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,9 +49,19 @@ jobs:
           echo "::set-output name=commit_message::$(git log --pretty=format:'%an - %s' -1)"
       - name: "Pack 7z Package for nightly"
         run: |
+          # Make artifacts directory
+          mkdir -p ~/artifacts
+
+          # Theme is currently unused
+          rm -rf 7zfile/_nds/TWiLightMenu/akmenu
+
+          # Debug 7z
+          mv 7zfile/debug debug
+          7z a TWiLightMenu-debug.7z debug
+          mv TWiLightMenu-debug.7z ~/artifacts
+
           cp -r 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/
-          mkdir -p ~/artifacts
           mv TWiLightMenu.7z ~/artifacts
 
           # DSi 7z

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,8 +165,7 @@ jobs:
           cp ${{ github.workspace }}/build/TWiLightMenu-debug-release.7z .
           git stage .
           git commit -m "TWiLightMenu (Release) | $COMMIT_TAG"
-          git tag v$CURRENT_DATE
-          git push origin v$CURRENT_DATE master
+          git push origin master
           echo "::set-output name=twlbot_commit::$(git log --format=%H -1)"
       - name: Upload to ${{ github.repository }} release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,7 +162,7 @@ jobs:
           git config --global user.name "TWLBot"
           git clone --depth 1 https://${{ secrets.TWLBOT_TOKEN }}@github.com/TWLBot/Builds.git
           cd Builds/
-          cp ~/build/TWiLightMenu-debug-release.7z .
+          cp ${{ github.workspace }}/build/TWiLightMenu-debug-release.7z .
           git stage .
           git commit -m "TWiLightMenu (Release) | $COMMIT_TAG"
           git tag v$CURRENT_DATE
@@ -171,7 +171,7 @@ jobs:
       - name: Upload to ${{ github.repository }} release
         run: |
           # Delete debug 7z
-          rm ~/build/TWiLightMenu-debug-release.7z
+          rm ${{ github.workspace }}/build/TWiLightMenu-debug-release.7z
 
           ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,17 @@ jobs:
           echo "::set-output name=commit_message::$(git log --pretty=format:'%an - %s' -1)"
       - name: "Pack 7z Package for release"
         run: |
+          # Make artifacts directory
+          mkdir -p ~/artifacts
+
+          # Theme is currently unused
+          rm -rf 7zfile/_nds/TWiLightMenu/akmenu
+
+          # Debug 7z
+          mv 7zfile/debug debug
+          7z a TWiLightMenu-debug-release.7z debug
+          mv TWiLightMenu-debug-release.7z ~/artifacts
+
           mkdir -p 7zfile/_nds/TWiLightMenu/boxart/
           mkdir -p 7zfile/_nds/TWiLightMenu/extras/
           mkdir -p 7zfile/_nds/TWiLightMenu/gamesettings/
@@ -77,7 +88,6 @@ jobs:
           cp -r 7zfile TWiLightMenu
           cd TWiLightMenu
           7z a TWiLightMenu.7z .
-          mkdir -p ~/artifacts
           mv TWiLightMenu.7z ~/artifacts
 
           # DSi 7z
@@ -142,8 +152,27 @@ jobs:
         with:
           name: "build"
           path: "build"
+      - name: "Commit and push debug files to TWLBot/Builds"
+        id: "commit"
+        run: |
+          CURRENT_DATE=$(date +"%Y%m%d-%H%M%S")
+          echo "::set-output name=current_date::$CURRENT_DATE"
+
+          git config --global user.email "flamekat54@aol.com"
+          git config --global user.name "TWLBot"
+          git clone --depth 1 https://${{ secrets.TWLBOT_TOKEN }}@github.com/TWLBot/Builds.git
+          cd Builds/
+          cp ~/build/TWiLightMenu-debug-release.7z .
+          git stage .
+          git commit -m "TWiLightMenu (Release) | $COMMIT_TAG"
+          git tag v$CURRENT_DATE
+          git push origin v$CURRENT_DATE master
+          echo "::set-output name=twlbot_commit::$(git log --format=%H -1)"
       - name: Upload to ${{ github.repository }} release
         run: |
+          # Delete debug 7z
+          rm ~/build/TWiLightMenu-debug-release.7z
+
           ID=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)
 
           for file in ${{ github.workspace }}/build/*; do

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,8 @@ PACKAGE		:=	7zfile
 all:	booter booter_fc quickmenu manual romsel_dsimenutheme romsel_r4theme rungame settings slot1launch title
 
 package:
-	@mkdir 7zfile/Debug/
 	@$(MAKE) -C booter dist
-	@$(MAKE) -C booter_fc autoboot_dist
+	@$(MAKE) -C booter_fc dist
 	@$(MAKE) -C quickmenu dist
 	@$(MAKE) -C manual dist
 	#@$(MAKE) -C romsel_aktheme dist
@@ -26,8 +25,6 @@ package:
 
 	@rm -rf 7zfile/*/.gitkeep
 	@rm -rf 7zfile/*/*/.gitkeep
-	# Theme is currently unused
-	@rm -rf 7zfile/_nds/TWiLightMenu/akmenu
 
 booter:
 	@$(MAKE) -C booter

--- a/booter/Makefile
+++ b/booter/Makefile
@@ -123,12 +123,13 @@ export GAME_TITLE := $(TARGET)
 all:	bootloader bootstub $(TARGET).nds
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@mkdir -p "../7zfile/DSi&3DS - SD card users"
 	@cp "$(TARGET).nds" "../7zfile/DSi&3DS - SD card users/BOOT.NDS"
 	@mkdir -p "../7zfile/DSi - CFW users/SDNAND root/title/00030004/53524c41/content"
-	@cp "$(TARGET).nds" "../7zfile/DSi - CFW users/SDNAND root/title/00030004/53524c41/content/00000000.app"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds "../7zfile/DSi - CFW users/SDNAND root/title/00030004/53524c41/content/00000000.app"
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \

--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -29,135 +29,131 @@ makearm9_cyclodsi:
 	$(MAKE) -C flashcart_specifics/CycloDSi/arm9
 	cp flashcart_specifics/CycloDSi/arm9/$(TARGET).elf $(TARGET)_cyclodsi.arm9.elf
 
-dist:	all
-	@cp "$(TARGET)_fc.nds" "../7zfile/Flashcard users/BOOT.NDS"
-	@cp "$(TARGET)_cyclodsi.nds" "../7zfile/Flashcard users/BOOT_cyclodsi.NDS"
-	@cp "$(TARGET)_fc.arm7.elf" "../7zfile/Debug/$(TARGET)_fc.arm7.elf"
-	@cp "$(TARGET)_fc.arm9.elf" "../7zfile/Debug/$(TARGET)_fc.arm9.elf"
-	@cp "$(TARGET)_cyclodsi.arm7.elf" "../7zfile/Debug/$(TARGET)_cyclodsi.arm7.elf"
-	@cp "$(TARGET)_cyclodsi.arm9.elf" "../7zfile/Debug/$(TARGET)_cyclodsi.arm9.elf"
-
-autoboot_dist:	dist autoboot
+dist:	all autoboot
+	mkdir -p ../7zfile/debug
+	@cp $(TARGET)_fc.nds "../7zfile/Flashcard users/BOOT.NDS"
+	@cp $(TARGET)_cyclodsi.nds "../7zfile/Flashcard users/BOOT_cyclodsi.NDS"
+	@cp $(TARGET)_fc.arm7.elf ../7zfile/debug/$(TARGET)_fc.arm7.elf
+	@cp $(TARGET)_fc.arm9.elf ../7zfile/debug/$(TARGET)_fc.arm9.elf
+	@cp $(TARGET)_cyclodsi.arm7.elf ../7zfile/debug/$(TARGET)_cyclodsi.arm7.elf
+	@cp $(TARGET)_cyclodsi.arm9.elf ../7zfile/debug/$(TARGET)_cyclodsi.arm9.elf
 
 .ONESHELL:
 autoboot:
-	cp "$(TARGET)_fc.nds" "./flashcart_specifics/booter_fc.nds"
-	cd flashcart_specifics/
-
 	#### R4 Original & M3 Simply
-	cp "booter_fc.nds" "_DS_MENU.nds"
-	dlditool ./DLDI/r4_sd.dldi _DS_MENU.nds
+	cp booter_fc.nds _DS_MENU.nds
+	dlditool flashcart_specifics/DLDI/r4_sd.dldi _DS_MENU.nds
 	r4denc _DS_MENU.nds
-	mkdir "../../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/"
-	mv "_DS_MENU.dat" "../../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/_DS_MENU.DAT"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/"
+	mv "_DS_MENU.dat" "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/_DS_MENU.DAT"
 
 	#### R4i Gold 3DS Plus/R4i Gold 3DS Deluxe/R4i Gold 3DS RTS & R4iDSN/R4 Ultra
 	##### Global
-	cp "booter_fc.nds" "_DS_MENU.nds"
-	dlditool ./DLDI/r4idsn_sd.dldi _DS_MENU.nds
+	cp booter_fc.nds _DS_MENU.nds
+	dlditool flashcart_specifics/DLDI/r4idsn_sd.dldi _DS_MENU.nds
 
 	##### R4iDSN & R4 Ultra specific
-	cp "_DS_MENU.nds" "../../7zfile/Flashcard users/Autoboot/R4iDSN & R4 Ultra/_MENU_.NDS"
-	mv "_DS_MENU.nds" "../../7zfile/Flashcard users/Autoboot/R4iDSN & R4 Ultra/_MENU_B.NDS"
+	cp _DS_MENU.nds "../7zfile/Flashcard users/Autoboot/R4iDSN & R4 Ultra/_MENU_.NDS"
+	mv _DS_MENU.nds "../7zfile/Flashcard users/Autoboot/R4iDSN & R4 Ultra/_MENU_B.NDS"
 
 	##### R4i Gold 3DS Plus/R4i Gold 3DS Deluxe/R4i Gold 3DS RTS specific
-	#r4denc _DS_MENU.nds
-	#mkdir "../../7zfile/Flashcard users/Autoboot/R4i Gold 3DS Plus, R4i Gold 3DS Deluxe & R4i Gold 3DS RTS/"
-	#mv "_DS_MENU.dat" "../../7zfile/Flashcard users/Autoboot/R4i Gold 3DS Plus, R4i Gold 3DS Deluxe & R4i Gold 3DS RTS/_DS_MENU.DAT"
+	# r4denc _DS_MENU.nds
+	# mkdir "../7zfile/Flashcard users/Autoboot/R4i Gold 3DS Plus, R4i Gold 3DS Deluxe & R4i Gold 3DS RTS/"
+	# mv _DS_MENU.dat "../7zfile/Flashcard users/Autoboot/R4i Gold 3DS Plus, R4i Gold 3DS Deluxe & R4i Gold 3DS RTS/_DS_MENU.DAT"
 
 	#### EZ-Flash 5
-	cp "booter_fc.nds" "ez5sys.bin"
-	dlditool ./DLDI/EZ5V2.dldi ez5sys.bin
-	mkdir "../../7zfile/Flashcard users/Autoboot/EZ Flash V/"
-	mv "ez5sys.bin" "../../7zfile/Flashcard users/Autoboot/EZ Flash V/ez5sys.bin"
+	cp booter_fc.nds ez5sys.bin
+	dlditool flashcart_specifics/DLDI/EZ5V2.dldi ez5sys.bin
+	mkdir -p "../7zfile/Flashcard users/Autoboot/EZ Flash V/"
+	mv ez5sys.bin "../7zfile/Flashcard users/Autoboot/EZ Flash V/ez5sys.bin"
 
 	#### GBAMP + PassMe, FlashMe or WifiMe
-	cp "booter_fc.nds" "_BOOT_MP.NDS"
-	dlditool ./DLDI/mpcf.dldi _BOOT_MP.NDS
-	mkdir "../../7zfile/Flashcard users/Autoboot/GBAMP + PassMe, FlashMe or WifiMe/"
-	mv "_BOOT_MP.NDS" "../../7zfile/Flashcard users/Autoboot/GBAMP + PassMe, FlashMe or WifiMe/_BOOT_MP.NDS"
+	cp booter_fc.nds _BOOT_MP.NDS
+	dlditool flashcart_specifics/DLDI/mpcf.dldi _BOOT_MP.NDS
+	mkdir -p "../7zfile/Flashcard users/Autoboot/GBAMP + PassMe, FlashMe or WifiMe/"
+	mv _BOOT_MP.NDS "../7zfile/Flashcard users/Autoboot/GBAMP + PassMe, FlashMe or WifiMe/_BOOT_MP.NDS"
 
 	#### iSmart Premium
 	##### research done entirely by devkitPro
-	cp "booter_fc.nds" "ismat.dat"
-	dlditool ./DLDI/Mat.dldi ismat.dat
-	mkdir -p "../../7zfile/Flashcard users/Autoboot/iSmart Premium/system/"
-	mv "ismat.dat" "../../7zfile/Flashcard users/Autoboot/iSmart Premium/system/ismat.dat"
+	cp booter_fc.nds ismat.dat
+	dlditool flashcart_specifics/DLDI/Mat.dldi ismat.dat
+	mkdir -p "../7zfile/Flashcard users/Autoboot/iSmart Premium/system/"
+	mv ismat.dat "../7zfile/Flashcard users/Autoboot/iSmart Premium/system/ismat.dat"
 
 	#### Acekard 2i/Acekard 2.1 & Galaxy Eagle
-	cp "booter_fc.nds" "akmenu4.nds"
-	dlditool ./DLDI/ak2_sd.dldi akmenu4.nds
-	cp "akmenu4.nds" "../../7zfile/Flashcard users/Autoboot/Galaxy Eagle/_MENU_.NDS"
-	cp "akmenu4.nds" "../../7zfile/Flashcard users/Autoboot/Galaxy Eagle/_MENU_B.NDS"
-	mkdir "../../7zfile/Flashcard users/Autoboot/Acekard 2i & Acekard 2.1/"
-	mv "akmenu4.nds" "../../7zfile/Flashcard users/Autoboot/Acekard 2i & Acekard 2.1/akmenu4.nds"
+	cp booter_fc.nds akmenu4.nds
+	dlditool flashcart_specifics/DLDI/ak2_sd.dldi akmenu4.nds
+	cp akmenu4.nds "../7zfile/Flashcard users/Autoboot/Galaxy Eagle/_MENU_.NDS"
+	cp akmenu4.nds "../7zfile/Flashcard users/Autoboot/Galaxy Eagle/_MENU_B.NDS"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/Acekard 2i & Acekard 2.1/"
+	mv akmenu4.nds "../7zfile/Flashcard users/Autoboot/Acekard 2i & Acekard 2.1/akmenu4.nds"
 
 	#### DSTT
-	cp "booter_fc.nds" "TTMenu.dat"
-	dlditool "./DLDI/DSTTDLDIboyakkeyver.dldi" TTMenu.dat
+	cp booter_fc.nds TTMenu.dat
+	dlditool flashcart_specifics/DLDI/DSTTDLDIboyakkeyver.dldi TTMenu.dat
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/DSTT, DSTTi, DSTTi Gold, DSTT-Advance, R4Top Revolution, & R4i-SDHC v1.41 + v1.42/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/DSTT, DSTTi, DSTTi Gold, DSTT-Advance, R4Top Revolution, & R4i-SDHC v1.41 + v1.42/TTMenu.dat"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/DSTT, DSTTi, DSTTi Gold, DSTT-Advance, R4Top Revolution, & R4i-SDHC v1.41 + v1.42/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/DSTT, DSTTi, DSTTi Gold, DSTT-Advance, R4Top Revolution, & R4i-SDHC v1.41 + v1.42/TTMenu.dat"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/Ace3DS/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/Ace3DS/3DSCARD.DAT"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/Ace3DS/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/Ace3DS/3DSCARD.DAT"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/Blue R4i Revolution v1.4.1, R4i Gold Upgrade Revolution v1.4.1, GoldR4 3DS (v4.301 kernel) & R4i SDHC Upgrade Revolution (www.r4i-sdhc.com.tw)/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/Blue R4i Revolution v1.4.1, R4i Gold Upgrade Revolution v1.4.1, GoldR4 3DS (v4.301 kernel) & R4i SDHC Upgrade Revolution (www.r4i-sdhc.com.tw)/iLL.iL"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/Blue R4i Revolution v1.4.1, R4i Gold Upgrade Revolution v1.4.1, GoldR4 3DS (v4.301 kernel) & R4i SDHC Upgrade Revolution (www.r4i-sdhc.com.tw)/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/Blue R4i Revolution v1.4.1, R4i Gold Upgrade Revolution v1.4.1, GoldR4 3DS (v4.301 kernel) & R4i SDHC Upgrade Revolution (www.r4i-sdhc.com.tw)/iLL.iL"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/R4i Gold Upgrade Revolution (v1.14b kernel)/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4i Gold Upgrade Revolution (v1.14b kernel)/R4i.dat"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4i Gold Upgrade Revolution (v1.14b kernel)/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i Gold Upgrade Revolution (v1.14b kernel)/R4i.dat"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/R4IIISDHC (v3.07 kernel) & R4i SDHC Silver RTS Lite/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4IIISDHC (v3.07 kernel) & R4i SDHC Silver RTS Lite/R4.dat"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4IIISDHC (v3.07 kernel) & R4i SDHC Silver RTS Lite/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4IIISDHC (v3.07 kernel) & R4i SDHC Silver RTS Lite/R4.dat"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/R4i Upgrade Revolution/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4i Upgrade Revolution/R4i.3ds"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4i Upgrade Revolution/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i Upgrade Revolution/R4i.3ds"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/R4i SDHC Upgrade Revolution (www.r4i-dshc.com), R4i 3DS (v4.3 kernel) & R4i YES/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4i SDHC Upgrade Revolution (www.r4i-dshc.com), R4i 3DS (v4.3 kernel) & R4i YES/R4i.TP"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4i SDHC Upgrade Revolution (www.r4i-dshc.com), R4i 3DS (v4.3 kernel) & R4i YES/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i SDHC Upgrade Revolution (www.r4i-dshc.com), R4i 3DS (v4.3 kernel) & R4i YES/R4i.TP"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/R4i King LL/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4i King LL/R4KING"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4i King LL/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i King LL/R4KING"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/R4i.TP"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/iLL.iL"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/R4i.TP"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/iLL.iL"
 
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/_BOOT_DS.NDS"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/_BOOT_DS.NDS"
 
-	mkdir "../../7zfile/Flashcard users/Autoboot/R4 Deluxe v1.20/"
-	cp TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4 Deluxe v1.20/_DS_MENU.DAT"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4 Deluxe v1.20/"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4 Deluxe v1.20/_DS_MENU.DAT"
 
 	# Since this is the last one, move it instead of copy
-	mkdir "../../7zfile/Flashcard users/Autoboot/R4i-REDANT/"
-	mv TTMenu.dat "../../7zfile/Flashcard users/Autoboot/R4i-REDANT/Redant.dat"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4i-REDANT/"
+	mv TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i-REDANT/Redant.dat"
 
 	#### Games N Music
-	mkdir "../../7zfile/Flashcard users/Autoboot/Games N Music/"
+	mkdir -p "../7zfile/Flashcard users/Autoboot/Games N Music/"
 
 	##### SDHC but Faster
-	cp "booter_fc.nds" "bootme.nds"
-	dlditool ./DLDI/gmtf2.dldi bootme.nds
-	mkdir "../../7zfile/Flashcard users/Autoboot/Games N Music/SDHC/"
-	mv "bootme.nds" "../../7zfile/Flashcard users/Autoboot/Games N Music/SDHC/bootme.nds"
+	cp booter_fc.nds bootme.nds
+	dlditool flashcart_specifics/DLDI/gmtf2.dldi bootme.nds
+	mkdir -p "../7zfile/Flashcard users/Autoboot/Games N Music/SDHC/"
+	mv bootme.nds "../7zfile/Flashcard users/Autoboot/Games N Music/SDHC/bootme.nds"
 
 	##### Not-SDHC restricted but slower
-	cp "booter_fc.nds" "bootme.nds"
-	dlditool ./DLDI/gmtf.dldi bootme.nds
-	mkdir "../../7zfile/Flashcard users/Autoboot/Games N Music/Non-SDHC/"
-	mv "bootme.nds" "../../7zfile/Flashcard users/Autoboot/Games N Music/Non-SDHC/bootme.nds"
+	cp booter_fc.nds bootme.nds
+	dlditool flashcart_specifics/DLDI/gmtf.dldi bootme.nds
+	mkdir -p "../7zfile/Flashcard users/Autoboot/Games N Music/Non-SDHC/"
+	mv bootme.nds "../7zfile/Flashcard users/Autoboot/Games N Music/Non-SDHC/bootme.nds"
 
 	#### SuperCard DSTWO
-	cp "booter_fc.nds" "dstwo.nds"
-	dlditool ./DLDI/dstwo.dldi dstwo.nds
-	mkdir -p "../../7zfile/Flashcard users/Autoboot/SuperCard DSTWO/_dstwo/"
-	mv "dstwo.nds" "../../7zfile/Flashcard users/Autoboot/SuperCard DSTWO/_dstwo/dstwo.nds"
+	cp booter_fc.nds dstwo.nds
+	dlditool flashcart_specifics/DLDI/dstwo.dldi dstwo.nds
+	mkdir -p "../7zfile/Flashcard users/Autoboot/SuperCard DSTWO/_dstwo/"
+	mv dstwo.nds "../7zfile/Flashcard users/Autoboot/SuperCard DSTWO/_dstwo/dstwo.nds"
 
 	#### SuperCard DSONE
-	cp "../booter_fc.nds" "TTMenu.DAT"
-	dlditool ./DLDI/DSONESlot-1.dldi TTMenu.DAT
-	mv TTMenu.DAT "../../7zfile/Flashcard users/Autoboot/SuperCard DSONE & SuperCard DSONEi/TTMenu.DAT"
+	cp booter_fc.nds TTMenu.DAT
+	dlditool flashcart_specifics/DLDI/DSONESlot-1.dldi TTMenu.DAT
+	mv TTMenu.DAT "../7zfile/Flashcard users/Autoboot/SuperCard DSONE & SuperCard DSONEi/TTMenu.DAT"
 
 $(TARGET).nds:	makearm7_fc makearm7_cyclodsi makearm9_fc makearm9_cyclodsi
 	# simple nds srl without dsi extended header
@@ -178,7 +174,7 @@ clean:
 	@$(MAKE) -C flashcart_specifics/CycloDSi/arm7 clean
 
 	@echo Cleaning Flashcart Autobooters
-	@rm -fr "../../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/"
+	@rm -fr "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/"
 
 data:
 	@mkdir -p data

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -23,9 +23,9 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/manual.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/manual.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g HBLA -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \

--- a/quickmenu/Makefile
+++ b/quickmenu/Makefile
@@ -23,9 +23,9 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/mainmenu.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/mainmenu.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g HBLA -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \

--- a/rebooter_fc/Makefile
+++ b/rebooter_fc/Makefile
@@ -22,9 +22,9 @@ makearm9_fc:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
-	@cp "$(TARGET).nds" "../../7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/TWLMRS.DAT"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds "../../7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/TWLMRS.DAT"
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 autoboot_dist:	dist autoboot
 

--- a/romsel_aktheme/Makefile
+++ b/romsel_aktheme/Makefile
@@ -23,9 +23,9 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/akmenu.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/akmenu.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g HBLA -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \

--- a/romsel_dsimenutheme/Makefile
+++ b/romsel_dsimenutheme/Makefile
@@ -23,9 +23,9 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/dsimenu.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/dsimenu.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g HBLA -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \

--- a/romsel_r4theme/Makefile
+++ b/romsel_r4theme/Makefile
@@ -23,9 +23,9 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/r4menu.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/r4menu.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g HBLA -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \

--- a/rungame/Makefile
+++ b/rungame/Makefile
@@ -123,10 +123,10 @@ export GAME_TITLE := $(TARGET)
 all:	bootloader bootstub $(TARGET).nds
 	
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/DSi - CFW users/SDNAND root/title/00030015/534c524e/content/00000000.app"
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/resetgame.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds "../7zfile/DSi - CFW users/SDNAND root/title/00030015/534c524e/content/00000000.app"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/resetgame.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-u 00030015 -g SLRN -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \

--- a/settings/Makefile
+++ b/settings/Makefile
@@ -23,9 +23,9 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/settings.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/settings.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g HBLA -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \

--- a/slot1launch/Makefile
+++ b/slot1launch/Makefile
@@ -29,9 +29,9 @@ export PATH		:=	$(DEVKITARM)/bin:$(PATH)
 all: cardengine_arm7 bootloader $(TARGET).nds
 
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/slot1launch.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/slot1launch.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \

--- a/title/Makefile
+++ b/title/Makefile
@@ -23,9 +23,9 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
-	@cp "$(TARGET).nds" "../7zfile/_nds/TWiLightMenu/main.srldr"
-	@cp "$(TARGET).arm7.elf" "../7zfile/Debug/$(TARGET).arm7.elf"
-	@cp "$(TARGET).arm9.elf" "../7zfile/Debug/$(TARGET).arm9.elf"
+	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/main.srldr
+	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
+	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g HBLA -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

This PR:
- Moves the debug files from the main 7z files to their own special 7z files that only go to TWLBot/Builds commits
  - Nighties to [`TWiLightMenu-debug.7z`](https://github.com/TWLBot/Builds/blob/master/TWiLightMenu-debug.7z), releases to [`TWiLightMenu-debug-release.7z`](https://github.com/TWLBot/Builds/blob/master/TWiLightMenu-debug-release.7z) (these are from the Actions runs linked below)
  - This makes the 7z's about 8MB smaller
- `make package` and some `make dist`s weren't working repeatedly / were changing non-ignored files, as that's the way I prefer to build TWiLight I've cleaned those up so that `make package` and all `make dist`s work nicely
  - Deletes Acekard files in the pipeline instead of the Makefile
  - Always does `mkdir -p`
  - Also just cleaned up the `""` a bit, I made them only used when needed where before they were sometimes used but sometimes not
  - Also made the autoboot files not `cd` to the directory as for some reason that was breaking it on macOS

#### Where have you tested it?

- macOS 10.14.6 (Mojave), [Release](https://github.com/Epicpkmn11/TWiLightMenu/actions/runs/213980086), [Nightly](https://github.com/Epicpkmn11/TWiLightMenu/actions/runs/213969059)

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
