### PR TITLE
Fix deselecting cheats *not* in single item folders...

### DIFF
--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -401,8 +401,8 @@ void CheatCodelist::selectCheats(std::string filename)
         bool select = !(cheat._flags & cParsedItem::ESelected);
         if(cheat._flags & cParsedItem::EOne)
           deselectFolder(std::distance(&_data[0], currentList[cheatWnd_cursorPosition]));
-        if(select)
-          cheat._flags |= cParsedItem::ESelected;
+        if(select || !(cheat._flags & cParsedItem::EOne))
+          cheat._flags ^= cParsedItem::ESelected;
       }
     } else if(pressed & KEY_B) {
       snd().playBack();

--- a/romsel_r4theme/arm9/source/cheat.cpp
+++ b/romsel_r4theme/arm9/source/cheat.cpp
@@ -392,8 +392,8 @@ void CheatCodelist::selectCheats(std::string filename)
         bool select = !(cheat._flags & cParsedItem::ESelected);
         if(cheat._flags & cParsedItem::EOne)
           deselectFolder(std::distance(&_data[0], currentList[cheatWnd_cursorPosition]));
-        if(select)
-          cheat._flags |= cParsedItem::ESelected;
+        if(select || !(cheat._flags & cParsedItem::EOne))
+          cheat._flags ^= cParsedItem::ESelected;
       }
     } else if(pressed & KEY_B) {
       if(mainListCurPos != -1) {


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- When I fixed the ones in single item folders I broke the rest... Now they all work

#### Where have you tested it?

- DSi (K) with the latest Unlaunch

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
