### PR TITLE
Don't show ._ files in the settings lists and a bit of other minor cleanup

### DIFF
--- a/quickmenu/arm9/source/common/dsimenusettings.cpp
+++ b/quickmenu/arm9/source/common/dsimenusettings.cpp
@@ -21,7 +21,6 @@ TWLSettings::TWLSettings()
 	gbar2DldiAccess = false;
     showMainMenu = true;
     theme = 0;
-    subtheme = 0;
     dsiMusic = 1;
 
 	showNds = true;
@@ -124,7 +123,6 @@ void TWLSettings::loadSettings()
 
     showMainMenu = settingsini.GetInt("SRLOADER", "SHOW_MAIN_MENU", showMainMenu);
     theme = settingsini.GetInt("SRLOADER", "THEME", theme);
-    subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", subtheme);
     dsiMusic = settingsini.GetInt("SRLOADER", "DSI_MUSIC", dsiMusic);
     updateRecentlyPlayedList = settingsini.GetInt("SRLOADER", "UPDATE_RECENTLY_PLAYED_LIST", updateRecentlyPlayedList);
     sortMethod = settingsini.GetInt("SRLOADER", "SORT_METHOD", sortMethod);
@@ -204,7 +202,6 @@ void TWLSettings::saveSettings()
     settingsini.SetInt("SRLOADER", "SECONDARY_ACCESS", secondaryAccess);
     settingsini.SetInt("SRLOADER", "SHOW_MAIN_MENU", showMainMenu);
     settingsini.SetInt("SRLOADER", "THEME", theme);
-    settingsini.SetInt("SRLOADER", "SUB_THEME", subtheme);
     settingsini.SetInt("SRLOADER", "DSI_MUSIC", dsiMusic);
 	settingsini.SetInt("SRLOADER", "SHOW_NDS", showNds);
 	settingsini.SetInt("SRLOADER", "SHOW_RVID", showRvid);

--- a/quickmenu/arm9/source/common/dsimenusettings.h
+++ b/quickmenu/arm9/source/common/dsimenusettings.h
@@ -147,7 +147,6 @@ class TWLSettings
     bool gbar2DldiAccess;
     bool showMainMenu;
     int theme;
-    int subtheme;
     int dsiMusic;
     bool showNds;
     bool showRvid;

--- a/quickmenu/arm9/source/graphics/graphics.cpp
+++ b/quickmenu/arm9/source/graphics/graphics.cpp
@@ -94,7 +94,6 @@ extern bool isDSPhat(void);
 extern bool sdFound(void);
 extern bool flashcardFound(void);
 extern int theme;
-extern int subtheme;
 extern int consoleModel;
 extern bool cardEjected;
 

--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -174,7 +174,6 @@ bool dlplayReboot = false;
 bool sdRemoveDetect = true;
 bool gbar2DldiAccess = false;	// false == ARM9, true == ARM7
 int theme = 0;
-int subtheme = 0;
 int showGba = 2;
 int showMd = 3;
 int cursorPosition[2] = {0};
@@ -221,7 +220,6 @@ void LoadSettings(void) {
 	sdRemoveDetect = settingsini.GetInt("SRLOADER", "SD_REMOVE_DETECT", 1);
 	gbar2DldiAccess = settingsini.GetInt("SRLOADER", "GBAR2_DLDI_ACCESS", gbar2DldiAccess);
 	theme = settingsini.GetInt("SRLOADER", "THEME", 0);
-	subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", 0);
 	showDirectories = settingsini.GetInt("SRLOADER", "SHOW_DIRECTORIES", 1);
 	showBoxArt = settingsini.GetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
 	animateDsiIcons = settingsini.GetInt("SRLOADER", "ANIMATE_DSI_ICONS", 0);
@@ -287,7 +285,6 @@ void SaveSettings(void) {
 		settingsini.SetInt("SRLOADER", "HOMEBREW_HAS_WIDE", homebrewHasWide);
 	}
 	//settingsini.SetInt("SRLOADER", "THEME", theme);
-	//settingsini.SetInt("SRLOADER", "SUB_THEME", subtheme);
 	settingsini.SaveIniFile(settingsinipath);
 }
 

