### PR TITLE
Various fixes: DSTWO, Flashcart themes

### DIFF
--- a/slot1launch/arm9/source/launch_engine.c
+++ b/slot1launch/arm9/source/launch_engine.c
@@ -60,6 +60,9 @@ void runLaunchEngine (bool altBootloader, bool isDSBrowser, bool EnableSD, int l
 {
 	nocashMessage("runLaunchEngine");
 
+	if (altBootloader)
+		TWLVRAM = false;
+
 	irqDisable(IRQ_ALL);
 
 	// Direct CPU access to VRAM bank D

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -819,7 +819,7 @@ int main(int argc, char **argv)
 	}
 	*(u32*)0x02000000 = 1;
 
-	if ((access(DSIMENUPP_INI, F_OK) != 0)
+	if ((access(settingsinipath, F_OK) != 0)
 	|| (ms().theme < 0) || (ms().theme == 3) || (ms().theme > 6)) {
 		// Create or modify "settings.ini"
 		(ms().theme == 3) ? ms().theme = 2 : ms().theme = 0;


### PR DESCRIPTION
Possibly fixes booting DS browser as well, and others that may require the quick altBootloader workaround in the future.
Closes #1215 

#### Where have you tested it?
[In my standalone fork](https://github.com/unresolvedsymbol/TWLM_NTR_Launcher)
DSi XL (DSiWare)
DSi XL (DSTWO Flashcart)

***
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
