### PR TITLE
Fix 2nd frame of tttstc being shown sometimes and make START always skip the splash

### DIFF
--- a/booter/Makefile
+++ b/booter/Makefile
@@ -118,7 +118,7 @@ endif
  
 export GAME_TITLE := $(TARGET)
 
-.PHONY: bootloader bootstub clean arm7/$(TARGET).elf arm9/$(TARGET).elf
+.PHONY: bootloader bootstub clean
 
 all:	bootloader bootstub $(TARGET).nds $(TARGET)_rungame.nds
 

--- a/title/arm9/source/bootsplash.cpp
+++ b/title/arm9/source/bootsplash.cpp
@@ -98,14 +98,13 @@ void bootSplashDSi(void) {
 	}
 	Gif healthSafety(path, false, true);
 
-	timerStart(0, ClockDivider_1024, TIMER_FREQ_1024(100), Gif::timerHandler);
-
 	// For the default splashes, draw first frame, then wait until the top is done
 	if(!custom) {
-		while(healthSafety.currentFrame() == 0)
-			swiWaitForVBlank();
+		healthSafety.displayFrame();
 		healthSafety.pause();
 	}
+
+	timerStart(0, ClockDivider_1024, TIMER_FREQ_1024(100), Gif::timerHandler);
 
 	if (cartInserted && !custom) {
 		u16 *gfx[2];
@@ -176,10 +175,11 @@ void bootSplashDSi(void) {
 			scanKeys();
 		}
 	} else {
-		while (!(splash.finished() && healthSafety.finished())) {
+		u16 pressed = 0;
+		while (!(splash.finished() && healthSafety.finished()) && !(pressed & KEY_START)) {
 			swiWaitForVBlank();
 			scanKeys();
-			u16 pressed = keysDown();
+			pressed = keysDown();
 
 			if (splash.waitingForInput()) {
 				if(!custom && healthSafety.paused())

--- a/title/arm9/source/graphics/gif.hpp
+++ b/title/arm9/source/graphics/gif.hpp
@@ -89,8 +89,6 @@ class Gif {
 
 	static void animate(bool top);
 
-	void displayFrame(void);
-
 public:
 	static void timerHandler(void);
 
@@ -101,6 +99,8 @@ public:
 	bool load(const char *path, bool top, bool animate);
 
 	Frame &frame(int frame) { return _frames[frame]; }
+
+	void displayFrame(void);
 
 	bool paused() { return _paused; }
 	void pause() { _paused = true; }


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes the second frame of the touch the touch screen to continue gif sometimes being shown before pausing (notable on English without the H&S, I never noticed because the Japanese gifs weren't doing it)
- Makes START always skip the splash, regardless of if it's done or not. The other buttons all still behave the same and will resume from the user input flag without skipping
- Also fixes the booter Makefile being weird due to having the elf's in `.PHONY`, as noticed by urmum_69 on Discord

#### Where have you tested it?

- DSi (K) from internal SD and DSTT

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
