### PR TITLE
Fix punctuation after LTR at end of line

### DIFF
--- a/manual/arm9/source/graphics/FontGraphic.cpp
+++ b/manual/arm9/source/graphics/FontGraphic.cpp
@@ -248,11 +248,13 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 			// If on an RTL char right now, add one
 			if(*it >= 0x0590 && *it <= 0x05FF) {
 				it++;
-				// And skip all punctuation at the end if not at beginning
-				while(*it < '0' || (*it > '9' && *it < 'A') || (*it > 'Z' && *it < 'a') || (*it > 'z' && *it < 127)) {
-					it++;
+			}
+
+			// Skip all punctuation at the end
+			while(*it < '0' || (*it > '9' && *it < 'A') || (*it > 'Z' && *it < 'a') || (*it > 'z' && *it < 127)) {
+				if(it != text.begin())
 					ltrBegin++;
-				}
+				it++;
 			}
 			rtl = false;
 		}

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
@@ -248,11 +248,13 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 			// If on an RTL char right now, add one
 			if(*it >= 0x0590 && *it <= 0x05FF) {
 				it++;
-				// And skip all punctuation at the end if not at beginning
-				while(*it < '0' || (*it > '9' && *it < 'A') || (*it > 'Z' && *it < 'a') || (*it > 'z' && *it < 127)) {
-					it++;
+			}
+
+			// Skip all punctuation at the end
+			while(*it < '0' || (*it > '9' && *it < 'A') || (*it > 'Z' && *it < 'a') || (*it > 'z' && *it < 127)) {
+				if(it != text.begin())
 					ltrBegin++;
-				}
+				it++;
 			}
 			rtl = false;
 		}

--- a/settings/arm9/source/graphics/FontGraphic.cpp
+++ b/settings/arm9/source/graphics/FontGraphic.cpp
@@ -248,11 +248,13 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 			// If on an RTL char right now, add one
 			if(*it >= 0x0590 && *it <= 0x05FF) {
 				it++;
-				// And skip all punctuation at the end if not at beginning
-				while(*it < '0' || (*it > '9' && *it < 'A') || (*it > 'Z' && *it < 'a') || (*it > 'z' && *it < 127)) {
-					it++;
+			}
+
+			// Skip all punctuation at the end
+			while(*it < '0' || (*it > '9' && *it < 'A') || (*it > 'Z' && *it < 'a') || (*it > 'z' && *it < 127)) {
+				if(it != text.begin())
 					ltrBegin++;
-				}
+				it++;
 			}
 			rtl = false;
 		}


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

For some reason I made punctuation at the end of a line after LTR be ignored when it should be processed in RTL

#### Where have you tested it?

- no$gba

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
