### PR TITLE
Derp fix hotkey strings in ini

### DIFF
--- a/settings/nitrofiles/languages/en/language.ini
+++ b/settings/nitrofiles/languages/en/language.ini
@@ -327,6 +327,6 @@ AB_SETBORDER=\A / \B: Set border
 AB_SETBG=\A / \B: Set background
 AB_SETFONT=\A / \B: Set font
 
-STRING(HOLD_1S_SET, "Hold keys to set hotkey")
-STRING(TOUCH, "Touch")
-STRING(HOTKEY_SET, "Hotkey set!")
+HOLD_1S_SET=Hold keys to set hotkey
+TOUCH=Touch
+HOTKEY_SET=Hotkey set!


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Accidentally had the ini hotkey strings formatted wrong, this simply fixes that

#### Where have you tested it?

- N/A

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
