### PR TITLE
Skip loadFixedBanner if rom's animated banner is good

### DIFF
--- a/quickmenu/arm9/source/iconTitle.cpp
+++ b/quickmenu/arm9/source/iconTitle.cpp
@@ -472,6 +472,23 @@ void loadFixedBanner(bool isSlot1) {
 	/* Banner fixes start here */
 	u32 bannersize = 0;
 
+	//Check reserved area before loadFixedBanner
+	int total = 0;
+	for (int i = 0; i < 8; i++)
+	{
+		if (ndsBanner.reserved2[i] == 0)
+			total++;
+	}
+
+	for (int i = 2047; i > 2039; i--)
+	{
+		if (ndsBanner.reserved2[i] == 0)
+			total++;
+	}
+
+	if (total == 16)
+		return;
+
 	/*FILE* bannerFile = fopen("sd:/_nds/TWiLightMenu/slot1.bnr", "wb");
 	bannersize = NDS_BANNER_SIZE_ORIGINAL;
 	fwrite(&ndsBanner, 1, bannersize, bannerFile);

--- a/romsel_aktheme/arm9/source/common/fixedbanners.h
+++ b/romsel_aktheme/arm9/source/common/fixedbanners.h
@@ -4,6 +4,24 @@
 
 inline void fixBanner(sNDSBannerExt *banner)
 {
+    //Check reserved area before loadFixedBanner
+    int total = 0;
+    int i;
+    for (i = 0; i < 8; i++)
+    {
+        if (banner->reserved2[i] == 0)
+            total++;
+    }
+
+    for (i = 2047; i > 2039; i--)
+    {
+        if (banner->reserved2[i] == 0)
+            total++;
+    }
+
+    if (total == 16)
+        return;
+
     // Check for fixed banner here.
     u16 crc1 = banner->crc[0];
 	//u16 crc2 = banner->crc[1];

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -164,6 +164,23 @@ void loadFixedBanner(void) {
 	/* Banner fixes start here */
 	u32 bannersize = 0;
 
+	//Check reserved area before loadFixedBanner
+	int total = 0;
+	for (int i = 0; i < 8; i++)
+	{
+		if (ndsBanner.reserved2[i] == 0)
+			total++;
+	}
+
+	for (int i = 2047; i > 2039; i--)
+	{
+		if (ndsBanner.reserved2[i] == 0)
+			total++;
+	}
+
+	if (total == 16)
+		return;
+
 	// Alice in Wonderland (U)
 	if (ndsBanner.crc[3] == 0xB9EA) {
 		// Use fixed banner.

--- a/romsel_r4theme/arm9/source/iconTitle.cpp
+++ b/romsel_r4theme/arm9/source/iconTitle.cpp
@@ -539,6 +539,23 @@ void loadFixedBanner(void) {
 	/* Banner fixes start here */
 	u32 bannersize = 0;
 
+	//Check reserved area before loadFixedBanner
+	int total = 0;
+	for (int i = 0; i < 8; i++)
+	{
+		if (ndsBanner.reserved2[i] == 0)
+			total++;
+	}
+
+	for (int i = 2047; i > 2039; i--)
+	{
+		if (ndsBanner.reserved2[i] == 0)
+			total++;
+	}
+
+	if (total == 16)
+		return;
+
 	// Alice in Wonderland (U)
 	if (ndsBanner.crc[3] == 0xB9EA) {
 		// Use fixed banner.


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

_Check reserved area before loadFixedBanner (If animated banner is good, the unused reserved2 area should be all zerofilled)_

#### Where have you tested it?

_Tested it on DSi console (except akmenu theme)_

***

#### Pull Request status
- [√] This PR has been tested using the latest version of devkitARM and libnds.
