### PR TITLE
Change "Greyscale" to "Grayscale"

### DIFF
--- a/settings/arm9/source/language.inl
+++ b/settings/arm9/source/language.inl
@@ -232,7 +232,7 @@ STRING(SYSTEMSETTINGS, "System Settings")
 // STRING(RESTOREDSIMENU, "Restore DSi Menu")
 
 STRING(SYSTEM, "System")
-STRING(BW_GREYSCALE, "B&W/Greyscale")
+STRING(BW_GREYSCALE, "B&W/Grayscale")
 // STRING(BLUELIGHTFILTER, "Blue light filter")
 STRING(WITH_HS, "With H&S")
 STRING(WITHOUT_HS, "Without H&S")

--- a/settings/nitrofiles/languages/english.ini
+++ b/settings/nitrofiles/languages/english.ini
@@ -221,7 +221,7 @@ DEFAULT_LAUNCHER=Default launcher
 SYSTEMSETTINGS=System Settings
 
 SYSTEM=System
-BW_GREYSCALE=B&W/Greyscale
+BW_GREYSCALE=B&W/Grayscale
 WITH_HS=With H&S
 WITHOUT_HS=Without H&S
 CUSTOM_SPLASH=Custom


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- TWiLight typically uses American spellings, even the Nintendo logo color is ["Gray"](https://github.com/DS-Homebrew/TWiLightMenu/blob/master/settings/nitrofiles/languages/english.ini#L230), so I think it's kinda odd that this uses the British spelling

#### Where have you tested it?

- N/A

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