--- a/romsel_aktheme/arm9/source/common/dsimenusettings.cpp
+++ b/romsel_aktheme/arm9/source/common/dsimenusettings.cpp
@@ -27,7 +27,6 @@ TWLSettings::TWLSettings()
     gbar2DldiAccess = false;
     showMicroSd = false;
     theme = 0;
-    subtheme = 0;
 
     showNds = true;
     showRvid = true;
@@ -131,7 +130,6 @@ void TWLSettings::loadSettings()
     fcSaveOnSd = settingsini.GetInt("SRLOADER", "FC_SAVE_ON_SD", fcSaveOnSd);
 
     theme = settingsini.GetInt("SRLOADER", "THEME", theme);
-    subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", subtheme);
     showDirectories = settingsini.GetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);
     showHidden = settingsini.GetInt("SRLOADER", "SHOW_HIDDEN", showHidden);
     showBoxArt = settingsini.GetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
@@ -202,7 +200,6 @@ void TWLSettings::saveSettings()
         settingsini.SetInt("SRLOADER", "SECONDARY_DEVICE", secondaryDevice);
     }
     settingsini.SetInt("SRLOADER", "THEME", theme);
-    settingsini.SetInt("SRLOADER", "SUB_THEME", subtheme);
     settingsini.SetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);
     settingsini.SetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
     settingsini.SetInt("SRLOADER", "ANIMATE_DSI_ICONS", animateDsiIcons);

--- a/romsel_aktheme/arm9/source/common/dsimenusettings.h
+++ b/romsel_aktheme/arm9/source/common/dsimenusettings.h
@@ -130,7 +130,6 @@ class TWLSettings
     bool gbar2DldiAccess;
     bool showMicroSd;
     int theme;
-    int subtheme;
     bool showNds;
     bool showRvid;
     bool showA26;

--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
@@ -37,7 +37,6 @@ TWLSettings::TWLSettings()
 	gbar2DldiAccess = false;
 	showSelectMenu = false;
 	theme = 0;
-	subtheme = 0;
 	dsiMusic = 1;
 	boxArtColorDeband = true;
 
@@ -176,7 +175,6 @@ void TWLSettings::loadSettings()
 	
 	showSelectMenu = settingsini.GetInt("SRLOADER", "SHOW_SELECT_MENU", showSelectMenu);
 	theme = settingsini.GetInt("SRLOADER", "THEME", theme);
-	subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", subtheme);
 	dsiMusic = settingsini.GetInt("SRLOADER", "DSI_MUSIC", dsiMusic);
 	boxArtColorDeband = settingsini.GetInt("SRLOADER", "PHOTO_BOXART_COLOR_DEBAND", boxArtColorDeband);
 	showDirectories = settingsini.GetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);

--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.h
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.h
@@ -168,7 +168,6 @@ public:
 	bool gbar2DldiAccess;
 	bool showSelectMenu;
 	int theme;
-	int subtheme;
 	int dsiMusic;
 	bool boxArtColorDeband;
 	bool showNds;

--- a/romsel_r4theme/arm9/source/graphics/fontHandler.cpp
+++ b/romsel_r4theme/arm9/source/graphics/fontHandler.cpp
@@ -35,7 +35,6 @@
 #include "TextPane.h"
 
 extern int theme;
-extern int subtheme;
 
 using namespace std;
 

--- a/romsel_r4theme/arm9/source/graphics/graphics.cpp
+++ b/romsel_r4theme/arm9/source/graphics/graphics.cpp
@@ -72,7 +72,6 @@ extern bool startMenu;
 
 extern bool dsiWareList;
 extern int theme;
