### PR TITLE
Fix typo in settings

### DIFF
--- a/settings/arm9/source/language.inl
+++ b/settings/arm9/source/language.inl
@@ -238,7 +238,7 @@ STRING(SYSTEM_MENU, "System Menu")
 STRING(GRAY, "Gray")
 STRING(RED, "Red")
 STRING(BLUE, "Blue")
-STRING(MAGNETA, "Magneta")
+STRING(MAGENTA, "Magenta")
 
 STRING(DESCRIPTION_LANGUAGE_1, "Avoid the limited selections of your console language by setting this option.")
 STRING(DESCRIPTION_GAMELANGUAGE_1, "Set language for DS ROMs played using nds-bootstrap.")

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -1071,7 +1071,7 @@ int main(int argc, char **argv)
 	}
 	miscPage
 		.option(STR_DSISPLASH, STR_DESCRIPTION_DSISPLASH, Option::Int(&ms().dsiSplash), {STR_WITHOUT_HS, STR_WITH_HS, STR_CUSTOM_SPLASH, STR_HIDE}, {1, 2, 3, 0})
-		.option(STR_NINTENDOLOGOCOLOR, STR_DESCRIPTION_NINTENDOLOGOCOLOR, Option::Int(&ms().nintendoLogoColor), {STR_RED, STR_BLUE, STR_MAGNETA, STR_GRAY}, {1, 2, 3, 0})
+		.option(STR_NINTENDOLOGOCOLOR, STR_DESCRIPTION_NINTENDOLOGOCOLOR, Option::Int(&ms().nintendoLogoColor), {STR_RED, STR_BLUE, STR_MAGENTA, STR_GRAY}, {1, 2, 3, 0})
 		.option(STR_DSIMENUPPLOGO, STR_DESCRIPTION_DSIMENUPPLOGO_1, Option::Bool(&ms().showlogo), {STR_SHOW, STR_HIDE}, {true, false});
 
 	if (isDSiMode() && sdAccessible) {

--- a/settings/nitrofiles/languages/english.ini
+++ b/settings/nitrofiles/languages/english.ini
@@ -225,7 +225,7 @@ SYSTEM_MENU=System Menu
 GRAY=Gray
 RED=Red
 BLUE=Blue
-MAGNETA=Magneta
+MAGENTA=Magenta
 
 DESCRIPTION_LANGUAGE_1=Avoid the limited selections of your console language by setting this option.
 DESCRIPTION_GAMELANGUAGE_1=Set language for DS ROMs played using nds-bootstrap.


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- As noticed by @vargaviktor on Crowdin, it's `Magenta`, not `Magneta` ;P

#### Where have you tested it?

- N/A

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
