### PR TITLE
Fix issue where the booter_fc makefile doesn't create a folder for new autoboots

### DIFF
--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -57,12 +57,14 @@ autoboot:
 	#### Original R4 / M3 Simply specific
 	dlditool flashcart_specifics/DLDI/r4tfv2.dldi _DS_MENU.nds
 	r4denc _DS_MENU.nds
+	mkdir "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply"
 	mv _DS_MENU.dat "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/_DS_MENU.DAT"
 	
 	#### Ace3DS+, Ace3DS X specific
 	cp booter_fc.nds _DS_MENU_ACEP.nds
 	dlditool flashcart_specifics/DLDI/ace3ds_sd.dldi _DS_MENU_ACEP.nds
 	r4denc -k 0x4002 _DS_MENU_ACEP.nds _DS_MENU.dat
+	mkdir "../7zfile/Flashcard users/Autoboot/Ace3DS+, Ace3DS X"
 	mv _DS_MENU.dat "../7zfile/Flashcard users/Autoboot/Ace3DS+, Ace3DS X/_DS_MENU.DAT"
 	
 	#### EDGE (TODO: Find out how to encrypt the .dat file)


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

_Tell us what you've changed._
I did an oopsie in #1490 and #1491. It should now create a folder for each autoboot file whereas it didn't previously. ~~I blame the gitignore, the thing is confusing~~

#### Where have you tested it?

_Tell us where you've tested it._
WSL2 Ubuntu 20.04

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
