### PR TITLE
Add Ace3DS+ autoboot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,8 @@ ipch/
 7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/_BOOT_DS.NDS
 7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS/TTMENU.DAT
 7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/_DS_MENU.DAT
+7zfile/Flashcard users/Autoboot/Ace3DS+, Ace3DS X/_DS_MENU.DAT
+
 7zfile/_nds/TWiLightMenu/extras/apfix.pck
 7zfile/_nds/TWiLightMenu/extras/widescreen.pck
 

--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -58,7 +58,13 @@ autoboot:
 	dlditool flashcart_specifics/DLDI/r4tfv2.dldi _DS_MENU.nds
 	r4denc _DS_MENU.nds
 	mv _DS_MENU.dat "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/_DS_MENU.DAT"
-
+	
+	#### Ace3DS+, Ace3DS X specific
+	cp booter_fc.nds _DS_MENU_ACEP.nds
+	dlditool flashcart_specifics/DLDI/ace3ds_sd.dldi _DS_MENU_ACEP.nds
+	r4denc -k 0x4002 _DS_MENU_ACEP.nds _DS_MENU.dat
+	mv _DS_MENU.dat "../7zfile/Flashcard users/Autoboot/Ace3DS+, Ace3DS X/_DS_MENU.DAT"
+	
 	#### EDGE (TODO: Find out how to encrypt the .dat file)
 	# cp booter_fc.nds EDGE.dat
 	# dlditool flashcart_specifics/DLDI/EDGEv1.0.dldi EDGE.dat


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

_Tell us what you've changed._

Because #1490 works, that means we can add autoboot files for Ace3DS+ and Ace3DS X using a different encryption key, thanks to the updated `r4denc`.

#### Where have you tested it?

_Tell us where you've tested it._
Ace3DS+

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
