### PR TITLE
Fix reset not reloading settings & allow newlines in its title

### DIFF
--- a/title/arm9/source/common/dsimenusettings.cpp
+++ b/title/arm9/source/common/dsimenusettings.cpp
@@ -255,6 +255,11 @@ TWLSettings::TLanguage TWLSettings::getGuiLanguage()
     return (TLanguage)guiLanguage;
 }
 
+void TWLSettings::reloadSettings()
+{
+    
+}
+
 std::string TWLSettings::getGuiLanguageString()
 {
     switch (getGuiLanguage())

--- a/title/arm9/source/common/dsimenusettings.cpp
+++ b/title/arm9/source/common/dsimenusettings.cpp
@@ -255,11 +255,6 @@ TWLSettings::TLanguage TWLSettings::getGuiLanguage()
     return (TLanguage)guiLanguage;
 }
 
-void TWLSettings::reloadSettings()
-{
-    
-}
-
 std::string TWLSettings::getGuiLanguageString()
 {
     switch (getGuiLanguage())

--- a/title/arm9/source/common/dsimenusettings.h
+++ b/title/arm9/source/common/dsimenusettings.h
@@ -143,10 +143,11 @@ class TWLSettings
 
   public:
     TWLSettings();
-    ~TWLSettings();
+    ~TWLSettings() {};
 
   public:
     void loadSettings();
+    void reloadSettings();
     void saveSettings();
 
     TLanguage getGuiLanguage();

--- a/title/arm9/source/common/dsimenusettings.h
+++ b/title/arm9/source/common/dsimenusettings.h
@@ -147,7 +147,6 @@ class TWLSettings
 
   public:
     void loadSettings();
-    void reloadSettings();
     void saveSettings();
 
     TLanguage getGuiLanguage();

--- a/title/arm9/source/language.cpp
+++ b/title/arm9/source/language.cpp
@@ -101,10 +101,10 @@ std::string getString(CIniFile &ini, const std::string &item, const std::string 
  * Initialize translations.
  * Uses the language ID specified in settings.ui.language.
  */
-void langInit(void)
+void langInit(const char *language = nullptr)
 {
 	char languageIniPath[64];
-	snprintf(languageIniPath, sizeof(languageIniPath), "nitro:/languages/%s/language.ini", ms().getGuiLanguageString().c_str());
+	snprintf(languageIniPath, sizeof(languageIniPath), "nitro:/languages/%s/language.ini", language ? language : ms().getGuiLanguageString().c_str());
 
 	CIniFile languageini(languageIniPath);
 

--- a/title/arm9/source/language.h
+++ b/title/arm9/source/language.h
@@ -19,6 +19,6 @@ extern int setTitleLanguage;
  * Check the language variable outside of settings to determine
  * the actual language in use.
  */
-void langInit(void);
+void langInit(const char *language = nullptr);
 
 #endif /* DSIMENUPP_LANGUAGE_H */

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1137,11 +1137,15 @@ void graphicsInit(void) {
 	toncset16(bgGetGfxPtr(3), 0x1010, 256 * 192);
 	toncset16(bgGetGfxPtr(7), 0x1010, 256 * 192);
 
-	langInit();
 	fontInit();
 }
 
 void resetSettingsPrompt(void) {
+	TWLSettings settings;
+	settings.loadSettings();
+
+	langInit(settings.getGuiLanguageString().c_str());
+
 	graphicsInit();
 
 	fadeType = true;
@@ -1152,10 +1156,11 @@ void resetSettingsPrompt(void) {
 
 	clearText();
 	printLarge(false, x1, 0, STR_RESET_TWILIGHT_SETTINGS, align);
-	printSmall(false, x1, 16, STR_PGS_WILL_BE_KEPT, align);
+	int y = calcLargeFontHeight(STR_RESET_TWILIGHT_SETTINGS);
+	printSmall(false, x1, y, STR_PGS_WILL_BE_KEPT, align);
 
-	printSmall(false, x1, 36, STR_A_YES, align);
-	printSmall(false, x1, 36 + 14, STR_B_NO, align);
+	printSmall(false, x1, y + 20, STR_A_YES, align);
+	printSmall(false, x1, y + 20 + 14, STR_B_NO, align);
 
 	updateText(false);
 
@@ -1269,6 +1274,7 @@ static const char* displayLanguage(int l, int type) {
 
 void languageSelect(void) {
 	graphicsInit();
+	langInit();
 
 	fadeType = true;
 
@@ -1405,6 +1411,7 @@ const std::string *regions[] {
 
 void regionSelect(void) {
 	graphicsInit();
+	langInit();
 
 	fadeType = true;
 
@@ -1588,7 +1595,6 @@ int main(int argc, char **argv)
 	}
 
 	bool fontInited = false;
-
 	scanKeys();
 	if ((keysHeld() & KEY_A)
 	 && (keysHeld() & KEY_B)


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- I accidentally broke the reset settings prompt so the settings weren't being reloaded if deleted, so this fixes that
- It also makes newlines in the title work since the English one is already quite tight

#### Where have you tested it?

- no$gba, DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
