### PR TITLE
Show warning when launching on non 32KB clusters

### DIFF
--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
@@ -112,6 +112,8 @@ TWLSettings::TWLSettings()
 	autorun = false;
 
 	wideScreen = false;
+
+	dontShowClusterWarning = false;
 }
 
 void TWLSettings::loadSettings()
@@ -224,6 +226,8 @@ void TWLSettings::loadSettings()
 	smsGgInRam = settingsini.GetInt("SRLOADER", "SMS_GG_IN_RAM", smsGgInRam);
 	
 	wideScreen = settingsini.GetInt("SRLOADER", "WIDESCREEN", wideScreen);
+
+	dontShowClusterWarning = settingsini.GetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
 }
 
 void TWLSettings::saveSettings()
@@ -258,6 +262,7 @@ void TWLSettings::saveSettings()
 		settingsini.SetString("SRLOADER", ms().secondaryDevice ? "SECONDARY_HOMEBREW_ARG" : "HOMEBREW_ARG", homebrewArg);
 		settingsini.SetInt("SRLOADER", "HOMEBREW_BOOTSTRAP", homebrewBootstrap);
 		settingsini.SetInt("SRLOADER", "HOMEBREW_HAS_WIDE", homebrewHasWide);
+		settingsini.SetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
 	}
 	
 	settingsini.SetInt("SRLOADER", "SORT_METHOD", sortMethod);

--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.h
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.h
@@ -236,6 +236,8 @@ public:
     std::string unlaunchBg;
 
 	bool wideScreen;
+
+	bool dontShowClusterWarning;
 };
 
 typedef singleton<TWLSettings> menuSettings_s;

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -2777,10 +2777,11 @@ std::string browseForFile(const std::vector<std::string> extensionList) {
 						}
 					}
 
-					// If SD card's cluster size is not 32KB, then show warning
+					// If SD card's cluster size is not 32KB, then show warning for DS games
 					struct statvfs st;
 					statvfs("/", &st);
