### PR TITLE
Show index.gif as first manual page

### DIFF
--- a/manual/arm9/source/main.cpp
+++ b/manual/arm9/source/main.cpp
@@ -431,6 +431,9 @@ int main(int argc, char **argv) {
 	}
 
 	loadPageList();
+	// Move index.gif to the start
+	std::sort(manPagesList.begin(), manPagesList.end(), [](DirEntry a, DirEntry b) {return a.name == "index.gif"; });
+
 	loadPageInfo(manPagesList[0].name.substr(0,manPagesList[0].name.length()-3) + "ini");
 	pageLoad(manPagesList[0].name);
 	topBarLoad();

--- a/manual/arm9/source/main.cpp
+++ b/manual/arm9/source/main.cpp
@@ -432,7 +432,7 @@ int main(int argc, char **argv) {
 
 	loadPageList();
 	// Move index.gif to the start
-	std::sort(manPagesList.begin(), manPagesList.end(), [](DirEntry a, DirEntry b) {return a.name == "index.gif"; });
+	std::sort(manPagesList.begin(), manPagesList.end(), [](DirEntry a, DirEntry b) { return a.name == "index.gif"; });
 
 	loadPageInfo(manPagesList[0].name.substr(0,manPagesList[0].name.length()-3) + "ini");
 	pageLoad(manPagesList[0].name);


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This just make it sort the manual pages such that `index.gif` is the first page instead of relying on an early character (`_howToUse.gif`) since this way is much nicer on the web side and just cleaner in general imo

#### Where have you tested it?

- no$gba

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
