### PR TITLE
allow YSMenu to SR to TWLMenu using r4isdhc.com cards

### DIFF
--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -118,6 +118,7 @@ autoboot:
 	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/iLL.iL"
 
 	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/_BOOT_DS.NDS"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/TTMENU.DAT"
 
 	mkdir -p "../7zfile/Flashcard users/Autoboot/R4 Deluxe v1.20/"
 	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4 Deluxe v1.20/_DS_MENU.DAT"


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

_Tell us what you've changed._

YSMenu, when using the LRABXY soft reset combo, automatically loads whatever is TTMenu.dat. For most other carts, this is fine, however, for r4isdhc.com cards and others using the Autoboot files for that same folder, either TTMenu.dat doesn't exist, or, if YSMenu was extracted, will be YSmenu instead. This would cause the SR to not load the menu, but to load the same game again, since when using YSmenu as a backend, it will load the file listed in AUTO_BOOT.

To fix this, the makefile in booter_fc now copies a DLDI patched BOOT.NDS to a new TTMenu.dat in the r4isdhc.com cards folder. Now when using LRABXY to SR when using YSMenu to load games, it will automatically load TWLMenu++ instead, as that is what that reset combo was intended as (resetting back to YSMenu).

#### Where have you tested it?

_Tell us where have you tested it._

Tested R4i Gold V1.4.1 on a DS Lite. nds-bootstrap off, with _BOOT_DS.NDS (a DLDI patched BOOT.NDS) duplicated and renamed to TTMENU.DAT.
Reset works.

*** 
#### Pull Request status
- [ ]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