-					if (proceedToLaunch && st.f_bsize != 32 << 10 && !ms().dontShowClusterWarning) {
+					if (bnrRomType[CURPOS] == 0 && !isDSiWare[CURPOS] && isHomebrew[CURPOS] == 0 &&
+						proceedToLaunch && st.f_bsize != 32 << 10 && !ms().dontShowClusterWarning) {
 						if (ms().theme == 4) {
 							snd().playStartup();
 							fadeType = false; // Fade to black

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -2777,6 +2777,90 @@ std::string browseForFile(const std::vector<std::string> extensionList) {
 						}
 					}
 
+					// If SD card's cluster size is not 32KB, then show warning
+					struct statvfs st;
+					statvfs("/", &st);
+					if (proceedToLaunch && st.f_bsize != 32 << 10 && !ms().dontShowClusterWarning) {
+						if (ms().theme == 4) {
+							snd().playStartup();
+							fadeType = false; // Fade to black
+							for (int i = 0; i < 25; i++) {
+								snd().updateStream();
+								swiWaitForVBlank();
+							}
+							currentBg = 1;
+							displayGameIcons = false;
+							fadeType = true;
+						} else {
+							showdialogbox = true;
+						}
+						dbox_showIcon = false;
+						clearText();
+						updateText(false);
+						if (ms().theme == 4) {
+							while (!screenFadedIn()) { swiWaitForVBlank(); }
+							snd().playWrong();
+						} else {
+							for (int i = 0; i < 30; i++) { snd().updateStream(); swiWaitForVBlank(); }
+						}
+
+						printSmall(false, 0, 40, STR_BAD_CLUSTER_SIZE, Alignment::center);
+						printSmall(false, 0, 160, STR_B_A_OK_X_DONT_SHOW, Alignment::center);
+						updateText(false);
+						pressed = 0;
+						while (1) {
+							scanKeys();
+							pressed = keysDown();
+							checkSdEject();
+							tex().drawVolumeImageCached();
+							tex().drawBatteryImageCached();
+
+							drawCurrentTime();
+							drawCurrentDate();
+							drawClockColon();
+							snd().updateStream();
+							swiWaitForVBlank();
+							if (pressed & KEY_A) {
+								pressed = 0;
+								break;
+							}
+							if (pressed & KEY_B) {
+								snd().playBack();
+								proceedToLaunch = false;
+								pressed = 0;
+								break;
+							}
+							if (pressed & KEY_X) {
+								ms().dontShowClusterWarning = true;
+								pressed = 0;
+								break;
+							}
+						}
+						showdialogbox = false;
+						if (ms().theme == 4) {
+							fadeType = false;	   // Fade to black
+							for (int i = 0; i < 25; i++) {
+								swiWaitForVBlank();
+							}
+							clearText();
+							updateText(false);
+							currentBg = 0;
+							displayGameIcons = true;
+							fadeType = true;
+							snd().playStartup();
+							if (proceedToLaunch) {
+								while (!screenFadedIn()) { swiWaitForVBlank(); }
+							}
+						} else {
+							clearText();
+							updateText(false);
+							for (int i = 0; i < (proceedToLaunch ? 20 : 15); i++) {
+								snd().updateStream();
+								swiWaitForVBlank();
+							}
+						}
+					}
+
 					if (proceedToLaunch) {
 						snd().playLaunch();
 						controlTopBright = true;

--- a/romsel_dsimenutheme/arm9/source/language.inl
+++ b/romsel_dsimenutheme/arm9/source/language.inl
@@ -53,6 +53,7 @@ STRING(GAME_INCOMPATIBLE_MSG, "This game is known to not run.\nIf there's an nds
 STRING(CANNOT_LAUNCH_WITHOUT_SD, "This game cannot be launched\nwithout an SD card.")
 STRING(CANNOT_LAUNCH_IN_DS_MODE, "This game cannot be launched\nin DS mode.")
 STRING(PRESS_B_RETURN, "Press \\B to return.")
+STRING(BAD_CLUSTER_SIZE, "Your SD card is not formatted\nusing 32KB clusters, this causes\nsome games to load very slowly.\nIt's recommended to reformat your\nSD card using 32KB clusters.")
 
 // Donor rom
 STRING(DONOR_ROM_MSG_ESDK2, "This game requires a donor ROM\nto run. Please set an existing\nearly SDK2 game as a donor ROM.")

--- a/romsel_dsimenutheme/nitrofiles/languages/english.ini
+++ b/romsel_dsimenutheme/nitrofiles/languages/english.ini
@@ -51,6 +51,7 @@ GAME_INCOMPATIBLE_MSG = This game is known to not run.\nIf there's an nds-bootst
 CANNOT_LAUNCH_WITHOUT_SD = This game cannot be launched\nwithout an SD card.
 CANNOT_LAUNCH_IN_DS_MODE = This game cannot be launched\nin DS mode.
 PRESS_B_RETURN = Press \B to return.
+BAD_CLUSTER_SIZE = Your SD card is not formatted\nusing 32KB clusters, this causes\nsome games to load very slowly.\nIt's recommended to reformat your\nSD card using 32KB clusters.
 
 DONOR_ROM_MSG_ESDK2 = This game requires a donor ROM\nto run. Please set an existing\nearly SDK2 game as a donor ROM.
 DONOR_ROM_MSG_SDK2 = This game requires a donor ROM\nto run. Please set an existing\nlate SDK2 game as a donor ROM.

--- a/romsel_r4theme/arm9/source/fileBrowse.cpp
+++ b/romsel_r4theme/arm9/source/fileBrowse.cpp
@@ -106,6 +106,8 @@ extern int startMenu_cursorPosition;
 extern int pagenum[2];
 extern bool showMicroSd;
 
+extern bool dontShowClusterWarning;
+
 bool settingsChanged = false;
 
 extern void SaveSettings();
@@ -759,6 +761,56 @@ string browseForFile(const vector<string> extensionList) {
 					if (!hasDsiBinaries) {
 						dsiBinariesMissingMsg();
 						proceedToLaunch = false;
+					}
+				}
+
+				// If SD card's cluster size is not 32KB, then show warning
+				struct statvfs st;
+				statvfs("/", &st);
+				if (proceedToLaunch && st.f_bsize != 32 << 10 && !dontShowClusterWarning) {
+					dialogboxHeight = 5;
+					showdialogbox = true;
+					// Clear location text
+					clearText();
+					titleUpdate(dirContents.at(fileOffset).isDirectory,dirContents.at(fileOffset).name.c_str());
+
+					printLargeCentered(false, 74, "Cluster Size Warning");
+					printSmallCentered(false, 98, "Your SD card is not formatted");
+					printSmallCentered(false, 110, "using 32KB clusters, this causes");
+					printSmallCentered(false, 122, "some games to load very slowly.");
+					printSmallCentered(false, 134, "It's recommended to reformat your");
+					printSmallCentered(false, 146, "SD card using 32KB clusters.");
+					printSmallCentered(false, 166, "\u2428 Return   \u2427 Launch");
+
+					pressed = 0;
+					while (1) {
+						snd().updateStream();
+						scanKeys();
+						pressed = keysDown();
+						checkSdEject();
+						swiWaitForVBlank();
+						if (pressed & KEY_A) {
+							pressed = 0;
+							break;
+						}
+						if (pressed & KEY_B) {
+							proceedToLaunch = false;
+							pressed = 0;
+							break;
+						}
+						if (pressed & KEY_X) {
+							dontShowClusterWarning = true;
+							pressed = 0;
+							break;
+						}
+					}
+					clearText();
+					showdialogbox = false;
+					dialogboxHeight = 0;
+
+					if (proceedToLaunch) {
+						titleUpdate(dirContents.at(fileOffset).isDirectory,dirContents.at(fileOffset).name.c_str());
+						showLocation();
 					}
 				}
 

--- a/romsel_r4theme/arm9/source/fileBrowse.cpp
+++ b/romsel_r4theme/arm9/source/fileBrowse.cpp
@@ -764,10 +764,11 @@ string browseForFile(const vector<string> extensionList) {
 					}
 				}
 
-				// If SD card's cluster size is not 32KB, then show warning
+				// If SD card's cluster size is not 32KB, then show warning for DS games
 				struct statvfs st;
 				statvfs("/", &st);
-				if (proceedToLaunch && st.f_bsize != 32 << 10 && !dontShowClusterWarning) {
+				if (bnrRomType == 0 && !isDSiWare && isHomebrew == 0 &&
+					proceedToLaunch && st.f_bsize != 32 << 10 && !dontShowClusterWarning) {
 					dialogboxHeight = 5;
 					showdialogbox = true;
 					// Clear location text

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -178,6 +178,8 @@ int bstrap_extendedMemory = 0;
 bool forceSleepPatch = false;
 bool dsiWareBooter = false;
 
+bool dontShowClusterWarning = false;
+
 void LoadSettings(void) {
 	useBootstrap = isDSiMode();
 	showGba = 1 + isDSiMode();
@@ -277,6 +279,8 @@ void LoadSettings(void) {
 	launchType[1] = settingsini.GetInt("SRLOADER", "SECONDARY_LAUNCH_TYPE", launchType[1]);
 
 	wideScreen = settingsini.GetInt("SRLOADER", "WIDESCREEN", wideScreen);
+
+	dontShowClusterWarning = settingsini.GetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
 }
 
 void SaveSettings(void) {
@@ -308,6 +312,7 @@ void SaveSettings(void) {
 		settingsini.SetString("SRLOADER", secondaryDevice ? "SECONDARY_HOMEBREW_ARG" : "HOMEBREW_ARG", homebrewArg);
 		settingsini.SetInt("SRLOADER", "HOMEBREW_BOOTSTRAP", homebrewBootstrap);
 		settingsini.SetInt("SRLOADER", "HOMEBREW_HAS_WIDE", homebrewHasWide);
+		settingsini.SetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
 	}
 	//settingsini.SetInt("SRLOADER", "THEME", theme);
 	//settingsini.SetInt("SRLOADER", "SUB_THEME", subtheme);


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

This makes it show a warning when launching anything on an SD card that isn't 32KB clusters. If you'd prefer I could change it to only show for DS games as I don't think the others (except maybe GBA?) are impacted much/at all as they don't read from SD much, but I figure it's best to just show it whenever as even TWiLight itself is slower on smaller clusters. I made it dismissible permanently with X in case for whatever reason you can't format to 32KB clusters.

Edit: Oh yeah, added to DSi-based and R4-based themes, so everything currently usable except the quick menu.

#### Where have you tested it?

- DSi (K) with the internal SD, DSTT, Acekard 2i, and Datel Game n' Music, all (except GNM) with both a 32KB clusters card and an 8KB clusters card

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
