### PR TITLE
Add R4i-SDHC TTMENU.DAT to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ ipch/
 7zfile/Flashcard users/Autoboot/R4i-REDANT/Redant.dat
 7zfile/Flashcard users/Autoboot/R4IIISDHC (v3.07 kernel) & R4i SDHC Silver RTS Lite/R4.dat
 7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/_BOOT_DS.NDS
+7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/TTMENU.DAT
 
 7zfile/_nds/TWiLightMenu/extras/apfix.pck
 7zfile/_nds/TWiLightMenu/extras/widescreen.pck


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

#1413 adds a new file to 7zfile which isn't added to gitignore, so I added it. It's a petty change, but it was getting annoying.

#### Where have you tested it?

WSL2 Ubuntu 20.04

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
