### PR TITLE
Fix non-ASCII file name DSiWare with Unlaunch

### DIFF
--- a/manual/arm9/source/main.cpp
+++ b/manual/arm9/source/main.cpp
@@ -101,10 +101,6 @@ extern void ClearBrightness();
 
 const char* settingsinipath = "sd:/_nds/TWiLightMenu/settings.ini";
 
-const char *unlaunchAutoLoadID = "AutoLoadInfo";
-static char hiyaNdsPath[14] = {'s','d','m','c',':','/','h','i','y','a','.','d','s','i'};
-char unlaunchDevicePath[256];
-
 bool arm7SCFGLocked = false;
 int consoleModel = 0;
 /*	0 = Nintendo DSi (Retail)
@@ -316,55 +312,6 @@ void loadROMselect() {
 	fadeType = true;	// Fade in from white
 }
 
-void unalunchRomBoot(const char* rom) {
-	char unlaunchDevicePath[256];
-	snprintf(unlaunchDevicePath, sizeof(unlaunchDevicePath), "__%s", rom);
-	unlaunchDevicePath[0] = 's';
-	unlaunchDevicePath[1] = 'd';
-	unlaunchDevicePath[2] = 'm';
-	unlaunchDevicePath[3] = 'c';
-
-	memcpy((u8*)0x02000800, unlaunchAutoLoadID, 12);
-	*(u16*)(0x0200080C) = 0x3F0;		// Unlaunch Length for CRC16 (fixed, must be 3F0h)
-	*(u16*)(0x0200080E) = 0;			// Unlaunch CRC16 (empty)
-	*(u32*)(0x02000810) = 0;			// Unlaunch Flags
-	*(u32*)(0x02000810) |= BIT(0);		// Load the title at 2000838h
-	*(u32*)(0x02000810) |= BIT(1);		// Use colors 2000814h
-	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
-	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
-	memset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < (int)sizeof(unlaunchDevicePath); i++) {
-		*(u8*)(0x02000838+i2) = unlaunchDevicePath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
-	}
-	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
-		*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16
-	}
-
-	fifoSendValue32(FIFO_USER_02, 1);	// Reboot into DSiWare title, booted via Launcher
-	for (int i = 0; i < 15; i++) swiWaitForVBlank();
-}
-
-void unlaunchSetHiyaBoot(void) {
-	memcpy((u8*)0x02000800, unlaunchAutoLoadID, 12);
-	*(u16*)(0x0200080C) = 0x3F0;		// Unlaunch Length for CRC16 (fixed, must be 3F0h)
-	*(u16*)(0x0200080E) = 0;			// Unlaunch CRC16 (empty)
-	*(u32*)(0x02000810) |= BIT(0);		// Load the title at 2000838h
-	*(u32*)(0x02000810) |= BIT(1);		// Use colors 2000814h
-	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
-	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
-	memset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < 14; i++) {
-		*(u8*)(0x02000838+i2) = hiyaNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
-	}
-	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
-		*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16
-	}
-}
-
 //---------------------------------------------------------------------------------
 int main(int argc, char **argv) {
 //---------------------------------------------------------------------------------
@@ -402,47 +349,6 @@ int main(int argc, char **argv) {
 	fifoSendValue32(FIFO_USER_07, 0);
 
 	LoadSettings();
-
-	if (isDSiMode() && (access("sd:/", F_OK) == 0) && consoleModel < 2 && launcherApp != -1) {
-		u8 setRegion = 0;
-		if (sysRegion == -1) {
-			// Determine SysNAND region by searching region of System Settings on SDNAND
-			char tmdpath[256];
-			for (u8 i = 0x41; i <= 0x5A; i++)
-			{
-				snprintf(tmdpath, sizeof(tmdpath), "sd:/title/00030015/484e42%x/content/title.tmd", i);
-				if (access(tmdpath, F_OK) == 0)
-				{
-					setRegion = i;
-					break;
-				}
-			}
-		} else {
-			switch(sysRegion) {
-				case 0:
-				default:
-					setRegion = 0x4A;	// JPN
-					break;
-				case 1:
-					setRegion = 0x45;	// USA
-					break;
-				case 2:
-					setRegion = 0x50;	// EUR
-					break;
-				case 3:
-					setRegion = 0x55;	// AUS
-					break;
-				case 4:
-					setRegion = 0x43;	// CHN
-					break;
-				case 5:
-					setRegion = 0x4B;	// KOR
-					break;
-			}
-		}
-
-		snprintf(unlaunchDevicePath, sizeof(unlaunchDevicePath), "nand:/title/00030017/484E41%x/content/0000000%i.app", setRegion, launcherApp);
-	}
 
 	graphicsInit();
 	fontInit();

--- a/quickmenu/arm9/Makefile
+++ b/quickmenu/arm9/Makefile
@@ -36,7 +36,7 @@ CFLAGS	:=	-g -Wall -O2\
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++1z
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++17
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=../../../universal/arm9/ds_arm9_twlm.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/quickmenu/arm9/source/graphics/FontGraphic.cpp
+++ b/quickmenu/arm9/source/graphics/FontGraphic.cpp
@@ -15,6 +15,27 @@
 
 int fontTextureID[2];
 
+std::u16string FontGraphic::utf8to16(std::string_view text) {
+	std::u16string out;
+	for(uint i=0;i<text.size();) {
+		char16_t c;
+		if(!(text[i] & 0x80)) {
+			c = text[i++];
+		} else if((text[i] & 0xE0) == 0xC0) {
+			c  = (text[i++] & 0x1F) << 6;
+			c |=  text[i++] & 0x3F;
+		} else if((text[i] & 0xF0) == 0xE0) {
+			c  = (text[i++] & 0x0F) << 12;
+			c |= (text[i++] & 0x3F) << 6;
+			c |=  text[i++] & 0x3F;
+		} else {
+			i++; // out of range or something (This only does up to 0xFFFF since it goes to a U16 anyways)
+		}
+		out += c;
+	}
+	return out;
+}
+
 int FontGraphic::load(int textureID, glImage *_font_sprite,
 				  const unsigned int numframes,
 				  const unsigned int *texcoords,

--- a/quickmenu/arm9/source/graphics/FontGraphic.h
+++ b/quickmenu/arm9/source/graphics/FontGraphic.h
@@ -8,6 +8,7 @@
  *******************************************************************************
  ******************************************************************************/
 #pragma once
