### PR TITLE
Add RLM and LRM support

### DIFF
--- a/manual/arm9/source/graphics/FontGraphic.h
+++ b/manual/arm9/source/graphics/FontGraphic.h
@@ -13,6 +13,9 @@ enum class Alignment {
 
 class FontGraphic {
 private:
+	static bool isStrongRTL(char16_t c);
+	static bool isWeak(char16_t c);
+
 	u8 tileWidth, tileHeight;
 	u16 tileSize;
 	u16 questionMark = 0;

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
@@ -13,6 +13,9 @@ enum class Alignment {
 
 class FontGraphic {
 private:
+	static bool isStrongRTL(char16_t c);
+	static bool isWeak(char16_t c);
+
 	u8 tileWidth, tileHeight;
 	u16 tileSize;
 	u16 questionMark = 0;

--- a/romsel_dsimenutheme/arm9/source/language.cpp
+++ b/romsel_dsimenutheme/arm9/source/language.cpp
@@ -62,6 +62,12 @@ std::string getString(CIniFile &ini, const std::string &item, const std::string 
 				default:
 					break;
 			}
+		} else if(out[i] == '&') {
+			if(out.substr(i + 1, 4) == "lrm;") {
+				out = out.substr(0, i) + "\u200E" + out.substr(i + 5); // Left-to-Right mark
+			} else if(out.substr(i + 1, 4) == "rlm;") {
+				out = out.substr(0, i) + "\u200F" + out.substr(i + 5); // Right-to-Left mark
+			}
 		}
 	}
 

--- a/settings/arm9/source/graphics/FontGraphic.h
+++ b/settings/arm9/source/graphics/FontGraphic.h
@@ -13,6 +13,9 @@ enum class Alignment {
 
 class FontGraphic {
 private:
+	static bool isStrongRTL(char16_t c);
+	static bool isWeak(char16_t c);
+
 	u8 tileWidth, tileHeight;
 	u16 tileSize;
 	u16 questionMark = 0;

--- a/settings/arm9/source/language.cpp
+++ b/settings/arm9/source/language.cpp
@@ -58,6 +58,12 @@ std::string getString(CIniFile &ini, const std::string &item, const std::string 
 				default:
 					break;
 			}
+		} else if(out[i] == '&') {
+			if(out.substr(i + 1, 4) == "lrm;") {
+				out = out.substr(0, i) + "\u200E" + out.substr(i + 5); // Left-to-Right mark
+			} else if(out.substr(i + 1, 4) == "rlm;") {
+				out = out.substr(0, i) + "\u200F" + out.substr(i + 5); // Right-to-Left mark
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Adds Left-to-Right Mark and Right-to-Left Mark support to the text printing for when needed to force a specific direction
    - Ex `TWiLight Menu++` in an RTL string prints as `++TWiLight Menu`, but `TWiLight Menu++&lrm;` prints as `TWiLight Menu++` because there are strong LTR chars on either side of the weak ++
- The HTML entities (`&lrm;` and `&rlm;`) can be used to avoid confusing invisible characters in the strings, though the actual characters will work too
- Currently they will display as �, but I'll update the fonts in #1326 to add them as invisible, zero-width chars
- Also move the RTL and weak char checks to functions to be a bit cleaner

#### Where have you tested it?

- DSi (K) from internal SD and DSTT

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
