### PR TITLE
make clean deletes Original R4 / M3 Simply autoboot files for no reason

### DIFF
--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -171,8 +171,8 @@ clean:
 	@$(MAKE) -C arm7 clean
 	@$(MAKE) -C flashcart_specifics/CycloDSi/arm7 clean
 
-	@echo Cleaning Flashcart Autobooters
-	@rm -fr "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/"
+	# echo Cleaning Flashcart Autobooters
+	# rm -fr "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/"
 
 data:
 	@mkdir -p data


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Running make clean yeets Original R4 / M3 Simply autoboot file.
Solution: found the issue in booter_fc/makefile, and commented it out. If you want me to completely delete it I can do that.

#### Where have you tested it?

uh WSL2? 

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