-extern int subtheme;
 extern int cursorPosition;
 extern int dsiWare_cursorPosition;
 extern int startMenu_cursorPosition;

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -145,7 +145,6 @@ bool wideScreen = false;
 bool sdRemoveDetect = true;
 bool gbar2DldiAccess = false;	// false == ARM9, true == ARM7
 int theme = 0;
-int subtheme = 0;
 int cursorPosition[2] = {0};
 int startMenu_cursorPosition = 0;
 int pagenum[2] = {0};
@@ -224,7 +223,6 @@ void LoadSettings(void) {
 	gbar2DldiAccess = settingsini.GetInt("SRLOADER", "GBAR2_DLDI_ACCESS", gbar2DldiAccess);
 	showMicroSd = settingsini.GetInt("SRLOADER", "SHOW_MICROSD", showMicroSd);
 	theme = settingsini.GetInt("SRLOADER", "THEME", 0);
-	subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", 0);
 	showDirectories = settingsini.GetInt("SRLOADER", "SHOW_DIRECTORIES", 1);
 	showHidden = settingsini.GetInt("SRLOADER", "SHOW_HIDDEN", 0);
     preventDeletion = settingsini.GetInt("SRLOADER", "PREVENT_ROM_DELETION", preventDeletion);
@@ -316,7 +314,6 @@ void SaveSettings(void) {
 		settingsini.SetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
 	}
 	//settingsini.SetInt("SRLOADER", "THEME", theme);
-	//settingsini.SetInt("SRLOADER", "SUB_THEME", subtheme);
 	settingsini.SaveIniFile(settingsinipath);
 }
 

--- a/settings/arm9/source/common/dsimenusettings.cpp
+++ b/settings/arm9/source/common/dsimenusettings.cpp
@@ -29,7 +29,6 @@ TWLSettings::TWLSettings()
     showMainMenu = false;
     showSelectMenu = false;
     theme = 0;
-    subtheme = 0;
     settingsMusic = -1;
     dsiMusic = 1;
 	boxArtColorDeband = true;
@@ -167,7 +166,6 @@ void TWLSettings::loadSettings()
     showMainMenu = settingsini.GetInt("SRLOADER", "SHOW_MAIN_MENU", showMainMenu);
     showSelectMenu = settingsini.GetInt("SRLOADER", "SHOW_SELECT_MENU", showSelectMenu);
     theme = settingsini.GetInt("SRLOADER", "THEME", theme);
-    subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", subtheme);
     settingsMusic = settingsini.GetInt("SRLOADER", "SETTINGS_MUSIC", settingsMusic);
     dsiMusic = settingsini.GetInt("SRLOADER", "DSI_MUSIC", dsiMusic);
 	boxArtColorDeband = settingsini.GetInt("SRLOADER", "PHOTO_BOXART_COLOR_DEBAND", boxArtColorDeband);
@@ -266,7 +264,6 @@ void TWLSettings::saveSettings()
     settingsini.SetInt("SRLOADER", "SHOW_MAIN_MENU", showMainMenu);
     settingsini.SetInt("SRLOADER", "SHOW_SELECT_MENU", showSelectMenu);
     settingsini.SetInt("SRLOADER", "THEME", theme);
-    settingsini.SetInt("SRLOADER", "SUB_THEME", subtheme);
     settingsini.SetInt("SRLOADER", "SETTINGS_MUSIC", settingsMusic);
     settingsini.SetInt("SRLOADER", "DSI_MUSIC", dsiMusic);
 	settingsini.SetInt("SRLOADER", "PHOTO_BOXART_COLOR_DEBAND", boxArtColorDeband);

--- a/settings/arm9/source/common/dsimenusettings.h
+++ b/settings/arm9/source/common/dsimenusettings.h
@@ -141,7 +141,6 @@ class TWLSettings
     bool showMainMenu;
     bool showSelectMenu;
     int theme;
