### PR TITLE
Expand compiling info and link to manual in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,19 @@ It can launch Nintendo DS, SNES, NES, GameBoy (Color), GameBoy Advance, Sega Gam
 
 # Compiling
 
+## Setting up
+
 Compiling this app requires devkitPro's devkitARM, libnds, grit, and mmutil. These can be installed using [devkitPro pacman](https://devkitpro.org/wiki/devkitPro_pacman) with the following command:
 ```
 sudo dkp-pacman -S nds-dev
 ```
 (Note: Command will vary by OS, sudo may not be needed and it may be just `pacman` instead)
+
+## Building
+
+Once you have devkitPro's toolchains installed you can build the entirety of TWiLight Menu++ by simply running `make package` in the root of the repository. If you only want to build a specific part of TWiLight Menu++ you can `cd` to that folder and run `make dist`.
+
+Once it finishes building, the output files will be in the `7zfile` folder following the same directory structure as the official `TWiLightMenu.7z` builds.
 
 ## Using Docker
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ It can launch Nintendo DS, SNES, NES, GameBoy (Color), GameBoy Advance, Sega Gam
 
 # Compiling
 
-Compiling this app requires devkitPRO with devkitARM and libnds. Be sure you have grit and mmutil installed.
+Compiling this app requires devkitPro's devkitARM, libnds, grit, and mmutil. These can be installed using [devkitPro pacman](https://devkitpro.org/wiki/devkitPro_pacman) with the following command:
+```
+sudo dkp-pacman -S nds-dev
+```
+(Note: Command will vary by OS, sudo may not be needed and it may be just `pacman` instead)
 
 ## Using Docker
 
@@ -29,9 +33,13 @@ The script accepts `make` arguments as well. For example, `.\compile_docker.ps1 
 
 Please note that Docker compilation is not compatible with native compilation on Windows. You should run `.\compile_docker.ps1 clean` to clean the artifacts before attempting to build with Docker. If a notification appears asking you to share your drive, you must choose to enable drive sharing for Docker to work on Windows.
 
+## Manual Pages
+
+The manual pages are stored in a separate repository and downloaded from a release when building TWiLight Menu++. For more information, see the [twilight-manual](https://github.com/DS-Homebrew/twilight-manual) repository.
+
 # Translating
 
-You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.com/project/TwilightMenu). If you'd like to request a new language be added then please ask on the Discord server.
+You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.com/project/TwilightMenu). If you'd like to request a new language be added then please ask on the [Discord server](https://ds-homebrew.com/discord).
 
 # Credits
 ## Main Developers

--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -30,7 +30,7 @@ makearm9_cyclodsi:
 	cp flashcart_specifics/CycloDSi/arm9/$(TARGET).elf $(TARGET)_cyclodsi.arm9.elf
 
 dist:	all autoboot
-	mkdir -p ../7zfile/debug
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET)_fc.nds "../7zfile/Flashcard users/BOOT.NDS"
 	@cp $(TARGET)_cyclodsi.nds "../7zfile/Flashcard users/BOOT_cyclodsi.NDS"
 	@cp $(TARGET)_fc.arm7.elf ../7zfile/debug/$(TARGET)_fc.arm7.elf

--- a/gbapatcher/Makefile
+++ b/gbapatcher/Makefile
@@ -23,6 +23,7 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/gbapatcher.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -23,6 +23,7 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/manual.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/quickmenu/Makefile
+++ b/quickmenu/Makefile
@@ -23,6 +23,7 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/mainmenu.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/rebooter_fc/Makefile
+++ b/rebooter_fc/Makefile
@@ -22,6 +22,7 @@ makearm9_fc:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds "../../7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/TWLMRS.DAT"
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/romsel_aktheme/Makefile
+++ b/romsel_aktheme/Makefile
@@ -23,6 +23,7 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/akmenu.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/romsel_dsimenutheme/Makefile
+++ b/romsel_dsimenutheme/Makefile
@@ -23,6 +23,7 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/dsimenu.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/romsel_r4theme/Makefile
+++ b/romsel_r4theme/Makefile
@@ -23,6 +23,7 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/r4menu.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/rungame/Makefile
+++ b/rungame/Makefile
@@ -123,6 +123,7 @@ export GAME_TITLE := $(TARGET)
 all:	bootloader bootstub $(TARGET).nds
 	
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/resetgame.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/settings/Makefile
+++ b/settings/Makefile
@@ -23,6 +23,7 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/settings.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/slot1launch/Makefile
+++ b/slot1launch/Makefile
@@ -24,6 +24,7 @@ export VERSTRING	:=	$(VERSION_MAJOR).$(VERSION_MINOR)
 all: cardengine_arm7 bootloader bootloaderAlt $(TARGET).nds
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/slot1launch.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf

--- a/title/Makefile
+++ b/title/Makefile
@@ -23,6 +23,7 @@ makearm9:
 	cp arm9/$(TARGET).elf $(TARGET).arm9.elf
 
 dist:	all
+	@mkdir -p ../7zfile/debug
 	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/main.srldr
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This just updates the README a little bit to have more detailed info on how to build TWiLight Menu++ and to link to the manual
- It also fixes most of the Makefiles not creating `../7zfile/debug` which would cause `make dist` to fail

#### Where have you tested it?

- N/A

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
