### PR TITLE
Make language/region select translatable

### DIFF
--- a/title/arm9/source/language.inl
+++ b/title/arm9/source/language.inl
@@ -6,3 +6,25 @@ STRING(LR_CHOOSE_A_SELECT, "\\DH: Choose   \\A: Select")
 STRING(ARE_YOU_SURE, "Are you sure this is the\nconsole you're using?")
 STRING(SELECTING_WRONG, "Selecting the wrong one will\ncause unintended behavior.")
 STRING(B_NO_A_YES, "\\B: No   \\A: Yes")
+
+// Language selection
+STRING(SELECT_YOUR_LANGUAGE, "Select your language:")
+STRING(GUI, "GUI: %s")
+STRING(GAME, "Game: %s")
+STRING(DS_BANNER_TITLE, "DS Game Titles: %s")
+STRING(UP_DOWN_CHOOSE, "\\DV Choose")
+STRING(LEFT_RIGHT_CHANGE_LANGUAGE, "\\DH Change Language")
+STRING(A_PROCEED, "\\A Proceed")
+
+STRING(SYSTEM, "System")
+
+// Region selection
+STRING(SELECT_YOUR_REGION, "Select your region:")
+
+STRING(GAME_SPECIFIC, "Game-specific")
+STRING(JAPAN, "Japan")
+STRING(USA, "USA")
+STRING(EUROPE, "Europe")
+STRING(AUSTRALIA, "Australia")
+STRING(CHINA, "China")
+STRING(KOREA, "Korea")

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1253,20 +1253,25 @@ void languageSelect(void) {
 	u16 held = 0, pressed = 0;
 	while (1) {
 		clearText(false);
-		printLarge(false, 2, 0, STR_SELECT_YOUR_LANGUAGE);
+
+		bool rtl = ms().guiLanguage == TWLSettings::TLanguage::ELangHebrew;
+		Alignment align = rtl ? Alignment::right : Alignment::left;
+		int x1 = rtl ? 256 - 2 : 2, x2 = rtl ? 256 - 15 : 15;
+
+		printLarge(false, x1, 0, STR_SELECT_YOUR_LANGUAGE, align);
 
 		snprintf(buffer, sizeof(buffer), STR_GUI.c_str(), displayLanguage(guiLanguage, 0));
-		printSmall(false, 15, 20, buffer);
+		printSmall(false, x2, 20, buffer, align);
 		snprintf(buffer, sizeof(buffer), STR_GAME.c_str(), displayLanguage(gameLanguage, 1));
-		printSmall(false, 15, 32, buffer);
+		printSmall(false, x2, 32, buffer, align);
 		snprintf(buffer, sizeof(buffer), STR_DS_BANNER_TITLE.c_str(), displayLanguage(titleLanguage, 2));
-		printSmall(false, 15, 44, buffer);
+		printSmall(false, x2, 44, buffer, align);
 
-		printSmall(false, 2, 20 + cursorPosition * 12, ">");
+		printSmall(false, x1, 20 + cursorPosition * 12, rtl ? "<" : ">", align);
 
-		printSmall(false, 2, 62, STR_UP_DOWN_CHOOSE);
-		printSmall(false, 2, 74, STR_LEFT_RIGHT_CHANGE_LANGUAGE);
-		printSmall(false, 2, 86, STR_A_PROCEED);
+		printSmall(false, x1, 62, STR_UP_DOWN_CHOOSE, align);
+		printSmall(false, x1, 74, STR_LEFT_RIGHT_CHANGE_LANGUAGE, align);
+		printSmall(false, x1, 86, STR_A_PROCEED, align);
 
 		updateText(false);
 
@@ -1376,20 +1381,24 @@ void regionSelect(bool fontInited) {
 
 	fadeType = true;
 
+	bool rtl = ms().guiLanguage == TWLSettings::TLanguage::ELangHebrew;
+	Alignment align = rtl ? Alignment::right : Alignment::left;
+	int x1 = rtl ? 256 - 2 : 2, x2 = rtl ? 256 - 15 : 15;
+
 	u16 held = 0, pressed = 0;
 	while (1) {
 		clearText();
-		printLarge(false, 2, 0, STR_SELECT_YOUR_REGION);
+		printLarge(false, x1, 0, STR_SELECT_YOUR_REGION, align);
 
 		for(uint i = dsiFeatures() ? 0 : 2, p = 0; i < sizeof(regions) / sizeof(regions[0]); i++, p++) {
-			printSmall(false, 15, 20 + p * 12, *regions[i]);
+			printSmall(false, x2, 20 + p * 12, *regions[i], align);
 		}
 
-		printSmall(false, 2, 20 + (ms().gameRegion + (dsiFeatures() ? 2 : 0)) * 12, ">");
+		printSmall(false, x1, 20 + (ms().gameRegion + (dsiFeatures() ? 2 : 0)) * 12, rtl ? "<" : ">", align);
 
-		int x = 20 + (sizeof(regions) / sizeof(regions[0])) * 12 + 10 - (dsiFeatures() ? 0 : 24);
-		printSmall(false, 2, x, STR_UP_DOWN_CHOOSE);
-		printSmall(false, 2, x + 12, STR_A_PROCEED);
+		int y = 20 + (sizeof(regions) / sizeof(regions[0])) * 12 + 10 - (dsiFeatures() ? 0 : 24);
+		printSmall(false, x1, y, STR_UP_DOWN_CHOOSE, align);
+		printSmall(false, x1, y + 12, STR_A_PROCEED, align);
 
 		updateText(false);
 

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1188,6 +1188,7 @@ static const char* displayLanguage(int l, int type) {
 	} else {
 		switch(type) {
 			case 0:
+			default:
 				return languages[guiLanguages[l]];
 			case 1:
 				return languages[gameLanguages[l]];
@@ -1222,15 +1223,15 @@ void languageSelect(void) {
 	fontInit();
 
 	int guiLanguage = -1, gameLanguage = -1, titleLanguage = -1;
-	for(int i = 0; i < sizeof(guiLanguages) / sizeof(guiLanguages[0]); i++) {
+	for(uint i = 0; i < sizeof(guiLanguages) / sizeof(guiLanguages[0]); i++) {
 		if(guiLanguages[i] == ms().guiLanguage)
 			guiLanguage = i;
 	}
-	for(int i = 0; i < sizeof(gameLanguages) / sizeof(gameLanguages[0]); i++) {
+	for(uint i = 0; i < sizeof(gameLanguages) / sizeof(gameLanguages[0]); i++) {
 		if(gameLanguages[i] == ms().gameLanguage)
 			gameLanguage = i;
 	}
-	for(int i = 0; i < sizeof(titleLanguages) / sizeof(titleLanguages[0]); i++) {
+	for(uint i = 0; i < sizeof(titleLanguages) / sizeof(titleLanguages[0]); i++) {
 		if(titleLanguages[i] == ms().titleLanguage)
 			titleLanguage = i;
 	}
@@ -1251,9 +1252,9 @@ void languageSelect(void) {
 
 		printSmall(false, 2, 20 + cursorPosition * 12, ">");
 
-		printSmall(false, 2, 64, STR_UP_DOWN_CHOOSE);
-		printSmall(false, 2, 76, STR_LEFT_RIGHT_CHANGE_LANGUAGE);
-		printSmall(false, 2, 88, STR_A_PROCEED);
+		printSmall(false, 2, 62, STR_UP_DOWN_CHOOSE);
+		printSmall(false, 2, 74, STR_LEFT_RIGHT_CHANGE_LANGUAGE);
+		printSmall(false, 2, 86, STR_A_PROCEED);
 
 		updateText(false);
 
@@ -1361,13 +1362,13 @@ void regionSelect(void) {
 		clearText();
 		printLarge(false, 2, 0, STR_SELECT_YOUR_REGION);
 
-		for(int i = dsiFeatures() ? 0 : 2; i < sizeof(regions) / sizeof(regions[0]); i++) {
-			printSmall(false, 15, 20 + i * 12, *regions[i]);
+		for(uint i = dsiFeatures() ? 0 : 2, p = 0; i < sizeof(regions) / sizeof(regions[0]); i++, p++) {
+			printSmall(false, 15, 20 + p * 12, *regions[i]);
 		}
 
-		printSmall(false, 2, 20 + (ms().gameRegion + 2) * 12, ">");
+		printSmall(false, 2, 20 + (ms().gameRegion + (dsiFeatures() ? 2 : 0)) * 12, ">");
 
-		int x = dsiFeatures() ? 136 : 136 - 24;
+		int x = 20 + (sizeof(regions) / sizeof(regions[0])) * 12 + 10 - (dsiFeatures() ? 0 : 24);
 		printSmall(false, 2, x, STR_UP_DOWN_CHOOSE);
 		printSmall(false, 2, x + 12, STR_A_PROCEED);
 
@@ -1381,7 +1382,7 @@ void regionSelect(void) {
 		} while(!held);
 
 		if (held & KEY_UP) {
-			if (ms().gameRegion > -2)
+			if (ms().gameRegion > (dsiFeatures() ? -2 : 0))
 				ms().gameRegion--;
 		} else if (held & KEY_DOWN) {
 			if (ms().gameRegion < (int)(sizeof(regions) / sizeof(regions[0])) - 3)

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -26,6 +26,8 @@
 #include "graphics/graphics.h"
 #include "nandio.h"
 #include "twlmenuppvideo.h"
+#include "language.h"
+#include "graphics/fontHandler.h"
 
 #include "autoboot.h"
 
@@ -1111,196 +1113,290 @@ void lastRunROM()
 static bool languageNowSet = false;
 static bool regionNowSet = false;
 
-static const char* displayLanguage(int l, bool s) {
-	switch (l) {
-		case -1:
-		default:
-			return "System";
-		case 0:
-			return "Japanese";
-		case 1:
-			return "English";
-		case 2:
-			return "French";
-		case 3:
-			return "German";
-		case 4:
-			return "Italian";
-		case 5:
-			return "Spanish";
-		case 6:
-			return s ? "ChineseS" : "Chinese";
-		case 7:
-			return "Korean";
-		case 8:
-			return "ChineseT";
-		case 9:
-			return "Polish";
-		case 10:
-			return "Portuguese";
-		case 11:
-			return "Russian";
-		case 12:
-			return "Swedish";
-		case 13:
-			return "Danish";
-		case 14:
-			return "Turkish";
-		case 15:
-			return "Ukrainian";
-		case 16:
-			return "Hungarian";
-		case 17:
-			return "Norwegian";
-		case 18:
-			return "Hebrew";
-		case 19:
-			return "Dutch";
-		case 20:
-			return "Indonesian";
-		case 21:
-			return "Greek";
-    }
+const char *languages[] = {
+	"日本語",
+	"English",
+	"Français",
+	"Deutsch",
+	"Italiano",
+	"Español",
+	"中文 (简体)",
+	"한국어",
+	"中文 (繁體)",
+	"Polski",
+	"Português",
+	"Русский",
+	"Svenska",
+	"Dansk",
+	"Türkçe",
+	"Українська",
+	"Magyar",
+	"Norsk",
+	"עברית",
+	"Nederlands",
+	"Bahasa Indonesia",
+	"Ελληνικά",
+};
+
+const int guiLanguages[] = {
+	TWLSettings::TLanguage::ELangIndonesian,
+	TWLSettings::TLanguage::ELangDanish,
+	TWLSettings::TLanguage::ELangGerman,
+	TWLSettings::TLanguage::ELangEnglish,
+	TWLSettings::TLanguage::ELangSpanish,
+	TWLSettings::TLanguage::ELangFrench,
+	TWLSettings::TLanguage::ELangItalian,
+	TWLSettings::TLanguage::ELangHungarian,
+	TWLSettings::TLanguage::ELangDutch,
+	TWLSettings::TLanguage::ELangNorwegian,
+	TWLSettings::TLanguage::ELangPolish,
+	TWLSettings::TLanguage::ELangPortuguese,
+	TWLSettings::TLanguage::ELangSwedish,
+	TWLSettings::TLanguage::ELangTurkish,
+	TWLSettings::TLanguage::ELangGreek,
+	TWLSettings::TLanguage::ELangRussian,
+	TWLSettings::TLanguage::ELangUkrainian,
+	TWLSettings::TLanguage::ELangHebrew,
+	TWLSettings::TLanguage::ELangChineseS,
+	TWLSettings::TLanguage::ELangChineseT,
+	TWLSettings::TLanguage::ELangJapanese,
+	TWLSettings::TLanguage::ELangKorean
+};
+
+const int gameLanguages[] = {
+	TWLSettings::TLanguage::ELangGerman,
+	TWLSettings::TLanguage::ELangEnglish,
+	TWLSettings::TLanguage::ELangSpanish,
+	TWLSettings::TLanguage::ELangFrench,
+	TWLSettings::TLanguage::ELangItalian,
+	TWLSettings::TLanguage::ELangChineseS,
+	TWLSettings::TLanguage::ELangJapanese,
+	TWLSettings::TLanguage::ELangKorean
+};
+const int titleLanguages[] = {
+	TWLSettings::TLanguage::ELangGerman,
+	TWLSettings::TLanguage::ELangEnglish,
+	TWLSettings::TLanguage::ELangSpanish,
+	TWLSettings::TLanguage::ELangFrench,
+	TWLSettings::TLanguage::ELangItalian,
+	TWLSettings::TLanguage::ELangJapanese
+};
+
+static const char* displayLanguage(int l, int type) {
+	if(l == -1) {
+		return STR_SYSTEM.c_str();
+	} else {
+		switch(type) {
+			case 0:
+				return languages[guiLanguages[l]];
+			case 1:
+				return languages[gameLanguages[l]];
+			case 2:
+				return languages[titleLanguages[l]];
+		}
+	}
 }
 
 void languageSelect(void) {
-	int cursorPosition = 0;
-	consoleDemoInit();
-	iprintf("Select your language.\n");
-	iprintf("\n");
-	iprintf("->GUI: \n");
-	iprintf("  Game: \n");
-	iprintf("  DS Banner title: \n");
-	iprintf("\n");
-	iprintf("Up/Down: Choose\n");
-	iprintf("Left/Right: Change language\n");
-	iprintf("A: Proceed\n");
+	videoSetMode(MODE_5_2D);
+	videoSetModeSub(MODE_5_2D);
 
-	iprintf("\x1b[2;7H%s", displayLanguage(ms().guiLanguage, true));
-	iprintf("\x1b[3;8H%s", displayLanguage(ms().gameLanguage, false));
-	iprintf("\x1b[4;19H%s", displayLanguage(ms().titleLanguage, false));
+	vramSetBankA(VRAM_A_MAIN_BG);
+	vramSetBankC(VRAM_C_SUB_BG);
 
-	for (int i = 0; i < 30; i++) {
-		swiWaitForVBlank();
+	bgInit(3, BgType_Bmp8, BgSize_B8_256x256, 0, 0);
+	bgSetPriority(3, 3);
+	bgInit(2, BgType_Bmp8, BgSize_B8_256x256, 3, 0);
+	bgSetPriority(2, 2);
+	bgInitSub(3, BgType_Bmp8, BgSize_B8_256x256, 0, 0);
+	bgSetPriority(7, 3);
+	bgInitSub(2, BgType_Bmp8, BgSize_B8_256x256, 3, 0);
+	bgSetPriority(6, 2);
+
+	BG_PALETTE[0x10] = 0xFFFF;
+	BG_PALETTE_SUB[0x10] = 0xFFFF;
+	toncset16(bgGetGfxPtr(3), 0x1010, 256 * 192);
+	toncset16(bgGetGfxPtr(7), 0x1010, 256 * 192);
+
+	langInit();
+	fontInit();
+
+	int guiLanguage = -1, gameLanguage = -1, titleLanguage = -1;
+	for(int i = 0; i < sizeof(guiLanguages) / sizeof(guiLanguages[0]); i++) {
+		if(guiLanguages[i] == ms().guiLanguage)
+			guiLanguage = i;
 	}
-	int pressed = 0;
+	for(int i = 0; i < sizeof(gameLanguages) / sizeof(gameLanguages[0]); i++) {
+		if(gameLanguages[i] == ms().gameLanguage)
+			gameLanguage = i;
+	}
+	for(int i = 0; i < sizeof(titleLanguages) / sizeof(titleLanguages[0]); i++) {
+		if(titleLanguages[i] == ms().titleLanguage)
+			titleLanguage = i;
+	}
+
+	int cursorPosition = 0;
+	char buffer[64] = {0};
+	u16 held = 0, pressed = 0;
 	while (1) {
-		swiWaitForVBlank();
-		scanKeys();
-		pressed = keysDown();
-		if (pressed & KEY_UP) {
-			iprintf("\x1b[%d;0H  ", 2 + cursorPosition);
-			cursorPosition--;
-			if (cursorPosition < 0) cursorPosition = 0;
-			iprintf("\x1b[%d;0H->", 2 + cursorPosition);
-		} else if (pressed & KEY_DOWN) {
-			iprintf("\x1b[%d;0H  ", 2 + cursorPosition);
-			cursorPosition++;
-			if (cursorPosition > 2) cursorPosition = 2;
-			iprintf("\x1b[%d;0H->", 2 + cursorPosition);
-		} else if (pressed & KEY_LEFT) {
+		clearText();
+		printLarge(false, 2, 0, STR_SELECT_YOUR_LANGUAGE);
+
+		snprintf(buffer, sizeof(buffer), STR_GUI.c_str(), displayLanguage(guiLanguage, 0));
+		printSmall(false, 15, 20, buffer);
+		snprintf(buffer, sizeof(buffer), STR_GAME.c_str(), displayLanguage(gameLanguage, 1));
+		printSmall(false, 15, 32, buffer);
+		snprintf(buffer, sizeof(buffer), STR_DS_BANNER_TITLE.c_str(), displayLanguage(titleLanguage, 2));
+		printSmall(false, 15, 44, buffer);
+
+		printSmall(false, 2, 20 + cursorPosition * 12, ">");
+
+		printSmall(false, 2, 64, STR_UP_DOWN_CHOOSE);
+		printSmall(false, 2, 76, STR_LEFT_RIGHT_CHANGE_LANGUAGE);
+		printSmall(false, 2, 88, STR_A_PROCEED);
+
+		updateText(false);
+
+		do {
+			swiWaitForVBlank();
+			scanKeys();
+			pressed = keysDown();
+			held = keysDownRepeat();
+		} while(!held);
+
+		if (held & KEY_UP) {
+			if (cursorPosition > 0)
+				cursorPosition--;
+		} else if (held & KEY_DOWN) {
+			if (cursorPosition < 2)
+				cursorPosition++;
+		} else if (held & KEY_LEFT) {
 			switch (cursorPosition) {
 				case 0:
-					iprintf("\x1b[2;7H            ");
-					ms().guiLanguage--;
-					if (ms().guiLanguage < -1) ms().guiLanguage = 21;
-					iprintf("\x1b[2;7H%s", displayLanguage(ms().guiLanguage, true));
+					if (guiLanguage > -1) {
+						guiLanguage--;
+						ms().guiLanguage = guiLanguage == -1 ? guiLanguage : guiLanguages[guiLanguage];
+						langInit();
+					}
 					break;
 				case 1:
-					iprintf("\x1b[3;8H            ");
-					ms().gameLanguage--;
-					if (ms().gameLanguage < -1) ms().gameLanguage = 7;
-					iprintf("\x1b[3;8H%s", displayLanguage(ms().gameLanguage, false));
+					if (gameLanguage > -1)
+						gameLanguage--;
 					break;
 				case 2:
-					iprintf("\x1b[4;19H            ");
-					ms().titleLanguage--;
-					if (ms().titleLanguage < -1) ms().titleLanguage = 5;
-					iprintf("\x1b[4;19H%s", displayLanguage(ms().titleLanguage, false));
+					if (titleLanguage > -1)
+						titleLanguage--;
 					break;
 			}
-		} else if (pressed & KEY_RIGHT) {
+		} else if (held & KEY_RIGHT) {
 			switch (cursorPosition) {
 				case 0:
-					iprintf("\x1b[2;7H            ");
-					ms().guiLanguage++;
-					if (ms().guiLanguage > 21) ms().guiLanguage = -1;
-					iprintf("\x1b[2;7H%s", displayLanguage(ms().guiLanguage, true));
+					if (guiLanguage < (int)(sizeof(languages) / sizeof(languages[0]))) {
+						guiLanguage++;
+						ms().guiLanguage = guiLanguage == -1 ? guiLanguage : guiLanguages[guiLanguage];
+						langInit();
+					}
 					break;
 				case 1:
-					iprintf("\x1b[3;8H            ");
-					ms().gameLanguage++;
-					if (ms().gameLanguage > 7) ms().gameLanguage = -1;
-					iprintf("\x1b[3;8H%s", displayLanguage(ms().gameLanguage, false));
+					if (gameLanguage < 7)
+						gameLanguage++;
 					break;
 				case 2:
-					iprintf("\x1b[4;19H            ");
-					ms().titleLanguage++;
-					if (ms().titleLanguage > 5) ms().titleLanguage = -1;
-					iprintf("\x1b[4;19H%s", displayLanguage(ms().titleLanguage, false));
+					if (titleLanguage < 5)
+						titleLanguage++;
 					break;
 			}
 		}
+
 		if (pressed & KEY_A) {
+			ms().gameLanguage = gameLanguage == -1 ? gameLanguage : gameLanguages[gameLanguage];
+			ms().titleLanguage = titleLanguage == -1 ? titleLanguage : titleLanguages[titleLanguage];
 			ms().languageSet = true;
 			languageNowSet = true;
 			break;
 		}
-	};
-	consoleClear();
+	}
+
+	clearText();
+	updateText(false);
 }
 
+const std::string *regions[] {
+	&STR_GAME_SPECIFIC,
+	&STR_SYSTEM,
+	&STR_JAPAN,
+	&STR_USA,
+	&STR_EUROPE,
+	&STR_AUSTRALIA,
+	&STR_CHINA,
+	&STR_KOREA
+};
+
 void regionSelect(void) {
-	int firstOption = (dsiFeatures() ? -2 : 0);
-	int firstOptionDisplay = ms().gameRegion+(dsiFeatures() ? 2 : 0);
+	videoSetMode(MODE_5_2D);
+	videoSetModeSub(MODE_5_2D);
 
-	consoleDemoInit();
-	iprintf("Select your region.\n");
-	iprintf("\n");
-	if (dsiFeatures()) {
-		iprintf("  Game-specific\n");
-		iprintf("  System default\n");
-	}
-	iprintf("  Japan\n");
-	iprintf("  USA\n");
-	iprintf("  Europe\n");
-	iprintf("  Australia\n");
-	iprintf("  China\n");
-	iprintf("  Korea\n");
-	iprintf("\n");
-	iprintf("Up/Down: Choose\n");
-	iprintf("A: Proceed\n");
+	vramSetBankA(VRAM_A_MAIN_BG);
+	vramSetBankC(VRAM_C_SUB_BG);
 
-	iprintf("\x1b[%d;0H->", 2 + firstOptionDisplay);
+	bgInit(3, BgType_Bmp8, BgSize_B8_256x256, 0, 0);
+	bgSetPriority(3, 3);
+	bgInit(2, BgType_Bmp8, BgSize_B8_256x256, 3, 0);
+	bgSetPriority(2, 2);
+	bgInitSub(3, BgType_Bmp8, BgSize_B8_256x256, 0, 0);
+	bgSetPriority(7, 3);
+	bgInitSub(2, BgType_Bmp8, BgSize_B8_256x256, 3, 0);
+	bgSetPriority(6, 2);
 
-	for (int i = 0; i < 30; i++) {
-		swiWaitForVBlank();
-	}
-	int pressed = 0;
+	BG_PALETTE[0x10] = 0xFFFF;
+	BG_PALETTE_SUB[0x10] = 0xFFFF;
+	toncset16(bgGetGfxPtr(3), 0x1010, 256 * 192);
+	toncset16(bgGetGfxPtr(7), 0x1010, 256 * 192);
+
+	langInit();
+	fontInit();
+
+	u16 held = 0, pressed = 0;
 	while (1) {
-		swiWaitForVBlank();
-		scanKeys();
-		pressed = keysDown();
-		if (pressed & KEY_UP) {
-			iprintf("\x1b[%d;0H  ", 2 + firstOptionDisplay);
-			ms().gameRegion--;
-			if (ms().gameRegion < firstOption) ms().gameRegion = firstOption;
-			firstOptionDisplay = ms().gameRegion+(dsiFeatures() ? 2 : 0);
-			iprintf("\x1b[%d;0H->", 2 + firstOptionDisplay);
-		} else if (pressed & KEY_DOWN) {
-			iprintf("\x1b[%d;0H  ", 2 + firstOptionDisplay);
-			ms().gameRegion++;
-			if (ms().gameRegion > 5) ms().gameRegion = 5;
-			firstOptionDisplay = ms().gameRegion+(dsiFeatures() ? 2 : 0);
-			iprintf("\x1b[%d;0H->", 2 + firstOptionDisplay);
+		clearText();
+		printLarge(false, 2, 0, STR_SELECT_YOUR_REGION);
+
+		for(int i = dsiFeatures() ? 0 : 2; i < sizeof(regions) / sizeof(regions[0]); i++) {
+			printSmall(false, 15, 20 + i * 12, *regions[i]);
 		}
+
+		printSmall(false, 2, 20 + (ms().gameRegion + 2) * 12, ">");
+
+		int x = dsiFeatures() ? 136 : 136 - 24;
+		printSmall(false, 2, x, STR_UP_DOWN_CHOOSE);
+		printSmall(false, 2, x + 12, STR_A_PROCEED);
+
+		updateText(false);
+
+		do {
+			swiWaitForVBlank();
+			scanKeys();
+			pressed = keysDown();
+			held = keysDownRepeat();
+		} while(!held);
+
+		if (held & KEY_UP) {
+			if (ms().gameRegion > -2)
+				ms().gameRegion--;
+		} else if (held & KEY_DOWN) {
+			if (ms().gameRegion < (int)(sizeof(regions) / sizeof(regions[0])) - 3)
+				ms().gameRegion++;
+		}
+
 		if (pressed & KEY_A) {
 			ms().regionSet = true;
 			regionNowSet = true;
 			break;
 		}
-	};
-	consoleClear();
+	}
+
+	clearText();
+	updateText(false);
 }
 
 //---------------------------------------------------------------------------------
@@ -1322,6 +1418,8 @@ int main(int argc, char **argv)
 		iprintf("fatInitDefault failed!");
 		stop();
 	}
+
+	keysSetRepeat(25, 5);
 
 	*(u32*)0x02FFFDFC = 0; // Reset TWLCFG location
 
@@ -1743,7 +1841,6 @@ int main(int argc, char **argv)
 		}
 	}
 
-	keysSetRepeat(25, 5);
 	// snprintf(vertext, sizeof(vertext), "Ver %d.%d.%d   ", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH); // Doesn't work :(
 
 	if (ms().showlogo && !(*(u32*)0x02000000 & BIT(1)))

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1238,12 +1238,12 @@ void languageSelect(void) {
 
 	printSmall(true, 2, 4, "\uE07Eを使用して言語を選択してください。");
 	printSmall(true, 2, 28, "Select your language with \uE07E.");
-	printSmall(true, 2, 52, "[French]");
-	printSmall(true, 2, 76, "[German]");
-	printSmall(true, 2, 100, "[Italian]");
-	printSmall(true, 2, 124, "[Spanish]");
-	printSmall(true, 2, 148, "[Chinese (Simplified)]");
-	printSmall(true, 2, 172, "[Korean]");
+	// printSmall(true, 2, 52, "[French]");
+	// printSmall(true, 2, 76, "[German]");
+	// printSmall(true, 2, 100, "[Italian]");
+	// printSmall(true, 2, 124, "[Spanish]");
+	// printSmall(true, 2, 148, "[Chinese (Simplified)]");
+	// printSmall(true, 2, 172, "[Korean]");
 	updateText(true);
 
 	int cursorPosition = 0;

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1222,6 +1222,8 @@ void languageSelect(void) {
 	langInit();
 	fontInit();
 
+	fadeType = true;
+
 	int guiLanguage = -1, gameLanguage = -1, titleLanguage = -1;
 	for(uint i = 0; i < sizeof(guiLanguages) / sizeof(guiLanguages[0]); i++) {
 		if(guiLanguages[i] == ms().guiLanguage)
@@ -1328,6 +1330,10 @@ void languageSelect(void) {
 		}
 	}
 
+	fadeType = false;
+	for (int i = 0; i < 30; i++)
+		swiWaitForVBlank();
+
 	clearText();
 	updateText(false);
 }
@@ -1343,7 +1349,7 @@ const std::string *regions[] {
 	&STR_KOREA
 };
 
-void regionSelect(void) {
+void regionSelect(bool fontInited) {
 	videoSetMode(MODE_5_2D);
 	videoSetModeSub(MODE_5_2D);
 
@@ -1365,7 +1371,10 @@ void regionSelect(void) {
 	toncset16(bgGetGfxPtr(7), 0x1010, 256 * 192);
 
 	langInit();
-	fontInit();
+	if(!fontInited)
+		fontInit();
+
+	fadeType = true;
 
 	u16 held = 0, pressed = 0;
 	while (1) {
@@ -1406,6 +1415,11 @@ void regionSelect(void) {
 		}
 	}
 
+
+	fadeType = false;
+	for (int i = 0; i < 30; i++)
+		swiWaitForVBlank();
+
 	clearText();
 	updateText(false);
 }
@@ -1431,6 +1445,8 @@ int main(int argc, char **argv)
 	}
 
 	keysSetRepeat(25, 5);
+
+	runGraphicIrq();
 
 	*(u32*)0x02FFFDFC = 0; // Reset TWLCFG location
 
@@ -1566,13 +1582,15 @@ int main(int argc, char **argv)
 	ms().loadSettings();
 	bs().loadSettings();
 
+	bool fontInited = false;
 	if (!ms().languageSet) {
 		languageSelect();
+		fontInited = true;
 	}
 
 	if (!ms().regionSet || (!dsiFeatures() && ms().gameRegion < 0)) {
 		if (!dsiFeatures() && ms().gameRegion < 0) ms().gameRegion = 0;
-		regionSelect();
+		regionSelect(fontInited);
 	}
 
 	if (isDSiMode()) {
@@ -1713,8 +1731,6 @@ int main(int argc, char **argv)
 		mkdir("fat:/_gba", 0777);
 		mkdir("fat:/_nds/TWiLightMenu/gamesettings", 0777);
 	}
-
-	runGraphicIrq();
 
 	if (REG_SCFG_EXT != 0) {
 		*(vu32*)(0x0DFFFE0C) = 0x53524C41;		// Check for 32MB of RAM

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1304,7 +1304,7 @@ void languageSelect(void) {
 		} else if (held & KEY_RIGHT) {
 			switch (cursorPosition) {
 				case 0:
-					if (guiLanguage < (int)(sizeof(languages) / sizeof(languages[0]))) {
+					if (guiLanguage < (int)(sizeof(languages) / sizeof(languages[0])) - 1) {
 						guiLanguage++;
 						ms().guiLanguage = guiLanguage == -1 ? guiLanguage : guiLanguages[guiLanguage];
 						langInit();

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1236,11 +1236,21 @@ void languageSelect(void) {
 			titleLanguage = i;
 	}
 
+	printSmall(true, 2, 4, "\uE07Eを使用して言語を選択してください。");
+	printSmall(true, 2, 28, "Select your language with \uE07E.");
+	printSmall(true, 2, 52, "[French]");
+	printSmall(true, 2, 76, "[German]");
+	printSmall(true, 2, 100, "[Italian]");
+	printSmall(true, 2, 124, "[Spanish]");
+	printSmall(true, 2, 148, "[Chinese (Simplified)]");
+	printSmall(true, 2, 172, "[Korean]");
+	updateText(true);
+
 	int cursorPosition = 0;
 	char buffer[64] = {0};
 	u16 held = 0, pressed = 0;
 	while (1) {
-		clearText();
+		clearText(false);
 		printLarge(false, 2, 0, STR_SELECT_YOUR_LANGUAGE);
 
 		snprintf(buffer, sizeof(buffer), STR_GUI.c_str(), displayLanguage(guiLanguage, 0));

--- a/title/nitrofiles/languages/en/language.ini
+++ b/title/nitrofiles/languages/en/language.ini
@@ -6,3 +6,22 @@ LR_CHOOSE_A_SELECT = \DH: Choose   \A: Select
 ARE_YOU_SURE = Are you sure this is the\nconsole you're using?
 SELECTING_WRONG = Selecting the wrong one will\ncause unintended behavior.
 B_NO_A_YES = \B: No   \A: Yes
+
+SELECT_YOUR_LANGUAGE = Select your language:
+GUI = GUI: %s
+GAME = Game: %s
+DS_BANNER_TITLE = DS Game Titles: %s
+UP_DOWN_CHOOSE = \DV Choose
+LEFT_RIGHT_CHANGE_LANGUAGE = \DH Change Language
+A_PROCEED = \A Proceed
+
+SYSTEM = System
+SELECT_YOUR_REGION = Select your region:
+
+GAME_SPECIFIC = Game-specific
+JAPAN = Japan
+USA = USA
+EUROPE = Europe
+AUSTRALIA = Australia
+CHINA = China
+KOREA = Korea

--- a/title/nitrofiles/languages/en/language.ini
+++ b/title/nitrofiles/languages/en/language.ini
@@ -7,6 +7,9 @@ ARE_YOU_SURE = Are you sure this is the\nconsole you're using?
 SELECTING_WRONG = Selecting the wrong one will\ncause unintended behavior.
 B_NO_A_YES = \B: No   \A: Yes
 
+; To be hardcoded in on the top screen for Japanese, English, French, German, Italian, Spanish, Chinese (Simplified), and Korean (the official langauges).
+SELECT_LANGUAGE_WITH = Select your language with \uE07E.
+
 SELECT_YOUR_LANGUAGE = Select your language:
 GUI = GUI: %s
 GAME = Game: %s


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Makes the language/region selector translatable (would you like it if something asked you 英語を話します？はい／いいえ ;P)

It reloads the language every time the GUI option is changed so it should be pretty easy to find your language even if it starts on one that isn't it. Maybe we should add hardcoded strings on the top screen for the official 8 languages or so, I'll need translations in them first though.

![lang](https://user-images.githubusercontent.com/41608708/122637585-2ac2ce80-d0b5-11eb-8611-7ab211e5a782.png) ![region](https://user-images.githubusercontent.com/41608708/122637586-2b5b6500-d0b5-11eb-82ac-f90b9f4cefff.png)


#### Where have you tested it?

- DSi (K) from Unlaunch and DSONE and no$gba

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
