### PR TITLE
Update gitignore to match booter_fc Makefile update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ ipch/
 7zfile/Flashcard users/Autoboot/iSmart Premium/system/ismat.dat
 7zfile/Flashcard users/Autoboot/R4iDSN & R4 Ultra/_MENU_.NDS
 7zfile/Flashcard users/Autoboot/R4iDSN & R4 Ultra/_MENU_B.NDS
+7zfile/Flashcard users/Autoboot/R4iDSN & R4 Ultra/_MENU_X.NDS
 7zfile/Flashcard users/Autoboot/SuperCard DSTWO/_dstwo/dstwo.nds
 7zfile/Flashcard users/Autoboot/SuperCard DSONE & SuperCard DSONEi/TTMenu.DAT
 7zfile/Flashcard users/Autoboot/R4i Gold 3DS Plus, R4i Gold 3DS Deluxe & R4i Gold 3DS RTS/_DS_MENU.DAT


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

_Tell us what you've changed._
The Makefile for booter_fc created a new file that wasn't ignored.

Well, now it is.

#### Where have you tested it?

_Tell us where you've tested it._
Ubuntu 20.04 WSL2

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
