### PR TITLE
Lower pre-decompression limit to 512KiB in DS mode

### DIFF
--- a/title/arm9/source/graphics/gif.cpp
+++ b/title/arm9/source/graphics/gif.cpp
@@ -98,7 +98,7 @@ bool Gif::load(const char *path, bool top, bool animate) {
 		return false;
 
 	fseek(file, 0, SEEK_END);
-	_compressed = ftell(file) > 1000000; // Decompress files bigger than 1MB while drawing
+	_compressed = ftell(file) > (isDSiMode() ? 1 << 20 : 1 << 19); // Decompress files bigger than 1MiB (512KiB in DS Mode) while drawing
 	fseek(file, 0, SEEK_SET);
 
 	// Reserve space for 2,000 frames

--- a/title/arm9/source/graphics/gif.cpp
+++ b/title/arm9/source/graphics/gif.cpp
@@ -98,7 +98,7 @@ bool Gif::load(const char *path, bool top, bool animate) {
 		return false;
 
 	fseek(file, 0, SEEK_END);
-	_compressed = ftell(file) > (isDSiMode() ? 1 << 20 : 1 << 19); // Decompress files bigger than 1MiB (512KiB in DS Mode) while drawing
+	_compressed = ftell(file) > (isDSiMode() ? 1 << 20 : 1 << 18); // Decompress files bigger than 1MiB (256KiB in DS Mode) while drawing
 	fseek(file, 0, SEEK_SET);
 
 	// Reserve space for 2,000 frames


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This just changes the limit to pre-decompress GIFs to 256KiB in DS Mode instead of 1MiB, I did a bit of testing and GIFs were crashing well before hitting 1MiB when pre-decompressing so this lets larger GIFs work in DS Mode

#### Where have you tested it?

- DSi (K) with latest Unlaunch
- DSi (K) with DSTT direct booting TWiLight Menu++

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
