### PR TITLE
Add missing safety checks

### DIFF
--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -667,8 +667,10 @@ void SetWidescreen(const char *filename) {
 				u8 *buffer = new u8[size];
 				fread(buffer, 1, size, file);
 
-				mkdir("fat:/_nds", 0777);
-				mkdir("fat:/_nds/nds-bootstrap", 0777);
+				if (flashcardFound()) {
+					mkdir("fat:/_nds", 0777);
+					mkdir("fat:/_nds/nds-bootstrap", 0777);
+				}
 				snprintf(wideBinPath, sizeof(wideBinPath), "%s:/_nds/nds-bootstrap/wideCheatData.bin", sdFound() ? "sd" : "fat");
 				FILE *out = fopen(wideBinPath, "wb");
 				if(out) {

--- a/romsel_aktheme/arm9/source/windows/mainwnd.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainwnd.cpp
@@ -602,8 +602,10 @@ std::string apFix(const char *filename, bool isHomebrew)
 				u8 *buffer = new u8[size];
 				fread(buffer, 1, size, file);
 
-				mkdir("fat:/_nds", 0777);
-				mkdir("fat:/_nds/nds-bootstrap", 0777);
+				if (flashcardFound()) {
+					mkdir("fat:/_nds", 0777);
+					mkdir("fat:/_nds/nds-bootstrap", 0777);
+				}
 				snprintf(ipsPath, sizeof(ipsPath), "%s:/_nds/nds-bootstrap/apFix%s", sdFound() ? "sd" : "fat", cheatVer ? "Cheat.bin" : ".ips");
 				FILE *out = fopen(ipsPath, "wb");
 				if(out) {
@@ -827,8 +829,10 @@ void bootWidescreen(const char *filename, bool isHomebrew, bool useWidescreen)
 				u8 *buffer = new u8[size];
 				fread(buffer, 1, size, file);
 
-				mkdir("fat:/_nds", 0777);
-				mkdir("fat:/_nds/nds-bootstrap", 0777);
+				if (flashcardFound()) {
+					mkdir("fat:/_nds", 0777);
+					mkdir("fat:/_nds/nds-bootstrap", 0777);
+				}
 				snprintf(wideBinPath, sizeof(wideBinPath), "%s:/_nds/nds-bootstrap/wideCheatData.bin", sdFound() ? "sd" : "fat");
 				FILE *out = fopen(wideBinPath, "wb");
 				if(out) {

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -302,8 +302,10 @@ std::string setApFix(const char *filename) {
 				u8 *buffer = new u8[size];
 				fread(buffer, 1, size, file);
 
-				mkdir("fat:/_nds", 0777);
-				mkdir("fat:/_nds/nds-bootstrap", 0777);
+				if (flashcardFound()) {
+					mkdir("fat:/_nds", 0777);
+					mkdir("fat:/_nds/nds-bootstrap", 0777);
+				}
 				snprintf(ipsPath, sizeof(ipsPath), "%s:/_nds/nds-bootstrap/apFix%s", sdFound() ? "sd" : "fat", cheatVer ? "Cheat.bin" : ".ips");
 				FILE *out = fopen(ipsPath, "wb");
 				if(out) {

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -792,8 +792,10 @@ void SetWidescreen(const char *filename) {
 				u8 *buffer = new u8[size];
 				fread(buffer, 1, size, file);
 
-				mkdir("fat:/_nds", 0777);
-				mkdir("fat:/_nds/nds-bootstrap", 0777);
+				if (flashcardFound()) {
+					mkdir("fat:/_nds", 0777);
+					mkdir("fat:/_nds/nds-bootstrap", 0777);
+				}
 				snprintf(wideBinPath, sizeof(wideBinPath), "%s:/_nds/nds-bootstrap/wideCheatData.bin", sdFound() ? "sd" : "fat");
 				FILE *out = fopen(wideBinPath, "wb");
 				if(out) {


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Looks like only some of the AP fix and widescreen folder making were given safety checks so the others are still causing crashes, this should fix that

#### Where have you tested it?

- Fixed it for Nadia on Discord

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
