### PR TITLE
Fix manual text and glitching on page load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,7 @@ thumbs.db
 !/7zfile/Flashcard users/Autoboot/*/*.NDS
 !/7zfile/Flashcard users/Autoboot/*/*/*.NDS
 !/7zfile/Flashcard users/Flashcart Loader/*/*/*.NDS
-manual/nitrofiles/pages/*/*
-!manual/nitrofiles/pages/english/*.ini
-manual/resources/server.pid
+manual/nitrofiles/pages
 
 # Build Directory
 build/

--- a/manual/arm9/source/graphics/FontGraphic.cpp
+++ b/manual/arm9/source/graphics/FontGraphic.cpp
@@ -272,13 +272,13 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 		}
 
 		// Don't draw off screen chars
-		if(x >= 0 && x < 256 && y >= 0 && y < 192 - tileHeight) {
+		if(x >= 0 && x + fontWidths[(index * 3) + 2] < 256 && y >= 0 && y + tileHeight < 192) {
 			u8 *dst = textBuf[top] + x + fontWidths[(index * 3)];
 			for(int i = 0; i < tileHeight; i++) {
 				for(int j = 0; j < tileWidth; j++) {
 					u8 px = fontTiles[(index * tileSize) + (i * tileWidth + j) / 4] >> ((3 - ((i * tileWidth + j) % 4)) * 2) & 3;
 					if(px)
-						dst[(y + i) * 256 + j] = px;
+						dst[(y + i) * 256 + j] = px + 0xF8;
 				}
 			}
 		}

--- a/manual/arm9/source/graphics/graphics.cpp
+++ b/manual/arm9/source/graphics/graphics.cpp
@@ -156,12 +156,7 @@ void pageLoad(const std::string &filename) {
 
 	dmaCopyWordsAsynch(0, pageImage.data(), bgGetGfxPtr(bg3Main)+(8*256), 176*256);
 	dmaCopyWordsAsynch(1, pageImage.data()+(176*256), bgGetGfxPtr(bg3Sub), 192*256);
-
-	pageImage.resize(pageImage.size() + 256 * 192);
-	for(int i=0;i<192;i++) {
-		if(i%2)	dmaFillHalfWords(bgColor1 | bgColor1 << 8, pageImage.data()+(pageYsize*256)+(i*256), 256);
-		else	dmaFillHalfWords(bgColor2 | bgColor2 << 8, pageImage.data()+(pageYsize*256)+(i*256), 256);
-	}
+	while (dmaBusy(0) || dmaBusy(1));
 }
 
 void pageScroll(void) {

--- a/manual/arm9/source/main.cpp
+++ b/manual/arm9/source/main.cpp
@@ -468,7 +468,7 @@ int main(int argc, char **argv) {
 			pageScroll();
 		} else if (held & KEY_DOWN) {
 			pageYpos += 4;
-			if (pageYpos > pageYsize-176) pageYpos = pageYsize-176;
+			if (pageYpos > pageYsize-368) pageYpos = pageYsize-368;
 			pageScroll();
 		} else if (repeat & KEY_LEFT) {
 			if(currentPage > 0) {
@@ -509,8 +509,8 @@ int main(int argc, char **argv) {
 								pageYpos = 0;
 								pageScroll();
 								break;
-							} else if (pageYpos > (pageYsize-176)) {
-								pageYpos = pageYsize-176;
+							} else if (pageYpos > (pageYsize-368)) {
+								pageYpos = pageYsize-368;
 								pageScroll();
 								break;
 							}
@@ -534,7 +534,7 @@ int main(int argc, char **argv) {
 						}
 					}
 
-					if(((pageYpos + touchStart.py - touch.py) > 0) && ((pageYpos + touchStart.py - touch.py) < (pageYsize - 176)))
+					if(((pageYpos + touchStart.py - touch.py) > 0) && ((pageYpos + touchStart.py - touch.py) < (pageYsize - 368)))
 						pageYpos += touchStart.py - touch.py;
 					pageScroll();
 
@@ -545,7 +545,7 @@ int main(int argc, char **argv) {
 			} else {
 				for(uint i=0;i<manPageLinks.size();i++) {
 					if(((touchStart.px >= manPageLinks[i].x) && (touchStart.px <= (manPageLinks[i].x + manPageLinks[i].w))) &&
-						(((touchStart.py + pageYpos) >= manPageLinks[i].y - 176) && ((touchStart.py + pageYpos) <= (manPageLinks[i].y - 176 + manPageLinks[i].h)))) {
+						(((touchStart.py + pageYpos) >= manPageLinks[i].y - 368) && ((touchStart.py + pageYpos) <= (manPageLinks[i].y - 368 + manPageLinks[i].h)))) {
 						pageYpos = 0;
 						returnPage = currentPage;
 						for(uint j=0;j<manPagesList.size();j++) {

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
@@ -272,7 +272,7 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 		}
 
 		// Don't draw off screen chars
-		if(x >= 0 && x < 256 && y >= 0 && y < 192 - tileHeight) {
+		if(x >= 0 && x + fontWidths[(index * 3) + 2] < 256 && y >= 0 && y + tileHeight < 192) {
 			u8 *dst = textBuf[top] + x + fontWidths[(index * 3)];
 			for(int i = 0; i < tileHeight; i++) {
 				for(int j = 0; j < tileWidth; j++) {

--- a/settings/arm9/source/graphics/FontGraphic.cpp
+++ b/settings/arm9/source/graphics/FontGraphic.cpp
@@ -272,7 +272,7 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 		}
 
 		// Don't draw off screen chars
-		if(x >= 0 && x < 256 && y >= 0 && y < 192 - tileHeight) {
+		if(x >= 0 && x + fontWidths[(index * 3) + 2] < 256 && y >= 0 && y + tileHeight < 192) {
 			u8 *dst = textBuf[top] + x + fontWidths[(index * 3)];
 			for(int i = 0; i < tileHeight; i++) {
 				for(int j = 0; j < tileWidth; j++) {


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes the manual text using the wrong palette and it glitching on page load
  - Fixes #1302 
- For some reason the freezing seems to have been caused by expanding the image vector and I couldn't get it to work properly while expanding so I just made it so that you can't scroll all the way onto the top screen
- Also fixes text being able to print 1 char past the edge of the screen in all places using the new text rendering

#### Where have you tested it?

- DSi (K) from internal SD and Acekard 2i

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