+#include <string>
 #include <gl2d.h>
 #define FONT_SX 8
 #define FONT_SY 10
@@ -24,6 +25,9 @@ private:
 	char16_t getCharacter(const char *&text);
 
 public:
+
+	// From the other rewritten FontGraphic, needed for Unlaunch
+	static std::u16string utf8to16(std::string_view text);
 
 	FontGraphic() { };
 	int load(int textureID, glImage *_font_sprite,

--- a/rebooter_fc/arm9/source/main.cpp
+++ b/rebooter_fc/arm9/source/main.cpp
@@ -4,7 +4,7 @@
 #include "tonccpy.h"
 
 static const char *unlaunchAutoLoadID = "AutoLoadInfo";
-static char bootNdsPath[14] = {'s','d','m','c',':','/','b','o','o','t','.','n','d','s'};
+static char16_t bootNdsPath[] = u"sdmc:/boot.nds";
 
 //---------------------------------------------------------------------------------
 int main(int argc, char **argv) {
@@ -17,10 +17,8 @@ int main(int argc, char **argv) {
 	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
 	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
 	toncset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < (int)sizeof(bootNdsPath); i++) {
-		*(u8*)(0x02000838+i2) = bootNdsPath[i];				// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
+	for (uint i = 0; i < sizeof(bootNdsPath)/sizeof(bootNdsPath[0]); i++) {
+		((char16_t*)0x02000838)[i] = bootNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 	}
 	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
 		*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -57,7 +57,7 @@ extern bool controlTopBright;
 extern bool controlBottomBright;
 
 extern const char *unlaunchAutoLoadID;
-extern void unlaunchRomBoot(const char* rom);
+extern void unlaunchRomBoot(std::string_view rom);
 
 extern bool dropDown;
 extern int currentBg;
@@ -653,25 +653,8 @@ void exitToSystemMenu(void) {
 		*(u32 *)(0x02000310) = 0x4D454E55; // "MENU"
 		unlaunchSetHiyaBoot();
 	} else {
-		extern char unlaunchDevicePath[256];
-
-		memcpy((u8 *)0x02000800, unlaunchAutoLoadID, 12);
-		*(u16 *)(0x0200080C) = 0x3F0;			   // Unlaunch Length for CRC16 (fixed, must be 3F0h)
-		*(u16 *)(0x0200080E) = 0;			   // Unlaunch CRC16 (empty)
-		*(u32 *)(0x02000810) = (BIT(0) | BIT(1));	  // Load the title at 2000838h
-								   // Use colors 2000814h
-		*(u16 *)(0x02000814) = 0x7FFF;			   // Unlaunch Upper screen BG color (0..7FFFh)
-		*(u16 *)(0x02000816) = 0x7FFF;			   // Unlaunch Lower screen BG color (0..7FFFh)
-		memset((u8 *)0x02000818, 0, 0x20 + 0x208 + 0x1C0); // Unlaunch Reserved (zero)
-		int i2 = 0;
-		for (int i = 0; i < (int)sizeof(unlaunchDevicePath); i++) {
-			*(u8 *)(0x02000838 + i2) =
-				unlaunchDevicePath[i]; // Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-			i2 += 2;
-		}
-		while (*(u16 *)(0x0200080E) == 0) { // Keep running, so that CRC16 isn't 0
-			*(u16 *)(0x0200080E) = swiCRC16(0xFFFF, (void *)0x02000810, 0x3F0); // Unlaunch CRC16
-		}
+		extern char launcherPath[256];
+		unlaunchRomBoot(launcherPath);
 	}
 	fifoSendValue32(FIFO_USER_02, 1); // ReturntoDSiMenu
 }

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -77,8 +77,8 @@ const char *settingsinipath = "sd:/_nds/TWiLightMenu/settings.ini";
 const char *bootstrapinipath = "sd:/_nds/nds-bootstrap.ini";
 
 const char *unlaunchAutoLoadID = "AutoLoadInfo";
-static char hiyaNdsPath[14] = {'s', 'd', 'm', 'c', ':', '/', 'h', 'i', 'y', 'a', '.', 'd', 's', 'i'};
-char unlaunchDevicePath[256];
+static char16_t hiyaNdsPath[] = u"sdmc:/hiya.dsi";
+char launcherPath[256];
 
 bool extention(const std::string& filename, const char* ext) {
 	if(strcasecmp(filename.c_str() + filename.size() - strlen(ext), ext)) {
@@ -448,16 +448,11 @@ void loadGameOnFlashcard (const char *ndsPath, bool dsGame) {
 	stop();
 }
 
-void unlaunchRomBoot(const char* rom) {
+void unlaunchRomBoot(std::string_view rom) {
 	snd().stopStream();
-	if (strncmp(rom, "cart:", 5) == 0) {
-		sprintf(unlaunchDevicePath, "cart:");
-	} else {
-		sprintf(unlaunchDevicePath, "__%s", rom);
-		unlaunchDevicePath[0] = 's';
-		unlaunchDevicePath[1] = 'd';
-		unlaunchDevicePath[2] = 'm';
-		unlaunchDevicePath[3] = 'c';
+	std::u16string path(FontGraphic::utf8to16(rom));
+	if (path.substr(0, 3) == u"sd:") {
+		path = u"sdmc:" + path.substr(3);
 	}
 
 	tonccpy((u8*)0x02000800, unlaunchAutoLoadID, 12);
@@ -469,10 +464,8 @@ void unlaunchRomBoot(const char* rom) {
 	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
 	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
 	toncset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < (int)sizeof(unlaunchDevicePath); i++) {
-		*(u8*)(0x02000838+i2) = unlaunchDevicePath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
+	for (uint i = 0; i < std::min(path.length(), 0x103u); i++) {
+		((char16_t*)0x02000838)[i] = path[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 	}
 	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
 		*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16
@@ -493,11 +486,8 @@ void unlaunchSetHiyaBoot(void) {
 	*(u16 *)(0x02000814) = 0x7FFF;			   // Unlaunch Upper screen BG color (0..7FFFh)
 	*(u16 *)(0x02000816) = 0x7FFF;			   // Unlaunch Lower screen BG color (0..7FFFh)
 	toncset((u8 *)0x02000818, 0, 0x20 + 0x208 + 0x1C0); // Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < 14; i++) {
-		*(u8 *)(0x02000838 + i2) =
-		    hiyaNdsPath[i]; // Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
+	for (uint i = 0; i < sizeof(hiyaNdsPath)/sizeof(hiyaNdsPath[0]); i++) {
+		((char16_t*)0x02000838)[i] = hiyaNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 	}
 	while (*(vu16 *)(0x0200080E) == 0) { // Keep running, so that CRC16 isn't 0
 		*(u16 *)(0x0200080E) = swiCRC16(0xFFFF, (void *)0x02000810, 0x3F0); // Unlaunch CRC16
@@ -717,7 +707,7 @@ int main(int argc, char **argv) {
 			}
 		}
 
-		snprintf(unlaunchDevicePath, sizeof(unlaunchDevicePath),
+		snprintf(launcherPath, sizeof(launcherPath),
 			 "nand:/title/00030017/484E41%x/content/0000000%i.app", setRegion, ms().launcherApp);
 	}
 
@@ -1186,44 +1176,7 @@ int main(int argc, char **argv) {
 					}
 				}
 
-				char unlaunchDevicePath[256];
-				if (ms().secondaryDevice) {
-					snprintf(unlaunchDevicePath, sizeof(unlaunchDevicePath),
-						 "sdmc:/_nds/TWiLightMenu/tempDSiWare.dsi");
-				} else {
-					snprintf(unlaunchDevicePath, sizeof(unlaunchDevicePath), "__%s",
-						 ms().dsiWareSrlPath.c_str());
-					unlaunchDevicePath[0] = 's';
-					unlaunchDevicePath[1] = 'd';
-					unlaunchDevicePath[2] = 'm';
-					unlaunchDevicePath[3] = 'c';
-				}
-
-				tonccpy((u8 *)0x02000800, unlaunchAutoLoadID, 12);
-				*(u16 *)(0x0200080C) = 0x3F0;   // Unlaunch Length for CRC16 (fixed, must be 3F0h)
-				*(u16 *)(0x0200080E) = 0;       // Unlaunch CRC16 (empty)
-				*(u32 *)(0x02000810) = 0;       // Unlaunch Flags
-				*(u32 *)(0x02000810) |= BIT(0); // Load the title at 2000838h
-				*(u32 *)(0x02000810) |= BIT(1); // Use colors 2000814h
-				*(u16 *)(0x02000814) = 0x7FFF;  // Unlaunch Upper screen BG color (0..7FFFh)
-				*(u16 *)(0x02000816) = 0x7FFF;  // Unlaunch Lower screen BG color (0..7FFFh)
-				toncset((u8 *)0x02000818, 0, 0x20 + 0x208 + 0x1C0); // Unlaunch Reserved (zero)
-				int i2 = 0;
-				for (int i = 0; i < (int)sizeof(unlaunchDevicePath); i++) {
-					*(u8 *)(0x02000838 + i2) =
-					    unlaunchDevicePath[i]; // Unlaunch Device:/Path/Filename.ext (16bit
-								   // Unicode,end by 0000h)
-					i2 += 2;
-				}
-				while (*(u16 *)(0x0200080E) == 0) { // Keep running, so that CRC16 isn't 0
-					*(u16 *)(0x0200080E) =
-					    swiCRC16(0xFFFF, (void *)0x02000810, 0x3F0); // Unlaunch CRC16
-				}
-				DC_FlushAll();
-				fifoSendValue32(FIFO_USER_02, 1); // Reboot into DSiWare title, booted via Unlaunch
-				for (int i = 0; i < 15; i++) {
-					swiWaitForVBlank();
-				}
+				unlaunchRomBoot(ms().secondaryDevice ? "sdmc:/_nds/TWiLightMenu/tempDSiWare.dsi" : ms().dsiWareSrlPath);
 			}
 
 			// Launch .nds directly or via nds-bootstrap

--- a/romsel_r4theme/arm9/Makefile
+++ b/romsel_r4theme/arm9/Makefile
@@ -35,7 +35,7 @@ CFLAGS	:=	-g -Wall -O2\
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-exceptions -std=gnu++11
+CXXFLAGS	:= $(CFLAGS) -fno-exceptions -std=gnu++17
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=../../../universal/arm9/ds_arm9_twlm.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/romsel_r4theme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_r4theme/arm9/source/graphics/FontGraphic.cpp
@@ -15,6 +15,27 @@
 
 int fontTextureID[2];
 
+std::u16string FontGraphic::utf8to16(std::string_view text) {
+	std::u16string out;
+	for(uint i=0;i<text.size();) {
+		char16_t c;
+		if(!(text[i] & 0x80)) {
+			c = text[i++];
+		} else if((text[i] & 0xE0) == 0xC0) {
+			c  = (text[i++] & 0x1F) << 6;
+			c |=  text[i++] & 0x3F;
+		} else if((text[i] & 0xF0) == 0xE0) {
+			c  = (text[i++] & 0x0F) << 12;
+			c |= (text[i++] & 0x3F) << 6;
+			c |=  text[i++] & 0x3F;
+		} else {
+			i++; // out of range or something (This only does up to 0xFFFF since it goes to a U16 anyways)
+		}
+		out += c;
+	}
+	return out;
+}
+
 int FontGraphic::load(int textureID, glImage *_font_sprite,
 				  const unsigned int numframes,
 				  const unsigned int *texcoords,

--- a/romsel_r4theme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_r4theme/arm9/source/graphics/FontGraphic.h
@@ -8,6 +8,7 @@
  *******************************************************************************
  ******************************************************************************/
 #pragma once
+#include <string>
 #include <gl2d.h>
 #define FONT_SX 8
 #define FONT_SY 10
@@ -24,6 +25,9 @@ private:
 	char16_t getCharacter(const char *&text);
 
 public:
+
+	// From the other rewritten FontGraphic, needed for Unlaunch
+	static std::u16string utf8to16(std::string_view text);
 
 	FontGraphic() { };
 	int load(int textureID, glImage *_font_sprite,

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -78,8 +78,8 @@ std::string unlaunchBg = "default.gif";
 bool removeLauncherPatches = true;
 
 const char *unlaunchAutoLoadID = "AutoLoadInfo";
-static char hiyaNdsPath[14] = {'s','d','m','c',':','/','h','i','y','a','.','d','s','i'};
-char unlaunchDevicePath[256];
+static char16_t hiyaNdsPath[] = u"sdmc:/hiya.dsi";
+char launcherPath[256];
 
 bool arm7SCFGLocked = false;
 int consoleModel = 0;
@@ -773,15 +773,10 @@ void loadGameOnFlashcard (const char* ndsPath, bool dsGame) {
 	stop();
 }
 
-void unlaunchRomBoot(const char* rom) {
-	if (strncmp(rom, "cart:", 5) == 0) {
-		sprintf(unlaunchDevicePath, "cart:");
-	} else {
-		sprintf(unlaunchDevicePath, "__%s", rom);
-		unlaunchDevicePath[0] = 's';
-		unlaunchDevicePath[1] = 'd';
-		unlaunchDevicePath[2] = 'm';
-		unlaunchDevicePath[3] = 'c';
+void unlaunchRomBoot(std::string_view rom) {
+	std::u16string path(FontGraphic::utf8to16(rom));
+	if (path.substr(0, 3) == u"sd:") {
+		path = u"sdmc:" + path.substr(3);
 	}
 
 	tonccpy((u8*)0x02000800, unlaunchAutoLoadID, 12);
@@ -793,10 +788,8 @@ void unlaunchRomBoot(const char* rom) {
 	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
 	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
 	toncset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < (int)sizeof(unlaunchDevicePath); i++) {
-		*(u8*)(0x02000838+i2) = unlaunchDevicePath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
+	for (uint i = 0; i < std::min(path.length(), 0x103u); i++) {
+		((char16_t*)0x02000838)[i] = path[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 	}
 	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
 		*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16
@@ -816,10 +809,8 @@ void unlaunchSetHiyaBoot(void) {
 	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
 	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
 	toncset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < 14; i++) {
-		*(u8*)(0x02000838+i2) = hiyaNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
+	for (uint i = 0; i < sizeof(hiyaNdsPath)/sizeof(hiyaNdsPath[0]); i++) {
+		((char16_t*)0x02000838)[i] = hiyaNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 	}
 	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
 		*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16
@@ -1007,7 +998,7 @@ int main(int argc, char **argv) {
 			}
 		}
 
-		snprintf(unlaunchDevicePath, sizeof(unlaunchDevicePath), "nand:/title/00030017/484E41%x/content/0000000%i.app", setRegion, launcherApp);
+		snprintf(launcherPath, sizeof(launcherPath), "nand:/title/00030017/484E41%x/content/0000000%i.app", setRegion, launcherApp);
 	}
 
 	keysSetRepeat(10, 2);
@@ -1307,22 +1298,7 @@ int main(int argc, char **argv) {
 					*(u32*)(0x02000310) = 0x4D454E55;	// "MENU"
 					unlaunchSetHiyaBoot();
 				} else {
-					tonccpy((u8*)0x02000800, unlaunchAutoLoadID, 12);
-					*(u16*)(0x0200080C) = 0x3F0;		// Unlaunch Length for CRC16 (fixed, must be 3F0h)
-					*(u16*)(0x0200080E) = 0;			// Unlaunch CRC16 (empty)
-					*(u32*)(0x02000810) |= BIT(0);		// Load the title at 2000838h
-					*(u32*)(0x02000810) |= BIT(1);		// Use colors 2000814h
-					*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
-					*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
-					toncset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-					int i2 = 0;
-					for (int i = 0; i < (int)sizeof(unlaunchDevicePath); i++) {
-						*(u8*)(0x02000838+i2) = unlaunchDevicePath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-						i2 += 2;
-					}
-					while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
-						*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16
-					}
+					unlaunchRomBoot(launcherPath);
 				}
 				fifoSendValue32(FIFO_USER_02, 1);	// ReturntoDSiMenu
 			}
@@ -1603,40 +1579,7 @@ int main(int argc, char **argv) {
 					}
 				}
 
-				char unlaunchDevicePath[256];
-				if (secondaryDevice) {
-					snprintf(unlaunchDevicePath, sizeof(unlaunchDevicePath), "sdmc:/_nds/TWiLightMenu/tempDSiWare.dsi");
-				} else {
-					snprintf(unlaunchDevicePath, sizeof(unlaunchDevicePath), "__%s", dsiWareSrlPath.c_str());
-					unlaunchDevicePath[0] = 's';
-					unlaunchDevicePath[1] = 'd';
-					unlaunchDevicePath[2] = 'm';
-					unlaunchDevicePath[3] = 'c';
-				}
-
-				tonccpy((u8*)0x02000800, unlaunchAutoLoadID, 12);
-				*(u16*)(0x0200080C) = 0x3F0;		// Unlaunch Length for CRC16 (fixed, must be 3F0h)
-				*(u16*)(0x0200080E) = 0;			// Unlaunch CRC16 (empty)
-				*(u32*)(0x02000810) = 0;			// Unlaunch Flags
-				*(u32*)(0x02000810) |= BIT(0);		// Load the title at 2000838h
-				*(u32*)(0x02000810) |= BIT(1);		// Use colors 2000814h
-				*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
-				*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
-				toncset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-				int i2 = 0;
-				for (int i = 0; i < (int)sizeof(unlaunchDevicePath); i++) {
-					*(u8*)(0x02000838+i2) = unlaunchDevicePath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-					i2 += 2;
-				}
-				while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
-					*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16
-				}
-				// Stabilization code to make DSiWare always boot successfully(?)
-				clearText();
-				for (int i = 0; i < 15; i++) swiWaitForVBlank();
-
-				fifoSendValue32(FIFO_USER_02, 1);	// Reboot into DSiWare title, booted via Launcher
-				for (int i = 0; i < 15; i++) swiWaitForVBlank();
+				unlaunchRomBoot(secondaryDevice ? "sdmc:/_nds/TWiLightMenu/tempDSiWare.dsi" : dsiWareSrlPath.c_str());
 			} else
 
 			// Launch .nds directly or via nds-bootstrap

--- a/rungame/arm9/Makefile
+++ b/rungame/arm9/Makefile
@@ -36,7 +36,7 @@ CFLAGS	:=	-g -Wall -O2\
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++17
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=../../../universal/arm9/ds_arm9_twlm.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/settings/arm9/Makefile
+++ b/settings/arm9/Makefile
@@ -44,7 +44,7 @@ CFLAGS	:=	-g -Wall -O2\
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++1z
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++17
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=../../../universal/arm9/ds_arm9_twlm.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/settings/arm9/source/common/cardlaunch.h
+++ b/settings/arm9/source/common/cardlaunch.h
@@ -2,8 +2,9 @@
 
 #ifndef __CARD_LAUNCH__
 #define __CARD_LAUNCH__
-extern const char *unlaunchAutoLoadID;
-extern char hiyaNdsPath[14];
+
+const char *unlaunchAutoLoadID = "AutoLoadInfo";
+const char16_t hiyaNdsPath[] = u"sdmc:/hiya.dsi";
 
 void unlaunchSetHiyaBoot(void) {
 	memcpy((u8*)0x02000800, unlaunchAutoLoadID, 12);
@@ -14,10 +15,8 @@ void unlaunchSetHiyaBoot(void) {
 	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
 	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
 	memset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < 14; i++) {
-		*(u8*)(0x02000838+i2) = hiyaNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
+	for (uint i = 0; i < sizeof(hiyaNdsPath)/sizeof(hiyaNdsPath[0]); i++) {
+		((char16_t*)0x02000838)[i] = hiyaNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 	}
 	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
 		*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -84,9 +84,6 @@ const char *hiyacfwinipath = "sd:/hiya/settings.ini";
 std::string homebrewArg;
 std::string bootstrapfilename;
 
-const char *unlaunchAutoLoadID = "AutoLoadInfo";
-char hiyaNdsPath[14] = {'s','d','m','c',':','/','h','i','y','a','.','d','s','i'};
-
 int subscreenmode = 0;
 
 int pressed = 0;

--- a/slot1launch/cardengine_arm7/source/cardEngine.c
+++ b/slot1launch/cardengine_arm7/source/cardEngine.c
@@ -32,8 +32,8 @@
 #include "sr_data_srllastran.h"	// For rebooting the game
 
 static const char *unlaunchAutoLoadID = "AutoLoadInfo";
-static char bootNdsPath[14] = {'s','d','m','c',':','/','b','o','o','t','.','n','d','s'};
-static const char *resetGameSrldrPath = "sdmc:/_nds/TWiLightMenu/resetgame.srldr";
+static const char bootNdsPath[15] = "sdmc:/boot.nds";
+static const char resetGameSrldrPath[40] = "sdmc:/_nds/TWiLightMenu/resetgame.srldr";
 
 extern void cheat_engine_start(void);
 
@@ -50,16 +50,13 @@ static void unlaunchSetFilename(bool boot) {
 	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
 	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
 	memset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
 	if (boot) {
-		for (int i = 0; i < (int)sizeof(bootNdsPath); i++) {
-			*(u8*)(0x02000838+i2) = bootNdsPath[i];				// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-			i2 += 2;
+		for (unsigned int i = 0; i < sizeof(bootNdsPath)/sizeof(bootNdsPath[0]); i++) {
+			((u16*)0x02000838)[i] = bootNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 		}
 	} else {
-		for (int i = 0; i < 39; i++) {
-			*(u8*)(0x02000838+i2) = resetGameSrldrPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-			i2 += 2;
+		for (unsigned int i = 0; i < sizeof(resetGameSrldrPath)/sizeof(resetGameSrldrPath[0]); i++) {
+			((u16*)0x02000838)[i] = resetGameSrldrPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 		}
 	}
 	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0

--- a/title/arm9/Makefile
+++ b/title/arm9/Makefile
@@ -37,7 +37,7 @@ CFLAGS	:=	-g -Wall -O2\
 		$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++1z
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++17
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=../../../universal/arm9/ds_arm9_twlm.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)

--- a/title/arm9/source/common/cardlaunch.h
+++ b/title/arm9/source/common/cardlaunch.h
@@ -2,8 +2,9 @@
 
 #ifndef __CARD_LAUNCH__
 #define __CARD_LAUNCH__
-extern const char *unlaunchAutoLoadID;
-extern char hiyaNdsPath[14];
+
+const char *unlaunchAutoLoadID = "AutoLoadInfo";
+const char16_t hiyaNdsPath[] = u"sdmc:/hiya.dsi";
 
 void unlaunchSetHiyaBoot(void) {
 	memcpy((u8*)0x02000800, unlaunchAutoLoadID, 12);
@@ -14,10 +15,8 @@ void unlaunchSetHiyaBoot(void) {
 	*(u16*)(0x02000814) = 0x7FFF;		// Unlaunch Upper screen BG color (0..7FFFh)
 	*(u16*)(0x02000816) = 0x7FFF;		// Unlaunch Lower screen BG color (0..7FFFh)
 	memset((u8*)0x02000818, 0, 0x20+0x208+0x1C0);		// Unlaunch Reserved (zero)
-	int i2 = 0;
-	for (int i = 0; i < 14; i++) {
-		*(u8*)(0x02000838+i2) = hiyaNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
-		i2 += 2;
+	for (uint i = 0; i < sizeof(hiyaNdsPath)/sizeof(hiyaNdsPath[0]); i++) {
+		((char16_t*)0x02000838)[i] = hiyaNdsPath[i];		// Unlaunch Device:/Path/Filename.ext (16bit Unicode,end by 0000h)
 	}
 	while (*(u16*)(0x0200080E) == 0) {	// Keep running, so that CRC16 isn't 0
 		*(u16*)(0x0200080E) = swiCRC16(0xFFFF, (void*)0x02000810, 0x3F0);		// Unlaunch CRC16


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Unlaunch expects DSiWare file names in UCS-2, not just UTF-8 with every other byte null, so this fixes that by properly converting the file names.

#### Where have you tested it?

- DSi (K) from internal SD, not from flashcard as I've not been able to get the secondary device stuff working

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
