### PR TITLE
Remove nightly lite and don't put skins or fonts in nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,8 +66,9 @@ jobs:
           # Theme is currently unused
           rm -rf 7zfile/_nds/TWiLightMenu/akmenu
 
-          # Don't include skins in nightlies
+          # Don't include skins or fonts in nightlies
           rm -rf 7zfile/_nds/TWiLightMenu/*menu/
+          rm -rf 7zfile/_nds/TWiLightMenu/extras/fonts
 
           # Debug 7z
           mv 7zfile/debug debug

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,6 +66,9 @@ jobs:
           # Theme is currently unused
           rm -rf 7zfile/_nds/TWiLightMenu/akmenu
 
+          # Don't include skins in nightlies
+          rm -rf 7zfile/_nds/TWiLightMenu/*menu/
+
           # Debug 7z
           mv 7zfile/debug debug
           7z a TWiLightMenu-debug.7z debug
@@ -116,17 +119,6 @@ jobs:
           rm -rf TWiLightMenu/DSi\ -\ CFW\ users
           7z a TWiLightMenu-Flashcard.7z TWiLightMenu
           mv TWiLightMenu-Flashcard.7z ~/artifacts
-
-          # Delete skins for lite
-          rm -rf TWiLightMenu
-          cp -r 7zfile/ TWiLightMenu/
-          rm -rf TWiLightMenu/Debug/
-          rm -rf TWiLightMenu/_nds/TWiLightMenu/*menu/
-          rm -rf TWiLightMenu/_nds/TWiLightMenu/extras/fonts/
-          rm -rf TWiLightMenu/Flashcard\ users/Autoboot/
-          rm -rf TWiLightMenu/Flashcard\ users/Flashcart\ Loader/
-          7z a TWiLightMenu-Lite.7z TWiLightMenu/
-          mv TWiLightMenu-Lite.7z ~/artifacts
       - name: Publish build to GH Actions
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
<!--- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Since the only thing the nightly lite does now is remove skins and you don't really need those in nightlies anyways there isn't much reason for it to exist anymore now that the pck files are a thing.

Also removes the fonts as they're quite large and don't update often.

#### Where have you tested it?

- This PR, check the Checks tab once it runs

*** 
#### Pull Request status
- [x]  This PR has been tested using the provided devkitPro, devkitARM, and EasyGL2D.  