-    int subtheme;
     int settingsMusic;
     int dsiMusic;
 	bool boxArtColorDeband;

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -202,7 +202,7 @@ void loadDSiThemeList()
 			// Reallocation here, but prevents our vector from being filled with
 
 			themeDir = ent->d_name;
-			if (themeDir == ".." || themeDir == "..." || themeDir == ".") continue;
+			if (themeDir == ".." || themeDir == "..." || themeDir == "." || themeDir.substr(0, 2) == "._") continue;
 
 			dsiThemeList.emplace_back(themeDir);
 		}
@@ -224,7 +224,7 @@ void load3DSThemeList()
 			// Reallocation here, but prevents our vector from being filled with
 
 			themeDir = ent->d_name;
-			if (themeDir == ".." || themeDir == "..." || themeDir == ".") continue;
+			if (themeDir == ".." || themeDir == "..." || themeDir == "." || themeDir.substr(0, 2) == "._") continue;
 
 			_3dsThemeList.emplace_back(themeDir);
 		}
@@ -246,7 +246,7 @@ void loadAkThemeList()
 			// Reallocation here, but prevents our vector from being filled with
 
 			themeDir = ent->d_name;
-			if (themeDir == ".." || themeDir == "..." || themeDir == ".") continue;
+			if (themeDir == ".." || themeDir == "..." || themeDir == "." || themeDir.substr(0, 2) == "._") continue;
 
 			akThemeList.emplace_back(themeDir);
 		}
@@ -267,7 +267,7 @@ void loadR4ThemeList()
 			// Reallocation here, but prevents our vector from being filled with
 
 			themeDir = ent->d_name;
-			if (themeDir == ".." || themeDir == "..." || themeDir == ".") continue;
+			if (themeDir == ".." || themeDir == "..." || themeDir == "." || themeDir.substr(0, 2) == "._") continue;
 
 			r4ThemeList.emplace_back(themeDir);
 		}
@@ -288,7 +288,7 @@ void loadUnlaunchBgList()
 			// Reallocation here, but prevents our vector from being filled with
 
 			themeDir = ent->d_name;
