### PR TITLE
Remove unused dataSize variable

### DIFF
--- a/manual/arm9/source/graphics/gif.hpp
+++ b/manual/arm9/source/graphics/gif.hpp
@@ -61,7 +61,6 @@ class Gif {
 		struct Image {
 			u8 lzwMinimumCodeSize;
 			std::vector<u8> imageData;
-			size_t dataSize;
 		} image;
 
 		std::vector<u16> lct; // In DS format

--- a/title/arm9/source/graphics/gif.hpp
+++ b/title/arm9/source/graphics/gif.hpp
@@ -60,7 +60,6 @@ class Gif {
 		struct Image {
 			u8 lzwMinimumCodeSize;
 			std::vector<u8> imageData;
-			size_t dataSize;
 		} image;
 
 		std::vector<u16> lct; // In DS format


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Was causing problems since apparently `size_t` isn't included properly in some cases and it's not actually used

#### Where have you tested it?

- macOS with latest devkitARM and such

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
