### PR TITLE
Make region names translatable

### DIFF
--- a/romsel_dsimenutheme/arm9/source/language.inl
+++ b/romsel_dsimenutheme/arm9/source/language.inl
@@ -153,6 +153,14 @@ STRING(JAPANESE, "Japanese")
 STRING(KOREAN, "Korean")
 STRING(SPANISH, "Spanish")
 
+// Regions
+STRING(JAPAN, "Japan")
+STRING(USA, "USA")
+STRING(EUROPE, "Europe")
+STRING(AUSTRALIA, "Australia")
+STRING(CHINA, "China")
+STRING(KOREA, "Korea")
+
 // Cheats
 STRING(CHEATS, "Cheats")
 STRING(SAVING, "Saving...")

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -663,17 +663,17 @@ void perGameSettings (std::string filename) {
 				} else if (perGameSettings_region == -1) {
 					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_SYSTEM, endAlign);
 				} else if (perGameSettings_region == 0) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "Japan", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_JAPAN, endAlign);
 				} else if (perGameSettings_region == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "USA", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_USA, endAlign);
 				} else if (perGameSettings_region == 2) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "Europe", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_EUROPE, endAlign);
 				} else if (perGameSettings_region == 3) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "Australia", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_AUSTRALIA, endAlign);
 				} else if (perGameSettings_region == 4) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "China", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_CHINA, endAlign);
 				} else if (perGameSettings_region == 5) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "Korea", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_KOREA, endAlign);
 				}
 				break;
 		}

--- a/romsel_dsimenutheme/nitrofiles/languages/en/language.ini
+++ b/romsel_dsimenutheme/nitrofiles/languages/en/language.ini
@@ -143,6 +143,13 @@ JAPANESE = Japanese
 KOREAN = Korean
 SPANISH = Spanish
 
+JAPAN = Japan
+USA = USA
+EUROPE = Europe
+AUSTRALIA = Australia
+CHINA = China
+KOREA = Korea
+
 CHEATS = Cheats
 SAVING = Saving...
 LOADING = Loading...


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes the region names translatable
- (don't bother remaking v20.0.1 for this, there won't actually be any translations yet anyways)

#### Where have you tested it?

- no$gba

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