-			if (themeDir == ".." || themeDir == "..." || themeDir == ".") continue;
+			if (themeDir == ".." || themeDir == "..." || themeDir == "." || themeDir.substr(0, 2) == "._") continue;
 
 			if (extention(themeDir, ".gif")) {
 				unlaunchBgList.emplace_back(themeDir);
@@ -302,7 +302,7 @@ void loadFontList()
 {
 	DIR *dir;
 	struct dirent *ent;
-	std::string themeDir;
+	std::string fontDir;
 	if ((dir = opendir(FONT_DIRECTORY)) != NULL)
 	{
 		// print all the files and directories within directory
@@ -310,10 +310,10 @@ void loadFontList()
 		{
 			// Reallocation here, but prevents our vector from being filled with
 
-			themeDir = ent->d_name;
-			if (themeDir == ".." || themeDir == "..." || themeDir == ".") continue;
+			fontDir = ent->d_name;
+			if (fontDir == ".." || fontDir == "..." || fontDir == "." || fontDir.substr(0, 2) == "._") continue;
 
-			fontList.emplace_back(themeDir);
+			fontList.emplace_back(fontDir);
 		}
 		closedir(dir);
 	}
@@ -332,7 +332,7 @@ void loadGbaBorderList()
 			// Reallocation here, but prevents our vector from being filled with
 
 			themeDir = ent->d_name;
-			if (themeDir == ".." || themeDir == "..." || themeDir == ".") continue;
+			if (themeDir == ".." || themeDir == "..." || themeDir == "." || themeDir.substr(0, 2) == "._") continue;
 
 			if (extention(themeDir, ".png")) {
 				gbaBorderList.emplace_back(themeDir);
@@ -354,7 +354,7 @@ void loadMenuSrldrList (const char* dirPath) {
 			// Reallocation here, but prevents our vector from being filled with
 
 			srldrDir = ent->d_name;
-			if (srldrDir == ".." || srldrDir == "..." || srldrDir == ".") continue;
+			if (srldrDir == ".." || srldrDir == "..." || srldrDir == "." || srldrDir.substr(0, 2) == "._") continue;
 
 			if (extention(srldrDir, "menu.srldr")) {
 				menuSrldrList.emplace_back(srldrDir);
@@ -381,17 +381,17 @@ std::optional<Option> opt_subtheme_select(Option::Int &optVal)
 	}
 }
 
-std::optional<Option> opt_gba_border_select(Option::Int &optVal)
+std::optional<Option> opt_gba_border_select(void)
 {
 	return Option(STR_BORDERSEL_GBA, STR_AB_SETBORDER, Option::Str(&ms().gbaBorder), gbaBorderList);
 }
 
-std::optional<Option> opt_bg_select(Option::Int &optVal)
+std::optional<Option> opt_bg_select(void)
 {
 	return Option(STR_BGSEL_UNLAUNCH, STR_AB_SETBG, Option::Str(&ms().unlaunchBg), unlaunchBgList);
 }
 
-std::optional<Option> opt_font_select(Option::Int &optVal)
+std::optional<Option> opt_font_select(void)
 {
 	return Option(STR_FONTSEL, STR_AB_SETFONT, Option::Str(&ms().font), fontList);
 }
@@ -581,13 +581,6 @@ void defaultExitHandler()
 	}
 	loadROMselect();
 }
-void opt_reset_subtheme(int prev, int next)
-{
-	if (prev != next)
-	{
-		ms().subtheme = 0;
-	}
-}
 
 void opt_reboot_system_menu()
 {
@@ -742,7 +735,7 @@ int main(int argc, char **argv)
 		// Theme
 		.option(STR_THEME,
 				STR_DESCRIPTION_THEME_1,
-				Option::Int(&ms().theme, opt_subtheme_select, opt_reset_subtheme),
+				Option::Int(&ms().theme, opt_subtheme_select),
 				/*{STR_NINTENDO_DSI, STR_NINTENDO_3DS, STR_SEGA_SATURN, STR_HOMEBREW_LAUNCHER, STR_WOOD_UI, STR_R4_ORIGINAL},
 				{0, 1, 4, 5, 3, 2})*/
 				{STR_NINTENDO_DSI, STR_NINTENDO_3DS, STR_SEGA_SATURN, STR_HOMEBREW_LAUNCHER, STR_R4_ORIGINAL, "GameBoy Color"},
@@ -759,7 +752,7 @@ int main(int argc, char **argv)
 				{0, 1, 2, 3, 4, 5})
 		.option(STR_FONT,
 				STR_DESCRIPTION_FONT,
-				Option::Int(&ms().subtheme, opt_font_select, opt_reset_subtheme),
+				Option::Nul(opt_font_select),
 				{STR_PRESS_A},
 				{0});
 
@@ -830,7 +823,7 @@ int main(int argc, char **argv)
 		gamesPage
 			.option(STR_GBABORDER,
 				STR_DESCRIPTION_GBABORDER,
-				Option::Int(&ms().subtheme, opt_gba_border_select, opt_reset_subtheme),
+				Option::Nul(opt_gba_border_select),
 				{STR_PRESS_A},
 				{0});
 	}
@@ -1163,7 +1156,7 @@ int main(int argc, char **argv)
 		unlaunchPage
 			.option(STR_BACKGROUND,
 				STR_DESCRIPTION_UNLAUNCH_BG,
-				Option::Int(&ms().subtheme, opt_bg_select, opt_reset_subtheme),
+				Option::Nul(opt_bg_select),
 				{STR_PRESS_A},
 				{0})
 			.option(STR_LAUNCHER_PATCHES,

--- a/settings/arm9/source/settingspage.h
+++ b/settings/arm9/source/settingspage.h
@@ -399,17 +399,17 @@ public:
     {
       return *action;
     }
-    if (auto action = std::get_if<Int>(&_action))
+    else if (auto action = std::get_if<Int>(&_action))
     {
       return *action;
     }
-    if (auto action = std::get_if<Str>(&_action))
+    else if (auto action = std::get_if<Str>(&_action))
     {
       return *action;
     }
-    if (auto action = std::get_if<Nul>(&_action))
+    else
     {
-      return *action;
+      return *std::get_if<Nul>(&_action);
     }
   }
 
@@ -450,6 +450,10 @@ public:
             return i;
         }
       }
