### PR TITLE
Even more bidi fixes!

### DIFF
--- a/manual/arm9/source/graphics/FontGraphic.h
+++ b/manual/arm9/source/graphics/FontGraphic.h
@@ -15,6 +15,7 @@ class FontGraphic {
 private:
 	static bool isStrongRTL(char16_t c);
 	static bool isWeak(char16_t c);
+	static bool isNumber(char16_t c);
 
 	u8 tileWidth, tileHeight;
 	u16 tileSize;

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
@@ -15,6 +15,7 @@ class FontGraphic {
 private:
 	static bool isStrongRTL(char16_t c);
 	static bool isWeak(char16_t c);
+	static bool isNumber(char16_t c);
 
 	u8 tileWidth, tileHeight;
 	u16 tileSize;

--- a/romsel_dsimenutheme/arm9/source/language.cpp
+++ b/romsel_dsimenutheme/arm9/source/language.cpp
@@ -63,10 +63,10 @@ std::string getString(CIniFile &ini, const std::string &item, const std::string 
 					break;
 			}
 		} else if(out[i] == '&') {
-			if(out.substr(i + 1, 4) == "lrm;") {
-				out = out.substr(0, i) + "\u200E" + out.substr(i + 5); // Left-to-Right mark
-			} else if(out.substr(i + 1, 4) == "rlm;") {
-				out = out.substr(0, i) + "\u200F" + out.substr(i + 5); // Right-to-Left mark
+			if(out.substr(i + 1, 3) == "lrm") {
+				out = out.substr(0, i) + "\u200E" + out.substr(i + 4); // Left-to-Right mark
+			} else if(out.substr(i + 1, 3) == "rlm") {
+				out = out.substr(0, i) + "\u200F" + out.substr(i + 4); // Right-to-Left mark
 			}
 		}
 	}

--- a/settings/arm9/source/graphics/FontGraphic.h
+++ b/settings/arm9/source/graphics/FontGraphic.h
@@ -15,6 +15,7 @@ class FontGraphic {
 private:
 	static bool isStrongRTL(char16_t c);
 	static bool isWeak(char16_t c);
+	static bool isNumber(char16_t c);
 
 	u8 tileWidth, tileHeight;
 	u16 tileSize;

--- a/settings/arm9/source/language.cpp
+++ b/settings/arm9/source/language.cpp
@@ -59,10 +59,10 @@ std::string getString(CIniFile &ini, const std::string &item, const std::string 
 					break;
 			}
 		} else if(out[i] == '&') {
-			if(out.substr(i + 1, 4) == "lrm;") {
-				out = out.substr(0, i) + "\u200E" + out.substr(i + 5); // Left-to-Right mark
-			} else if(out.substr(i + 1, 4) == "rlm;") {
-				out = out.substr(0, i) + "\u200F" + out.substr(i + 5); // Right-to-Left mark
+			if(out.substr(i + 1, 3) == "lrm") {
+				out = out.substr(0, i) + "\u200E" + out.substr(i + 4); // Left-to-Right mark
+			} else if(out.substr(i + 1, 3) == "rlm") {
+				out = out.substr(0, i) + "\u200F" + out.substr(i + 4); // Right-to-Left mark
 			}
 		}
 	}


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- So it turns out that numbers are weak (doesn't affect direction) ***b u t*** the numbers *are* LTR, so they need special handling
- It was also missing the last weak char if that was the only char left
- And Crowdin was being dumb with `&lrm;` and `&rlm;` because some flavors of ini (not ours) say that `;` is a comment, so it was quoting the string... but our ini parser doesn't support quoted strings, so I've just removed the `;`s so the new escapes are just `&lrm` and `&rlm`

#### Where have you tested it?

- DSi (K) from internal SD and no$gba

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
