### PR TITLE
Make reset settings prompt translatable

### DIFF
--- a/title/arm9/source/language.inl
+++ b/title/arm9/source/language.inl
@@ -7,6 +7,12 @@ STRING(ARE_YOU_SURE, "Are you sure this is the\nconsole you're using?")
 STRING(SELECTING_WRONG, "Selecting the wrong one will\ncause unintended behavior.")
 STRING(B_NO_A_YES, "\\B: No   \\A: Yes")
 
+// Settings reset
+STRING(RESET_TWILIGHT_SETTINGS, "Reset TWiLight Menu++ settings?")
+STRING(PGS_WILL_BE_KEPT, "Per-game settings will be kept.")
+STRING(A_YES, "\\A Yes")
+STRING(B_NO, "\\B No")
+
 // Language selection
 STRING(SELECT_YOUR_LANGUAGE, "Select your language:")
 STRING(GUI, "GUI: %s")

--- a/title/nitrofiles/languages/en/language.ini
+++ b/title/nitrofiles/languages/en/language.ini
@@ -7,6 +7,11 @@ ARE_YOU_SURE = Are you sure this is the\nconsole you're using?
 SELECTING_WRONG = Selecting the wrong one will\ncause unintended behavior.
 B_NO_A_YES = \B: No   \A: Yes
 
+RESET_TWILIGHT_SETTINGS=Reset TWiLight Menu++ settings?
+PGS_WILL_BE_KEPT=Per-game settings will be kept.
+A_YES=\A Yes
+B_NO=\B No
+
 ; To be hardcoded in on the top screen for Japanese, English, French, German, Italian, Spanish, Chinese (Simplified), and Korean (the official langauges).
 SELECT_LANGUAGE_WITH = Select your language with \uE07E.
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes the reset settings prompt translatable, am I missing anything else in title?
- Also adds French, German, Italian, and Chinese strings for top screen language select
- And makes the line spacing slightly larger in the language and region selects

#### Where have you tested it?

- DSi (K) from Unlaunch and DSONE and no$gba

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