+    }
+    if (std::get_if<Nul>(&action()))
+    {
+      return 0;
     }
     return -1;
   }

--- a/title/arm9/source/common/dsimenusettings.cpp
+++ b/title/arm9/source/common/dsimenusettings.cpp
@@ -26,7 +26,6 @@ TWLSettings::TWLSettings()
     useGbarunner = false;
     showMainMenu = false;
     theme = 0;
-    subtheme = 0;
 
 	showGba = 1 + isDSiMode();
 	showMd = 3;
@@ -121,7 +120,6 @@ void TWLSettings::loadSettings()
    	romPath[1] = settingsini.GetString("SRLOADER", "SECONDARY_ROM_PATH", romPath[1]);
     showMainMenu = settingsini.GetInt("SRLOADER", "SHOW_MAIN_MENU", showMainMenu);
     theme = settingsini.GetInt("SRLOADER", "THEME", theme);
-    subtheme = settingsini.GetInt("SRLOADER", "SUB_THEME", subtheme);
     showDirectories = settingsini.GetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);
     showBoxArt = settingsini.GetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
     animateDsiIcons = settingsini.GetInt("SRLOADER", "ANIMATE_DSI_ICONS", animateDsiIcons);
@@ -190,7 +188,6 @@ void TWLSettings::saveSettings()
     settingsini.SetInt("SRLOADER", "SECONDARY_ACCESS", secondaryAccess);
     settingsini.SetInt("SRLOADER", "SHOW_MAIN_MENU", showMainMenu);
     settingsini.SetInt("SRLOADER", "THEME", theme);
-    settingsini.SetInt("SRLOADER", "SUB_THEME", subtheme);
     settingsini.SetInt("SRLOADER", "SHOW_DIRECTORIES", showDirectories);
     settingsini.SetInt("SRLOADER", "SHOW_BOX_ART", showBoxArt);
     settingsini.SetInt("SRLOADER", "ANIMATE_DSI_ICONS", animateDsiIcons);

--- a/title/arm9/source/common/dsimenusettings.h
+++ b/title/arm9/source/common/dsimenusettings.h
@@ -140,7 +140,6 @@ class TWLSettings
     bool useGbarunner;
     bool showMainMenu;
     int theme;
-    int subtheme;
 	int showGba;
     int showMd;
     bool showDirectories;


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes macOS's annoying `._` files not be shown in the fonts, skins, etc lists in settings
- Also a bit of other minor things that I felt like cleaning up but shouldn't actually have any affect on usage
   - Makes the fonts, gba borders, and unlaunch background options use `Option::Nul` instead of having some unused subtheme leftovers in there
   - To make this work, made Option::Nul return a selection of `0` instead of `-1` so it actually shows the label if there is one, shouldn't break anything if there isn't I don't think
   - Fixes the Wreturn-type warning in settings by using else on Option::Nul since that's the only warning in all of settings and there's only those four types so it shouldn't break anything
   - Removes everything related to the `subtheme` setting and the already unused function to clear it as it was removed and replaced by separate ones for each theme a while ago

#### Where have you tested it?

- Tested on DSi (K) from internal SD and Acekard 2i

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
