### PR TITLE
Move DMA copy for debanding to the end of VBlank

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -492,12 +492,6 @@ void vBlankHandler() {
 		playRotatingCubesVideo();
 	}
 
-	if (boxArtColorDeband) {
-		//ndmaCopyWordsAsynch(0, tex().frameBuffer(secondBuffer), BG_GFX, 0x18000);
-		dmaCopyHalfWordsAsynch(1, tex().frameBufferBot(secondBuffer), BG_GFX_SUB, 0x18000);
-		secondBuffer = !secondBuffer;
-	}
-
 		if (fadeType == true) {
 			if (!fadeDelay) {
 				screenBrightness -= 1+(ms().theme<4 && fadeSpeed);
@@ -1459,6 +1453,12 @@ void vBlankHandler() {
 	// }
 	// if (applaunchprep && ms().theme == 0)
 	// 	launchDotDoFrameChange = !launchDotDoFrameChange;
+
+	if (boxArtColorDeband) {
+		//ndmaCopyWordsAsynch(0, tex().frameBuffer(secondBuffer), BG_GFX, 0x18000);
+		dmaCopyHalfWordsAsynch(1, tex().frameBufferBot(secondBuffer), BG_GFX_SUB, 0x18000);
+		secondBuffer = !secondBuffer;
+	}
 
 	bottomBgRefresh(); // Refresh the background image on vblank
 }


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Moves the DMA copy for color debanding to the end of the VBlank handler, I couldn't get it to freeze with this where it was freezing a lot for me before. I honestly see no difference at all between it on and off besides being a lot slower to load the boxart when on so not sure if this doesn't work as well? No one said anything on Discord so I'm assuming this is more stable at least, though tbh I think just removing the debanding would be a better solution.

#### Where have you tested it?

- DSi (K) from internal SD and Acekard 2i

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
