### PR TITLE
Re-enable manual icon in SELECT menu

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -422,7 +422,7 @@ void ThemeTextures::loadDSiTheme() {
 	_startTextTexture = std::make_unique<Texture>(TFN_GRF_START_TEXT, TFN_FALLBACK_GRF_START_TEXT);
 	_wirelessIconsTexture = std::make_unique<Texture>(TFN_GRF_WIRELESSICONS, TFN_FALLBACK_GRF_WIRELESSICONS);
 	_settingsIconTexture = std::make_unique<Texture>(TFN_GRF_ICON_SETTINGS, TFN_FALLBACK_GRF_ICON_SETTINGS);
-	//_manualIconTexture = std::make_unique<Texture>(TFN_GRF_ICON_MANUAL, TFN_FALLBACK_GRF_ICON_MANUAL);
+	_manualIconTexture = std::make_unique<Texture>(TFN_GRF_ICON_MANUAL, TFN_FALLBACK_GRF_ICON_MANUAL);
 
 	// Apply the DSi palette shifts
 	if (tc().startTextUserPalette())
@@ -461,7 +461,7 @@ void ThemeTextures::loadDSiTheme() {
 	// careful here, it's boxTexture, not boxFulltexture.
 	loadBoxfullImage(*_boxTexture);
 
-	//loadManualImage(*_manualIconTexture);
+	loadManualImage(*_manualIconTexture);
 	loadCornerButtonImage(*_cornerButtonTexture, (32 / 16) * (32 / 32), 32, 32);
 	loadSmallCartImage(*_smallCartTexture);
 	loadFolderImage(*_folderTexture);

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -1335,8 +1335,8 @@ void vBlankHandler() {
 						 &tex().smallCartImage()[3]); // GBA Mode
 					selIconYpos += 28;
 				}
-				/*glSprite(selIconXpos, (ms().theme == 4 ? 0 : dbox_Ypos) + selIconYpos, GL_FLIP_NONE,
-					 tex().manualImage());*/ // Manual
+				glSprite(selIconXpos, (ms().theme == 4 ? 0 : dbox_Ypos) + selIconYpos, GL_FLIP_NONE,
+					 tex().manualImage()); // Manual
 			}
 		}
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Re-enables the manual icon in the SELECT menu, I could never get the corruption in the first place though so please test this to see if it's fixed itself by now or I'm just lucky
- Closes #1023

#### Where have you tested it?

- DSi (K) from internal SD, DSTT, Acekard 2i, and Datel Games n' Music (Acekard 2i and Datel Games n' Music were on older version)

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
