### PR TITLE
Don't make .ignoreme files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,6 @@ jobs:
           # version.txt
           printf "TWiLight Menu++: $(git describe --tags)\nnds-bootstrap: $(jq --raw-output '.tag_name' nds-bootstrap.json)\n\nRocketRobz, ahezard\n" > 7zfile/version.txt
 
-          # Really dumb hidden file that for some reason fixes the releases
-          touch 7zfile/.ignoreme
-
           # Main 7z
           cp -r 7zfile TWiLightMenu
           cd TWiLightMenu


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- For who knows why adding this .ignoreme file helped avoid libarchive bugginess, but as that has finally been fixed for real in Universal-Updater, this is no longer needed

#### Where have you tested it?

- N/A

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
