### PR TITLE
Don't use fstream for cheat writing

### DIFF
--- a/quickmenu/arm9/source/cheat.h
+++ b/quickmenu/arm9/source/cheat.h
@@ -6,28 +6,26 @@
 #include <vector>
 #include <nds.h>
 
-void writeCheatsToFile(std::string data, const char* path);
-
 class CheatCodelist
 {
 public:
-	CheatCodelist (void)
-	{
-	}
-	
-	~CheatCodelist ();
+  CheatCodelist (void)
+  {
+  }
+  
+  ~CheatCodelist ();
 
-	bool parse(const std::string& aFileName);
+  bool parse(const std::string& aFileName);
 
-	bool searchCheatData(FILE* aDat,u32 gamecode,u32 crc32,long& aPos,size_t& aSize);
+  bool searchCheatData(FILE* aDat,u32 gamecode,u32 crc32,long& aPos,size_t& aSize);
 
-	bool parseInternal(FILE* aDat,u32 gamecode,u32 crc32);
+  bool parseInternal(FILE* aDat,u32 gamecode,u32 crc32);
 
-	void generateList(void);
+  void generateList(void);
 
-	bool romData(const std::string& aFileName,u32& aGameCode,u32& aCrc32);
+  bool romData(const std::string& aFileName,u32& aGameCode,u32& aCrc32);
 
-	private:
+  private:
     struct sDatIndex
     {
       u32 _gameCode;
@@ -39,7 +37,7 @@ public:
       public:
         std::string _title;
         std::string _comment;
-        std::string _cheat;
+        std::vector<u32> _cheat;
         u32 _flags;
         u32 _offset;
         cParsedItem(const std::string& title,const std::string& comment,u32 flags,u32 offset=0):_title(title),_comment(comment),_flags(flags),_offset(offset) {};
@@ -56,8 +54,9 @@ public:
     std::vector<cParsedItem> _data;
     std::vector<size_t> _indexes;
   public:
-    std::string getCheats();
-	
+    std::vector<u32> getCheats();
+    void writeCheatsToFile(const char* path);
+
 private:
 	enum TOKEN_TYPE {TOKEN_DATA, TOKEN_TAG_START, TOKEN_TAG_END, TOKEN_TAG_SINGLE};
 

--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -2356,7 +2356,7 @@ int main(int argc, char **argv) {
 												     crc32, cheatOffset,
 												     cheatSize)) {
 										codelist.parse(path);
-										writeCheatsToFile(codelist.getCheats(), cheatDataBin);
+										codelist.writeCheatsToFile(cheatDataBin);
 										FILE* cheatData=fopen(cheatDataBin,"rb");
 										if (cheatData) {
 											u32 check[2];

--- a/romsel_aktheme/arm9/source/common/bootstrapconfig.cpp
+++ b/romsel_aktheme/arm9/source/common/bootstrapconfig.cpp
@@ -308,7 +308,7 @@ void BootstrapConfig::loadCheats()
 						CheatWnd chtwnd((256)/2,(192)/2,100,100,NULL,_fullPath);
 
 						chtwnd.parse(_fullPath);
-						chtwnd.writeCheatsToFile(chtwnd.getCheats(), SFN_CHEAT_DATA);
+						chtwnd.writeCheatsToFile(SFN_CHEAT_DATA);
 						FILE* cheatData=fopen(SFN_CHEAT_DATA,"rb");
 						if (cheatData) {
 							u32 check[2];

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.cpp
@@ -26,9 +26,6 @@
 #include "gamecode.h"
 #include <sys/stat.h>
 #include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 
 using namespace akui;
 
@@ -460,12 +457,8 @@ bool CheatWnd::parseInternal(FILE* aDat,u32 gamecode,u32 crc32)
       {
         _data.push_back(cParsedItem(cheatName,cheatNote,flagItem|((*ccode&0xff000000)?selectValue:0),dataPos+(((char*)ccode+3)-buffer)));
         if((*ccode&0xff000000)&&(flagItem&cParsedItem::EOne)) selectValue=0;
-        for(size_t jj=0;jj<cheatDataLen;++jj)
-        {
-          _data.back()._cheat+=formatString("%08X",*(cheatData+jj));
-          _data.back()._cheat+=((jj+1)%2)?" ":"\n";
-        }
-        if(cheatDataLen%2) _data.back()._cheat+="\n";
+        _data.back()._cheat.resize(cheatDataLen);
+        tonccpy(_data.back()._cheat.data(),cheatData,cheatDataLen*4);
       }
       cc++;
       ccode=(u32*)((u32)ccode+(((*ccode&0x00ffffff)+1)*4));
@@ -516,33 +509,25 @@ void CheatWnd::deselectFolder(size_t anIndex)
   }
 }
 
-std::string CheatWnd::getCheats()
+std::vector<u32> CheatWnd::getCheats()
 {
-  std::string cheats;
-  for(uint i=0;i< _data.size();i++)
+  std::vector<u32> cheats;
+  for(uint i=0;i<_data.size();i++)
   {
     if(_data[i]._flags&cParsedItem::ESelected)
     {
-      cheats += _data[i]._cheat.substr(0, _data[i]._cheat.size());
+      cheats.insert(cheats.end(),_data[i]._cheat.begin(),_data[i]._cheat.end());
     }
   }
-  std::replace( cheats.begin(), cheats.end(), '\n', ' ');
   return cheats;
 }
 
-void CheatWnd::writeCheatsToFile(std::string data, const char* path) {
-  std::fstream fs;
-  fs.open(path, std::ios::binary | std::fstream::out);
-  std::stringstream str;
-  u32 value;
-  while(1) {
-    str.clear();
-    str << data.substr(0, data.find(" "));
-    str >> std::hex >> value;
-    fs.write(reinterpret_cast<char*>(&value),sizeof(value));
-    data = data.substr(data.find(" ")+1);
-    if((int)data.find(" ") == -1) break;
+void CheatWnd::writeCheatsToFile(const char* path) {
+  FILE *file = fopen(path, "wb");
+  if(file) {
+    std::vector<u32> cheats(getCheats());
+    fwrite(cheats.data(),4,cheats.size(),file);
+    fwrite("\0\0\0\xCF",4,1,file);
+    fclose(file);
   }
-  fs.write("\0\0\0\xCF", 4);
-  fs.close();
 }

--- a/romsel_aktheme/arm9/source/windows/cheatwnd.h
+++ b/romsel_aktheme/arm9/source/windows/cheatwnd.h
@@ -33,7 +33,7 @@ class CheatWnd: public akui::Form
     bool parse(const std::string& aFileName);
     static bool searchCheatData(FILE* aDat,u32 gamecode,u32 crc32,long& aPos,size_t& aSize);
     static bool romData(const std::string& aFileName,u32& aGameCode,u32& aCrc32);
-    void writeCheatsToFile(std::string data, const char* path);
+    void writeCheatsToFile(const char* path);
   protected:
     void draw();
     bool process(const akui::Message& msg);
@@ -70,7 +70,7 @@ class CheatWnd: public akui::Form
       public:
         std::string _title;
         std::string _comment;
-        std::string _cheat;
+        std::vector<u32> _cheat;
         u32 _flags;
         u32 _offset;
         cParsedItem(const std::string& title,const std::string& comment,u32 flags,u32 offset=0):_title(title),_comment(comment),_flags(flags),_offset(offset) {};
@@ -98,7 +98,7 @@ class CheatWnd: public akui::Form
     std::vector<size_t> _indexes;
     std::string _fileName;
   public:
-    std::string getCheats();
+    std::vector<u32> getCheats();
 };
 
 #endif

--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -26,9 +26,6 @@
 #include "tool/stringtool.h"
 #include "sound.h"
 #include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 
 #include "ndsheaderbanner.h"
 #include "iconTitle.h"
@@ -176,12 +173,8 @@ bool CheatCodelist::parseInternal(FILE* aDat,u32 gamecode,u32 crc32)
       {
         _data.push_back(cParsedItem(cheatName,cheatNote,flagItem|((*ccode&0xff000000)?selectValue:0),dataPos+(((char*)ccode+3)-buffer)));
         if((*ccode&0xff000000)&&(flagItem&cParsedItem::EOne)) selectValue=0;
-        for(size_t jj=0;jj<cheatDataLen;++jj)
-        {
-          _data.back()._cheat+=formatString("%08X",*(cheatData+jj));
-          _data.back()._cheat+=((jj+1)%2)?" ":"\n";
-        }
-        if(cheatDataLen%2) _data.back()._cheat+="\n";
+        _data.back()._cheat.resize(cheatDataLen);
+        tonccpy(_data.back()._cheat.data(),cheatData,cheatDataLen*4);
       }
       cc++;
       ccode=(u32*)((u32)ccode+(((*ccode&0x00ffffff)+1)*4));
@@ -250,17 +243,16 @@ bool CheatCodelist::romData(const std::string& aFileName,u32& aGameCode,u32& aCr
   return res;
 }
 
-std::string CheatCodelist::getCheats()
+std::vector<u32> CheatCodelist::getCheats()
 {
-  std::string cheats;
-  for(uint i=0;i< _data.size();i++)
+  std::vector<u32> cheats;
+  for(uint i=0;i<_data.size();i++)
   {
     if(_data[i]._flags&cParsedItem::ESelected)
     {
-      cheats += _data[i]._cheat.substr(0, _data[i]._cheat.size());
+      cheats.insert(cheats.end(),_data[i]._cheat.begin(),_data[i]._cheat.end());
     }
   }
-  std::replace( cheats.begin(), cheats.end(), '\n', ' ');
   return cheats;
 }
 
@@ -599,19 +591,12 @@ void CheatCodelist::onGenerate(void)
   }
 }
 
-void writeCheatsToFile(std::string data, const char* path) {
-  std::fstream fs;
-  fs.open(path, std::ios::binary | std::fstream::out);
-  std::stringstream str;
-  u32 value;
-  while(1) {
-    str.clear();
-    str << data.substr(0, data.find(" "));
-    str >> std::hex >> value;
-    fs.write(reinterpret_cast<char*>(&value),sizeof(value));
-    data = data.substr(data.find(" ")+1);
-    if((int)data.find(" ") == -1) break;
+void CheatCodelist::writeCheatsToFile(const char *path) {
+  FILE *file = fopen(path, "wb");
+  if(file) {
+    std::vector<u32> cheats(getCheats());
+    fwrite(cheats.data(),4,cheats.size(),file);
+    fwrite("\0\0\0\xCF",4,1,file);
+    fclose(file);
   }
-  fs.write("\0\0\0\xCF", 4);
-  fs.close();
 }

--- a/romsel_dsimenutheme/arm9/source/cheat.h
+++ b/romsel_dsimenutheme/arm9/source/cheat.h
@@ -6,8 +6,6 @@
 #include <vector>
 #include <nds.h>
 
-void writeCheatsToFile(std::string data, const char* path);
-
 class CheatCodelist
 {
 public:
@@ -47,7 +45,7 @@ public:
       public:
         std::string _title;
         std::string _comment;
-        std::string _cheat;
+        std::vector<u32> _cheat;
         u32 _flags;
         u32 _offset;
         cParsedItem(const std::string& title,const std::string& comment,u32 flags,u32 offset=0):_title(title),_comment(comment),_flags(flags),_offset(offset) {};
@@ -64,8 +62,9 @@ public:
     std::vector<cParsedItem> _data;
     std::vector<size_t> _indexes;
   public:
-    std::string getCheats();
-  
+    std::vector<u32> getCheats();
+    void writeCheatsToFile(const char *path);
+
 private:
   enum TOKEN_TYPE {TOKEN_DATA, TOKEN_TAG_START, TOKEN_TAG_END, TOKEN_TAG_SINGLE};
 

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1368,7 +1368,7 @@ int main(int argc, char **argv) {
 								if (dat) {
 									if (codelist.searchCheatData(dat, gameCode, crc32, cheatOffset, cheatSize)) {
 										codelist.parse(path);
-										writeCheatsToFile(codelist.getCheats(), cheatDataBin);
+										codelist.writeCheatsToFile(cheatDataBin);
 										FILE* cheatData=fopen(cheatDataBin,"rb");
 										if (cheatData) {
 											u32 check[2];

--- a/romsel_r4theme/arm9/source/cheat.cpp
+++ b/romsel_r4theme/arm9/source/cheat.cpp
@@ -24,9 +24,6 @@
 #include "tool/dbgtool.h"
 #include "tool/stringtool.h"
 #include <algorithm>
-#include <iostream>
-#include <fstream>
-#include <sstream>
 
 #include "ndsheaderbanner.h"
 #include "sound.h"
@@ -172,12 +169,8 @@ bool CheatCodelist::parseInternal(FILE* aDat,u32 gamecode,u32 crc32)
       {
         _data.push_back(cParsedItem(cheatName,cheatNote,flagItem|((*ccode&0xff000000)?selectValue:0),dataPos+(((char*)ccode+3)-buffer)));
         if((*ccode&0xff000000)&&(flagItem&cParsedItem::EOne)) selectValue=0;
-        for(size_t jj=0;jj<cheatDataLen;++jj)
-        {
-          _data.back()._cheat+=formatString("%08X",*(cheatData+jj));
-          _data.back()._cheat+=((jj+1)%2)?" ":"\n";
-        }
-        if(cheatDataLen%2) _data.back()._cheat+="\n";
+        _data.back()._cheat.resize(cheatDataLen);
+        tonccpy(_data.back()._cheat.data(),cheatData,cheatDataLen*4);
       }
       cc++;
       ccode=(u32*)((u32)ccode+(((*ccode&0x00ffffff)+1)*4));
@@ -246,17 +239,16 @@ bool CheatCodelist::romData(const std::string& aFileName,u32& aGameCode,u32& aCr
   return res;
 }
 
-std::string CheatCodelist::getCheats()
+std::vector<u32> CheatCodelist::getCheats()
 {
-  std::string cheats;
-  for(uint i=0;i< _data.size();i++)
+  std::vector<u32> cheats;
+  for(uint i=0;i<_data.size();i++)
   {
     if(_data[i]._flags&cParsedItem::ESelected)
     {
-      cheats += _data[i]._cheat.substr(0, _data[i]._cheat.size());
+      cheats.insert(cheats.end(),_data[i]._cheat.begin(),_data[i]._cheat.end());
     }
   }
-  std::replace( cheats.begin(), cheats.end(), '\n', ' ');
   return cheats;
 }
 
@@ -543,19 +535,12 @@ void CheatCodelist::onGenerate(void)
   }
 }
 
-void writeCheatsToFile(std::string data, const char* path) {
-  std::fstream fs;
-  fs.open(path, std::ios::binary | std::fstream::out);
-  std::stringstream str;
-  u32 value;
-  while(1) {
-    str.clear();
-    str << data.substr(0, data.find(" "));
-    str >> std::hex >> value;
-    fs.write(reinterpret_cast<char*>(&value),sizeof(value));
-    data = data.substr(data.find(" ")+1);
-    if((int)data.find(" ") == -1) break;
+void CheatCodelist::writeCheatsToFile(const char *path) {
+  FILE *file = fopen(path, "wb");
+  if(file) {
+    std::vector<u32> cheats(getCheats());
+    fwrite(cheats.data(),4,cheats.size(),file);
+    fwrite("\0\0\0\xCF",4,1,file);
+    fclose(file);
   }
-  fs.write("\0\0\0\xCF", 4);
-  fs.close();
 }

--- a/romsel_r4theme/arm9/source/cheat.h
+++ b/romsel_r4theme/arm9/source/cheat.h
@@ -6,8 +6,6 @@
 #include <vector>
 #include <nds.h>
 
-void writeCheatsToFile(std::string data, const char* path);
-
 class CheatCodelist
 {
 public:
@@ -47,7 +45,7 @@ public:
       public:
         std::string _title;
         std::string _comment;
-        std::string _cheat;
+        std::vector<u32> _cheat;
         u32 _flags;
         u32 _offset;
         cParsedItem(const std::string& title,const std::string& comment,u32 flags,u32 offset=0):_title(title),_comment(comment),_flags(flags),_offset(offset) {};
@@ -64,8 +62,9 @@ public:
     std::vector<cParsedItem> _data;
     std::vector<size_t> _indexes;
   public:
-    std::string getCheats();
-  
+    std::vector<u32> getCheats();
+    void writeCheatsToFile(const char* path);
+
 private:
   enum TOKEN_TYPE {TOKEN_DATA, TOKEN_TAG_START, TOKEN_TAG_END, TOKEN_TAG_SINGLE};
 

--- a/romsel_r4theme/arm9/source/graphics/graphics.cpp
+++ b/romsel_r4theme/arm9/source/graphics/graphics.cpp
@@ -20,7 +20,6 @@
 
 #include <nds.h>
 #include <maxmod9.h>
-#include <fstream>
 #include <gl2d.h>
 #include "graphics/lodepng.h"
 #include "bios_decompress_callback.h"

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1755,7 +1755,7 @@ int main(int argc, char **argv) {
 												     crc32, cheatOffset,
 												     cheatSize)) {
 										codelist.parse(path);
-										writeCheatsToFile(codelist.getCheats(), cheatDataBin);
+										codelist.writeCheatsToFile(cheatDataBin);
 										FILE* cheatData=fopen(cheatDataBin,"rb");
 										if (cheatData) {
 											u32 check[2];


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- I noticed this was using fstreams which adds ~300KB to the binary for no reason, so this just switches to normal `FILE *`s, saving like 1MB between all the places it was used
- Also makes it not convert from u32 to string and back for no reason

#### Where have you tested it?

- DSi (K) from internal SD with DSi and R4 themes and the DS classic menu, the Acekard theme did compile past the cheats but then hit errors elsewhere and it's disabled anyways so it's not tested, I did update it though

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
