### PR TITLE
Fix font being buggy when loaded to Memory Expansion Pak

### DIFF
--- a/manual/arm9/source/graphics/FontGraphic.cpp
+++ b/manual/arm9/source/graphics/FontGraphic.cpp
@@ -2,7 +2,7 @@
 
 #include "common/tonccpy.h"
 
-static u8* lastUsedLoc = (u8*)0x08000000;
+u8 *FontGraphic::lastUsedLoc = (u8*)0x08000000;
 
 u8 FontGraphic::textBuf[2][256 * 192];
 
@@ -18,7 +18,7 @@ bool FontGraphic::isNumber(char16_t c) {
 	return c >= '0' && c <= '9';
 }
 
-FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useExpansionPak) {
+FontGraphic::FontGraphic(const std::vector<std::string> &paths, bool useExpansionPak) : useExpansionPak(useExpansionPak) {
 	FILE *file = nullptr;
 	for(const auto &path : paths) {
 		file = fopen(path.c_str(), "rb");
@@ -27,7 +27,7 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 	}
 
 	if(file) {
-		if (useExpansionPak && *(u16*)(0x020000C0) == 0 && lastUsedLoc == (u8*)0x08000000) {
+		if(useExpansionPak && *(u16*)(0x020000C0) == 0 && lastUsedLoc == (u8*)0x08000000) {
 			lastUsedLoc += 0x01000000;
 		}
 
@@ -47,21 +47,26 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 		fread(&tileSize, 2, 1, file);
 
 		// Load character glyphs
-		int tileAmount = ((chunkSize-0x10)/tileSize);
-		if (!useExpansionPak) {
-			fontTilesVector = std::vector<u8>(tileSize*tileAmount);
-			fontTiles = fontTilesVector.data();
-		} else {
-			fontTiles = lastUsedLoc;
-		}
+		tileAmount = (chunkSize - 0x10) / tileSize;
 		fseek(file, 4, SEEK_CUR);
-		fread(fontTiles, tileSize, tileAmount, file);
+		if(useExpansionPak) {
+			fontTiles = lastUsedLoc;
+			lastUsedLoc += tileSize * tileAmount;
+
+			u8 *buf = new u8[tileSize * tileAmount];
+			fread(buf, tileSize, tileAmount, file);
+			tonccpy(fontTiles, buf, tileSize * tileAmount);
+			delete[] buf;
+		} else {
+			fontTiles = new u8[tileSize * tileAmount];
+			fread(fontTiles, tileSize, tileAmount, file);
+		}
 
 		// Fix top row
-		for(int i=0;i<tileAmount;i++) {
-			fontTiles[i*tileSize] = 0;
-			fontTiles[i*tileSize+1] = 0;
-			fontTiles[i*tileSize+2] = 0;
+		for(int i = 0; i < tileAmount; i++) {
+			fontTiles[i * tileSize] = 0;
+			fontTiles[i * tileSize + 1] = 0;
+			fontTiles[i * tileSize + 2] = 0;
 		}
 
 		// Load character widths
@@ -71,17 +76,27 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 		fseek(file, locHDWC-4, SEEK_SET);
 		fread(&chunkSize, 4, 1, file);
 		fseek(file, 8, SEEK_CUR);
-		if (!useExpansionPak) {
-			fontWidthsVector = std::vector<u8>(3*tileAmount);
-			fontWidths = fontWidthsVector.data();
+		if(useExpansionPak) {
+			fontWidths = lastUsedLoc;
+			lastUsedLoc += 3 * tileAmount;
+
+			u8 *buf = new u8[3 * tileAmount];
+			fread(buf, 3, tileAmount, file);
+			tonccpy(fontWidths, buf, 3 * tileAmount);
+			delete[] buf;
 		} else {
-			fontWidths = fontTiles+(tileSize*tileAmount);
-			lastUsedLoc = fontWidths+((3*tileAmount)*4);
+			fontWidths = new u8[3 * tileAmount];
+			fread(fontWidths, 3, tileAmount, file);
 		}
-		fread(fontWidths, 3, tileAmount, file);
 
 		// Load character maps
-		fontMap = std::vector<u16>(tileAmount);
+		if(useExpansionPak) {
+			fontMap = (u16*)lastUsedLoc;
+			lastUsedLoc += tileAmount * sizeof(u16);
+		} else {
+			fontMap = new u16[tileAmount];
+		}
+
 		fseek(file, 0x28, SEEK_SET);
 		u32 locPAMC, mapType;
 		fread(&locPAMC, 4, 1, file);
@@ -129,10 +144,21 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 	}
 }
 
+FontGraphic::~FontGraphic(void) {
+	if(!useExpansionPak) {
+		if(fontTiles)
+			delete[] fontTiles;
+		if(fontWidths)
+			delete[] fontWidths;
+		if(fontMap)
+			delete[] fontMap;
+	}
+}
+
 u16 FontGraphic::getCharIndex(char16_t c) {
 	// Try a binary search
 	int left = 0;
-	int right = fontMap.size();
+	int right = tileAmount;
 
 	while(left <= right) {
 		int mid = left + ((right - left) / 2);

--- a/manual/arm9/source/graphics/FontGraphic.h
+++ b/manual/arm9/source/graphics/FontGraphic.h
@@ -17,14 +17,16 @@ private:
 	static bool isWeak(char16_t c);
 	static bool isNumber(char16_t c);
 
-	u8 tileWidth, tileHeight;
-	u16 tileSize;
+	static u8 *lastUsedLoc;
+
+	bool useExpansionPak = false;
+	u8 tileWidth = 0, tileHeight = 0;
+	u16 tileSize = 0;
+	int tileAmount = 0;
 	u16 questionMark = 0;
-	u8* fontTiles = (u8*)0;
-	u8* fontWidths = (u8*)0;
-	std::vector<u8> fontTilesVector;
-	std::vector<u8> fontWidthsVector;
-	std::vector<u16> fontMap;
+	u8 *fontTiles = nullptr;
+	u8 *fontWidths = nullptr;
+	u16 *fontMap = nullptr;
 
 	u16 getCharIndex(char16_t c);
 
@@ -33,8 +35,9 @@ public:
 
 	static std::u16string utf8to16(std::string_view text);
 
-	FontGraphic() {};
 	FontGraphic(const std::vector<std::string> &paths, const bool useExpansionPak);
+
+	~FontGraphic(void);
 
 	u8 height(void) { return tileHeight; }
 

--- a/manual/arm9/source/graphics/fontHandler.cpp
+++ b/manual/arm9/source/graphics/fontHandler.cpp
@@ -1,15 +1,16 @@
-#include <nds/arm9/dldi.h>
-#include "common/systemdetails.h"
-#include "common/flashcard.h"
 #include "fontHandler.h"
+
+#include <nds/arm9/dldi.h>
 #include <list>
 
-#include "myDSiMode.h"
+#include "common/flashcard.h"
+#include "common/systemdetails.h"
 #include "common/tonccpy.h"
+#include "myDSiMode.h"
 #include "TextEntry.h"
 
-FontGraphic smallFont;
-FontGraphic largeFont;
+FontGraphic *smallFont;
+FontGraphic *largeFont;
 
 std::list<TextEntry> topText, bottomText;
 
@@ -18,14 +19,18 @@ bool shouldClear[] = {false, false};
 extern std::string font;
 
 void fontInit() {
-	//iprintf("fontInit()\n");
-
 	bool useExpansionPak = (sys().isRegularDS() && ((*(u16*)(0x020000C0) != 0 && *(u16*)(0x020000C0) != 0x5A45) || *(vu16*)(0x08240000) == 1) && (io_dldi_data->ioInterface.features & FEATURE_SLOT_NDS));
+
+	// Unload fonts if already loaded
+	if(smallFont)
+		delete smallFont;
+	if(largeFont)
+		delete largeFont;
 
 	// Load font graphics
 	std::string fontPath = std::string(sdFound() ? "sd:" : "fat:") + "/_nds/TWiLightMenu/extras/fonts/" + font;
-	smallFont = FontGraphic({fontPath + ((dsiFeatures() || useExpansionPak) ? "/small-dsi.nftr" : "/small-ds.nftr"), fontPath + "/small.nftr", "nitro:/graphics/font/small.nftr"}, useExpansionPak);
-	largeFont = FontGraphic({fontPath + ((dsiFeatures() || useExpansionPak) ? "/large-dsi.nftr" : "/large-ds.nftr"), fontPath + "/large.nftr", "nitro:/graphics/font/large.nftr"}, useExpansionPak);
+	smallFont = new FontGraphic({fontPath + ((dsiFeatures() || useExpansionPak) ? "/small-dsi.nftr" : "/small-ds.nftr"), fontPath + "/small.nftr", "nitro:/graphics/font/small.nftr"}, useExpansionPak);
+	largeFont = new FontGraphic({fontPath + ((dsiFeatures() || useExpansionPak) ? "/large-dsi.nftr" : "/large-ds.nftr"), fontPath + "/large.nftr", "nitro:/graphics/font/large.nftr"}, useExpansionPak);
 
 	// Load palettes
 	u16 palette[] = {
@@ -42,7 +47,7 @@ static std::list<TextEntry> &getTextQueue(bool top) {
 	return top ? topText : bottomText;
 }
 
-FontGraphic &getFont(bool large) {
+FontGraphic *getFont(bool large) {
 	return large ? largeFont : smallFont;
 }
 
@@ -56,7 +61,9 @@ void updateText(bool top) {
 	// Draw text
 	auto &text = getTextQueue(top);
 	for(auto it = text.begin(); it != text.end(); ++it) {
-		getFont(it->large).print(it->x, it->y, top, it->message, it->align);
+		FontGraphic *font = getFont(it->large);
+		if(font)
+			font->print(it->x, it->y, top, it->message, it->align);
 	}
 	text.clear();
 
@@ -88,43 +95,63 @@ void printLarge(bool top, int x, int y, std::u16string_view message, Alignment a
 }
 
 int calcSmallFontWidth(std::string_view text) {
-	return smallFont.calcWidth(text);
+	if(smallFont)
+		return smallFont->calcWidth(text);
+	return 0;
 }
 int calcSmallFontWidth(std::u16string_view text) {
-	return smallFont.calcWidth(text);
+	if(smallFont)
+		return smallFont->calcWidth(text);
+	return 0;
 }
 
 int calcLargeFontWidth(std::string_view text) {
-	return largeFont.calcWidth(text);
+	if(largeFont)
+		return largeFont->calcWidth(text);
+	return 0;
 }
 int calcLargeFontWidth(std::u16string_view text) {
-	return largeFont.calcWidth(text);
+	if(largeFont)
+		return largeFont->calcWidth(text);
+	return 0;
 }
 
 int calcSmallFontHeight(std::string_view text) { return calcSmallFontHeight(FontGraphic::utf8to16(text)); }
 int calcSmallFontHeight(std::u16string_view text) {
-	int lines = 1;
-	for(auto c : text) {
-		if(c == '\n')
-			lines++;
+	if(smallFont) {
+		int lines = 1;
+		for(auto c : text) {
+			if(c == '\n')
+				lines++;
+		}
+		return lines * smallFont->height();
 	}
-	return lines * smallFont.height();
+
+	return 0;
 }
 
 int calcLargeFontHeight(std::string_view text) { return calcLargeFontHeight(FontGraphic::utf8to16(text)); }
 int calcLargeFontHeight(std::u16string_view text) {
-	int lines = 1;
-	for(auto c : text) {
-		if(c == '\n')
-			lines++;
+	if(largeFont) {
+		int lines = 1;
+		for(auto c : text) {
+			if(c == '\n')
+				lines++;
+		}
+		return lines * largeFont->height();
 	}
-	return lines * largeFont.height();
+
+	return 0;
 }
 
 u8 smallFontHeight(void) {
-	return smallFont.height();
+	if(smallFont)
+		return smallFont->height();
+	return 0;
 }
 
 u8 largeFontHeight(void) {
-	return largeFont.height();
+	if(largeFont)
+		return largeFont->height();
+	return 0;
 }

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
@@ -17,24 +17,27 @@ private:
 	static bool isWeak(char16_t c);
 	static bool isNumber(char16_t c);
 
-	u8 tileWidth, tileHeight;
-	u16 tileSize;
+	static u8 *lastUsedLoc;
+
+	bool useExpansionPak = false;
+	u8 tileWidth = 0, tileHeight = 0;
+	u16 tileSize = 0;
+	int tileAmount = 0;
 	u16 questionMark = 0;
-	u8* fontTiles = (u8*)0;
-	u8* fontWidths = (u8*)0;
-	std::vector<u8> fontTilesVector;
-	std::vector<u8> fontWidthsVector;
-	std::vector<u16> fontMap;
+	u8 *fontTiles = nullptr;
+	u8 *fontWidths = nullptr;
+	u16 *fontMap = nullptr;
 
 	u16 getCharIndex(char16_t c);
 
 public:
-	static u8 textBuf[2][256 * 192];
+	static u8 textBuf[1][256 * 192]; // Increase to two if adding top screen support
 
 	static std::u16string utf8to16(std::string_view text);
 
-	FontGraphic() {};
 	FontGraphic(const std::vector<std::string> &paths, const bool useExpansionPak);
+
+	~FontGraphic(void);
 
 	u8 height(void) { return tileHeight; }
 

--- a/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
@@ -1,34 +1,38 @@
-#include <nds/arm9/dldi.h>
 #include "fontHandler.h"
+
+#include <nds/arm9/dldi.h>
 #include <list>
 
 #include "common/dsimenusettings.h"
-#include "myDSiMode.h"
 #include "common/flashcard.h"
 #include "common/systemdetails.h"
 #include "common/tonccpy.h"
+#include "myDSiMode.h"
 #include "TextEntry.h"
 #include "ThemeConfig.h"
 
-FontGraphic smallFont;
-FontGraphic largeFont;
+FontGraphic *smallFont;
+FontGraphic *largeFont;
 
 std::list<TextEntry> topText, bottomText;
 
 bool shouldClear[] = {false, false};
 
-
 void fontInit() {
-	//iprintf("fontInit()\n");
-
 	extern u32 rotatingCubesLoaded;
 	bool useExpansionPak = (sys().isRegularDS() && ((*(u16*)(0x020000C0) != 0 && *(u16*)(0x020000C0) != 0x5A45) || *(vu16*)(0x08240000) == 1) && (*(u16*)(0x020000C0) != 0 || !rotatingCubesLoaded)
 							&& (io_dldi_data->ioInterface.features & FEATURE_SLOT_NDS));
 
+	// Unload fonts if already loaded
+	if(smallFont)
+		delete smallFont;
+	if(largeFont)
+		delete largeFont;
+
 	// Load font graphics
 	std::string fontPath = std::string(sdFound() ? "sd:" : "fat:") + "/_nds/TWiLightMenu/extras/fonts/" + ms().font;
-	smallFont = FontGraphic({fontPath + (((dsiFeatures()&&!sys().arm7SCFGLocked()) || useExpansionPak) ? "/small-dsi.nftr" : "/small-ds.nftr"), fontPath + "/small.nftr", "nitro:/graphics/font/small.nftr"}, useExpansionPak);
-	largeFont = FontGraphic({fontPath + (((dsiFeatures()&&!sys().arm7SCFGLocked()) || useExpansionPak) ? "/large-dsi.nftr" : "/large-ds.nftr"), fontPath + "/large.nftr", "nitro:/graphics/font/large.nftr"}, useExpansionPak);
+	smallFont = new FontGraphic({fontPath + (((dsiFeatures()&&!sys().arm7SCFGLocked()) || useExpansionPak) ? "/small-dsi.nftr" : "/small-ds.nftr"), fontPath + "/small.nftr", "nitro:/graphics/font/small.nftr"}, useExpansionPak);
+	largeFont = new FontGraphic({fontPath + (((dsiFeatures()&&!sys().arm7SCFGLocked()) || useExpansionPak) ? "/large-dsi.nftr" : "/large-ds.nftr"), fontPath + "/large.nftr", "nitro:/graphics/font/large.nftr"}, useExpansionPak);
 
 	// Load palettes
 	u16 palette[] = {
@@ -42,29 +46,23 @@ void fontInit() {
 }
 
 void fontReinit() {
-	//iprintf("fontReinit()\n");
+	// Unload fonts if already loaded
+	if(smallFont)
+		delete smallFont;
+	if(largeFont)
+		delete largeFont;
 
 	// Load font graphics
 	std::string fontPath = std::string("fat:") + "/_nds/TWiLightMenu/extras/fonts/" + ms().font;
-	smallFont = FontGraphic({fontPath + "/small-ds.nftr", fontPath + "/small.nftr", "nitro:/graphics/font/small.nftr"}, false);
-	largeFont = FontGraphic({fontPath + "/large-ds.nftr", fontPath + "/large.nftr", "nitro:/graphics/font/large.nftr"}, false);
-
-	// Load palettes (Already loaded)
-	/*u16 palette[] = {
-		tc().fontPalette1(),
-		tc().fontPalette2(),
-		tc().fontPalette3(),
-		tc().fontPalette4(),
-	};
-	tonccpy(BG_PALETTE, palette, sizeof(palette));
-	tonccpy(BG_PALETTE_SUB, palette, sizeof(palette));*/
+	smallFont = new FontGraphic({fontPath + "/small-ds.nftr", fontPath + "/small.nftr", "nitro:/graphics/font/small.nftr"}, false);
+	largeFont = new FontGraphic({fontPath + "/large-ds.nftr", fontPath + "/large.nftr", "nitro:/graphics/font/large.nftr"}, false);
 }
 
 static std::list<TextEntry> &getTextQueue(bool top) {
 	return top ? topText : bottomText;
 }
 
-FontGraphic &getFont(bool large) {
+FontGraphic *getFont(bool large) {
 	return large ? largeFont : smallFont;
 }
 
@@ -80,7 +78,9 @@ void updateText(bool top) {
 	// Draw text
 	auto &text = getTextQueue(top);
 	for(auto it = text.begin(); it != text.end(); ++it) {
-		getFont(it->large).print(it->x, it->y, top, it->message, it->align);
+		FontGraphic *font = getFont(it->large);
+		if(font)
+			font->print(it->x, it->y, top, it->message, it->align);
 	}
 	text.clear();
 
@@ -112,43 +112,63 @@ void printLarge(bool top, int x, int y, std::u16string_view message, Alignment a
 }
 
 int calcSmallFontWidth(std::string_view text) {
-	return smallFont.calcWidth(text);
+	if(smallFont)
+		return smallFont->calcWidth(text);
+	return 0;
 }
 int calcSmallFontWidth(std::u16string_view text) {
-	return smallFont.calcWidth(text);
+	if(smallFont)
+		return smallFont->calcWidth(text);
+	return 0;
 }
 
 int calcLargeFontWidth(std::string_view text) {
-	return largeFont.calcWidth(text);
+	if(largeFont)
+		return largeFont->calcWidth(text);
+	return 0;
 }
 int calcLargeFontWidth(std::u16string_view text) {
-	return largeFont.calcWidth(text);
+	if(largeFont)
+		return largeFont->calcWidth(text);
+	return 0;
 }
 
 int calcSmallFontHeight(std::string_view text) { return calcSmallFontHeight(FontGraphic::utf8to16(text)); }
 int calcSmallFontHeight(std::u16string_view text) {
-	int lines = 1;
-	for(auto c : text) {
-		if(c == '\n')
-			lines++;
+	if(smallFont) {
+		int lines = 1;
+		for(auto c : text) {
+			if(c == '\n')
+				lines++;
+		}
+		return lines * smallFont->height();
 	}
-	return lines * smallFont.height();
+
+	return 0;
 }
 
 int calcLargeFontHeight(std::string_view text) { return calcLargeFontHeight(FontGraphic::utf8to16(text)); }
 int calcLargeFontHeight(std::u16string_view text) {
-	int lines = 1;
-	for(auto c : text) {
-		if(c == '\n')
-			lines++;
+	if(largeFont) {
+		int lines = 1;
+		for(auto c : text) {
+			if(c == '\n')
+				lines++;
+		}
+		return lines * largeFont->height();
 	}
-	return lines * largeFont.height();
+
+	return 0;
 }
 
 u8 smallFontHeight(void) {
-	return smallFont.height();
+	if(smallFont)
+		return smallFont->height();
+	return 0;
 }
 
 u8 largeFontHeight(void) {
-	return largeFont.height();
+	if(largeFont)
+		return largeFont->height();
+	return 0;
 }

--- a/settings/arm9/source/graphics/FontGraphic.cpp
+++ b/settings/arm9/source/graphics/FontGraphic.cpp
@@ -2,7 +2,7 @@
 
 #include "common/tonccpy.h"
 
-static u8* lastUsedLoc = (u8*)0x08000000;
+u8 *FontGraphic::lastUsedLoc = (u8*)0x08000000;
 
 u8 FontGraphic::textBuf[2][256 * 192];
 
@@ -18,7 +18,7 @@ bool FontGraphic::isNumber(char16_t c) {
 	return c >= '0' && c <= '9';
 }
 
-FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useExpansionPak) {
+FontGraphic::FontGraphic(const std::vector<std::string> &paths, bool useExpansionPak) : useExpansionPak(useExpansionPak) {
 	FILE *file = nullptr;
 	for(const auto &path : paths) {
 		file = fopen(path.c_str(), "rb");
@@ -27,7 +27,7 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 	}
 
 	if(file) {
-		if (useExpansionPak && *(u16*)(0x020000C0) == 0 && lastUsedLoc == (u8*)0x08000000) {
+		if(useExpansionPak && *(u16*)(0x020000C0) == 0 && lastUsedLoc == (u8*)0x08000000) {
 			lastUsedLoc += 0x01000000;
 		}
 
@@ -47,21 +47,26 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 		fread(&tileSize, 2, 1, file);
 
 		// Load character glyphs
-		int tileAmount = ((chunkSize-0x10)/tileSize);
-		if (!useExpansionPak) {
-			fontTilesVector = std::vector<u8>(tileSize*tileAmount);
-			fontTiles = fontTilesVector.data();
-		} else {
-			fontTiles = lastUsedLoc;
-		}
+		tileAmount = (chunkSize - 0x10) / tileSize;
 		fseek(file, 4, SEEK_CUR);
-		fread(fontTiles, tileSize, tileAmount, file);
+		if(useExpansionPak) {
+			fontTiles = lastUsedLoc;
+			lastUsedLoc += tileSize * tileAmount;
+
+			u8 *buf = new u8[tileSize * tileAmount];
+			fread(buf, tileSize, tileAmount, file);
+			tonccpy(fontTiles, buf, tileSize * tileAmount);
+			delete[] buf;
+		} else {
+			fontTiles = new u8[tileSize * tileAmount];
+			fread(fontTiles, tileSize, tileAmount, file);
+		}
 
 		// Fix top row
-		for(int i=0;i<tileAmount;i++) {
-			fontTiles[i*tileSize] = 0;
-			fontTiles[i*tileSize+1] = 0;
-			fontTiles[i*tileSize+2] = 0;
+		for(int i = 0; i < tileAmount; i++) {
+			fontTiles[i * tileSize] = 0;
+			fontTiles[i * tileSize + 1] = 0;
+			fontTiles[i * tileSize + 2] = 0;
 		}
 
 		// Load character widths
@@ -71,17 +76,27 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 		fseek(file, locHDWC-4, SEEK_SET);
 		fread(&chunkSize, 4, 1, file);
 		fseek(file, 8, SEEK_CUR);
-		if (!useExpansionPak) {
-			fontWidthsVector = std::vector<u8>(3*tileAmount);
-			fontWidths = fontWidthsVector.data();
+		if(useExpansionPak) {
+			fontWidths = lastUsedLoc;
+			lastUsedLoc += 3 * tileAmount;
+
+			u8 *buf = new u8[3 * tileAmount];
+			fread(buf, 3, tileAmount, file);
+			tonccpy(fontWidths, buf, 3 * tileAmount);
+			delete[] buf;
 		} else {
-			fontWidths = fontTiles+(tileSize*tileAmount);
-			lastUsedLoc = fontWidths+((3*tileAmount)*4);
+			fontWidths = new u8[3 * tileAmount];
+			fread(fontWidths, 3, tileAmount, file);
 		}
-		fread(fontWidths, 3, tileAmount, file);
 
 		// Load character maps
-		fontMap = std::vector<u16>(tileAmount);
+		if(useExpansionPak) {
+			fontMap = (u16*)lastUsedLoc;
+			lastUsedLoc += tileAmount * sizeof(u16);
+		} else {
+			fontMap = new u16[tileAmount];
+		}
+
 		fseek(file, 0x28, SEEK_SET);
 		u32 locPAMC, mapType;
 		fread(&locPAMC, 4, 1, file);
@@ -129,10 +144,21 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 	}
 }
 
+FontGraphic::~FontGraphic(void) {
+	if(!useExpansionPak) {
+		if(fontTiles)
+			delete[] fontTiles;
+		if(fontWidths)
+			delete[] fontWidths;
+		if(fontMap)
+			delete[] fontMap;
+	}
+}
+
 u16 FontGraphic::getCharIndex(char16_t c) {
 	// Try a binary search
 	int left = 0;
-	int right = fontMap.size();
+	int right = tileAmount;
 
 	while(left <= right) {
 		int mid = left + ((right - left) / 2);

--- a/settings/arm9/source/graphics/FontGraphic.h
+++ b/settings/arm9/source/graphics/FontGraphic.h
@@ -17,14 +17,16 @@ private:
 	static bool isWeak(char16_t c);
 	static bool isNumber(char16_t c);
 
-	u8 tileWidth, tileHeight;
-	u16 tileSize;
+	static u8 *lastUsedLoc;
+
+	bool useExpansionPak = false;
+	u8 tileWidth = 0, tileHeight = 0;
+	u16 tileSize = 0;
+	int tileAmount = 0;
 	u16 questionMark = 0;
-	u8* fontTiles = (u8*)0;
-	u8* fontWidths = (u8*)0;
-	std::vector<u8> fontTilesVector;
-	std::vector<u8> fontWidthsVector;
-	std::vector<u16> fontMap;
+	u8 *fontTiles = nullptr;
+	u8 *fontWidths = nullptr;
+	u16 *fontMap = nullptr;
 
 	u16 getCharIndex(char16_t c);
 
@@ -33,8 +35,9 @@ public:
 
 	static std::u16string utf8to16(std::string_view text);
 
-	FontGraphic() {};
 	FontGraphic(const std::vector<std::string> &paths, const bool useExpansionPak);
+
+	~FontGraphic(void);
 
 	u8 height(void) { return tileHeight; }
 

--- a/title/arm9/source/graphics/FontGraphic.cpp
+++ b/title/arm9/source/graphics/FontGraphic.cpp
@@ -2,7 +2,7 @@
 
 #include "common/tonccpy.h"
 
-static u8* lastUsedLoc = (u8*)0x08000000;
+u8 *FontGraphic::lastUsedLoc = (u8*)0x08000000;
 
 u8 FontGraphic::textBuf[2][256 * 192];
 
@@ -18,7 +18,7 @@ bool FontGraphic::isNumber(char16_t c) {
 	return c >= '0' && c <= '9';
 }
 
-FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useExpansionPak) {
+FontGraphic::FontGraphic(const std::vector<std::string> &paths, bool useExpansionPak) : useExpansionPak(useExpansionPak) {
 	FILE *file = nullptr;
 	for(const auto &path : paths) {
 		file = fopen(path.c_str(), "rb");
@@ -27,7 +27,7 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 	}
 
 	if(file) {
-		if (useExpansionPak && *(u16*)(0x020000C0) == 0 && lastUsedLoc == (u8*)0x08000000) {
+		if(useExpansionPak && *(u16*)(0x020000C0) == 0 && lastUsedLoc == (u8*)0x08000000) {
 			lastUsedLoc += 0x01000000;
 		}
 
@@ -47,21 +47,26 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 		fread(&tileSize, 2, 1, file);
 
 		// Load character glyphs
-		int tileAmount = ((chunkSize-0x10)/tileSize);
-		if (!useExpansionPak) {
-			fontTilesVector = std::vector<u8>(tileSize*tileAmount);
-			fontTiles = fontTilesVector.data();
-		} else {
-			fontTiles = lastUsedLoc;
-		}
+		tileAmount = (chunkSize - 0x10) / tileSize;
 		fseek(file, 4, SEEK_CUR);
-		fread(fontTiles, tileSize, tileAmount, file);
+		if(useExpansionPak) {
+			fontTiles = lastUsedLoc;
+			lastUsedLoc += tileSize * tileAmount;
+
+			u8 *buf = new u8[tileSize * tileAmount];
+			fread(buf, tileSize, tileAmount, file);
+			tonccpy(fontTiles, buf, tileSize * tileAmount);
+			delete[] buf;
+		} else {
+			fontTiles = new u8[tileSize * tileAmount];
+			fread(fontTiles, tileSize, tileAmount, file);
+		}
 
 		// Fix top row
-		for(int i=0;i<tileAmount;i++) {
-			fontTiles[i*tileSize] = 0;
-			fontTiles[i*tileSize+1] = 0;
-			fontTiles[i*tileSize+2] = 0;
+		for(int i = 0; i < tileAmount; i++) {
+			fontTiles[i * tileSize] = 0;
+			fontTiles[i * tileSize + 1] = 0;
+			fontTiles[i * tileSize + 2] = 0;
 		}
 
 		// Load character widths
@@ -71,17 +76,27 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 		fseek(file, locHDWC-4, SEEK_SET);
 		fread(&chunkSize, 4, 1, file);
 		fseek(file, 8, SEEK_CUR);
-		if (!useExpansionPak) {
-			fontWidthsVector = std::vector<u8>(3*tileAmount);
-			fontWidths = fontWidthsVector.data();
+		if(useExpansionPak) {
+			fontWidths = lastUsedLoc;
+			lastUsedLoc += 3 * tileAmount;
+
+			u8 *buf = new u8[3 * tileAmount];
+			fread(buf, 3, tileAmount, file);
+			tonccpy(fontWidths, buf, 3 * tileAmount);
+			delete[] buf;
 		} else {
-			fontWidths = fontTiles+(tileSize*tileAmount);
-			lastUsedLoc = fontWidths+((3*tileAmount)*4);
+			fontWidths = new u8[3 * tileAmount];
+			fread(fontWidths, 3, tileAmount, file);
 		}
-		fread(fontWidths, 3, tileAmount, file);
 
 		// Load character maps
-		fontMap = std::vector<u16>(tileAmount);
+		if(useExpansionPak) {
+			fontMap = (u16*)lastUsedLoc;
+			lastUsedLoc += tileAmount * sizeof(u16);
+		} else {
+			fontMap = new u16[tileAmount];
+		}
+
 		fseek(file, 0x28, SEEK_SET);
 		u32 locPAMC, mapType;
 		fread(&locPAMC, 4, 1, file);
@@ -129,10 +144,21 @@ FontGraphic::FontGraphic(const std::vector<std::string> &paths, const bool useEx
 	}
 }
 
+FontGraphic::~FontGraphic(void) {
+	if(!useExpansionPak) {
+		if(fontTiles)
+			delete[] fontTiles;
+		if(fontWidths)
+			delete[] fontWidths;
+		if(fontMap)
+			delete[] fontMap;
+	}
+}
+
 u16 FontGraphic::getCharIndex(char16_t c) {
 	// Try a binary search
 	int left = 0;
-	int right = fontMap.size();
+	int right = tileAmount;
 
 	while(left <= right) {
 		int mid = left + ((right - left) / 2);

--- a/title/arm9/source/graphics/FontGraphic.h
+++ b/title/arm9/source/graphics/FontGraphic.h
@@ -17,14 +17,16 @@ private:
 	static bool isWeak(char16_t c);
 	static bool isNumber(char16_t c);
 
-	u8 tileWidth, tileHeight;
-	u16 tileSize;
+	static u8 *lastUsedLoc;
+
+	bool useExpansionPak = false;
+	u8 tileWidth = 0, tileHeight = 0;
+	u16 tileSize = 0;
+	int tileAmount = 0;
 	u16 questionMark = 0;
-	u8* fontTiles = (u8*)0;
-	u8* fontWidths = (u8*)0;
-	std::vector<u8> fontTilesVector;
-	std::vector<u8> fontWidthsVector;
-	std::vector<u16> fontMap;
+	u8 *fontTiles = nullptr;
+	u8 *fontWidths = nullptr;
+	u16 *fontMap = nullptr;
 
 	u16 getCharIndex(char16_t c);
 
@@ -33,8 +35,9 @@ public:
 
 	static std::u16string utf8to16(std::string_view text);
 
-	FontGraphic() {};
 	FontGraphic(const std::vector<std::string> &paths, const bool useExpansionPak);
+
+	~FontGraphic(void);
 
 	u8 height(void) { return tileHeight; }
 

--- a/title/arm9/source/graphics/fontHandler.cpp
+++ b/title/arm9/source/graphics/fontHandler.cpp
@@ -1,5 +1,6 @@
-#include <nds/arm9/dldi.h>
 #include "fontHandler.h"
+
+#include <nds/arm9/dldi.h>
 #include <list>
 
 #include "common/dsimenusettings.h"
@@ -9,22 +10,26 @@
 #include "myDSiMode.h"
 #include "TextEntry.h"
 
-FontGraphic smallFont;
-FontGraphic largeFont;
+FontGraphic *smallFont;
+FontGraphic *largeFont;
 
 std::list<TextEntry> topText, bottomText;
 
 bool shouldClear[] = {false, false};
 
 void fontInit() {
-	//iprintf("fontInit()\n");
-
 	bool useExpansionPak = (sys().isRegularDS() && ((*(u16*)(0x020000C0) != 0 && *(u16*)(0x020000C0) != 0x5A45) || *(vu16*)(0x08240000) == 1) && (io_dldi_data->ioInterface.features & FEATURE_SLOT_NDS));
+
+	// Unload fonts if already loaded
+	if(smallFont)
+		delete smallFont;
+	if(largeFont)
+		delete largeFont;
 
 	// Load font graphics
 	std::string fontPath = std::string(sdFound() ? "sd:" : "fat:") + "/_nds/TWiLightMenu/extras/fonts/" + ms().font;
-	smallFont = FontGraphic({fontPath + ((dsiFeatures() || useExpansionPak) ? "/small-dsi.nftr" : "/small-ds.nftr"), fontPath + "/small.nftr", "nitro:/graphics/font/small.nftr"}, useExpansionPak);
-	largeFont = FontGraphic({fontPath + ((dsiFeatures() || useExpansionPak) ? "/large-dsi.nftr" : "/large-ds.nftr"), fontPath + "/large.nftr", "nitro:/graphics/font/large.nftr"}, useExpansionPak);
+	smallFont = new FontGraphic({fontPath + ((dsiFeatures() || useExpansionPak) ? "/small-dsi.nftr" : "/small-ds.nftr"), fontPath + "/small.nftr", "nitro:/graphics/font/small.nftr"}, useExpansionPak);
+	largeFont = new FontGraphic({fontPath + ((dsiFeatures() || useExpansionPak) ? "/large-dsi.nftr" : "/large-ds.nftr"), fontPath + "/large.nftr", "nitro:/graphics/font/large.nftr"}, useExpansionPak);
 
 	// Load palettes
 	u16 palette[] = {
@@ -41,7 +46,7 @@ static std::list<TextEntry> &getTextQueue(bool top) {
 	return top ? topText : bottomText;
 }
 
-FontGraphic &getFont(bool large) {
+FontGraphic *getFont(bool large) {
 	return large ? largeFont : smallFont;
 }
 
@@ -55,7 +60,9 @@ void updateText(bool top) {
 	// Draw text
 	auto &text = getTextQueue(top);
 	for(auto it = text.begin(); it != text.end(); ++it) {
-		getFont(it->large).print(it->x, it->y, top, it->message, it->align);
+		FontGraphic *font = getFont(it->large);
+		if(font)
+			font->print(it->x, it->y, top, it->message, it->align);
 	}
 	text.clear();
 
@@ -87,43 +94,63 @@ void printLarge(bool top, int x, int y, std::u16string_view message, Alignment a
 }
 
 int calcSmallFontWidth(std::string_view text) {
-	return smallFont.calcWidth(text);
+	if(smallFont)
+		return smallFont->calcWidth(text);
+	return 0;
 }
 int calcSmallFontWidth(std::u16string_view text) {
-	return smallFont.calcWidth(text);
+	if(smallFont)
+		return smallFont->calcWidth(text);
+	return 0;
 }
 
 int calcLargeFontWidth(std::string_view text) {
-	return largeFont.calcWidth(text);
+	if(largeFont)
+		return largeFont->calcWidth(text);
+	return 0;
 }
 int calcLargeFontWidth(std::u16string_view text) {
-	return largeFont.calcWidth(text);
+	if(largeFont)
+		return largeFont->calcWidth(text);
+	return 0;
 }
 
 int calcSmallFontHeight(std::string_view text) { return calcSmallFontHeight(FontGraphic::utf8to16(text)); }
 int calcSmallFontHeight(std::u16string_view text) {
-	int lines = 1;
-	for(auto c : text) {
-		if(c == '\n')
-			lines++;
+	if(smallFont) {
+		int lines = 1;
+		for(auto c : text) {
+			if(c == '\n')
+				lines++;
+		}
+		return lines * smallFont->height();
 	}
-	return lines * smallFont.height();
+
+	return 0;
 }
 
 int calcLargeFontHeight(std::string_view text) { return calcLargeFontHeight(FontGraphic::utf8to16(text)); }
 int calcLargeFontHeight(std::u16string_view text) {
-	int lines = 1;
-	for(auto c : text) {
-		if(c == '\n')
-			lines++;
+	if(largeFont) {
+		int lines = 1;
+		for(auto c : text) {
+			if(c == '\n')
+				lines++;
+		}
+		return lines * largeFont->height();
 	}
-	return lines * largeFont.height();
+
+	return 0;
 }
 
 u8 smallFontHeight(void) {
-	return smallFont.height();
+	if(smallFont)
+		return smallFont->height();
+	return 0;
 }
 
 u8 largeFontHeight(void) {
-	return largeFont.height();
+	if(largeFont)
+		return largeFont->height();
+	return 0;
 }

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1152,15 +1152,15 @@ void resetSettingsPrompt(void) {
 
 	bool rtl = ms().guiLanguage == TWLSettings::TLanguage::ELangHebrew;
 	Alignment align = rtl ? Alignment::right : Alignment::left;
-	int x1 = rtl ? 256 - 2 : 2, x2 = rtl ? 256 - 15 : 15;
+	int x = rtl ? 256 - 2 : 2;
 
 	clearText();
-	printLarge(false, x1, 0, STR_RESET_TWILIGHT_SETTINGS, align);
+	printLarge(false, x, 0, STR_RESET_TWILIGHT_SETTINGS, align);
 	int y = calcLargeFontHeight(STR_RESET_TWILIGHT_SETTINGS);
-	printSmall(false, x1, y, STR_PGS_WILL_BE_KEPT, align);
+	printSmall(false, x, y, STR_PGS_WILL_BE_KEPT, align);
 
-	printSmall(false, x1, y + 20, STR_A_YES, align);
-	printSmall(false, x1, y + 20 + 14, STR_B_NO, align);
+	printSmall(false, x, y + 20, STR_A_YES, align);
+	printSmall(false, x, y + 20 + 14, STR_B_NO, align);
 
 	updateText(false);
 
@@ -1594,7 +1594,6 @@ int main(int argc, char **argv)
 							   // SD card, or if SD access is disabled
 	}
 
-	bool fontInited = false;
 	scanKeys();
 	if ((keysHeld() & KEY_A)
 	 && (keysHeld() & KEY_B)


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Reads from the file to a buffer, then tonccpys that to the expansion pak, I think the problem was that fread() was doing 8-bit writes
- Also a fair bit of cleanup such as using pointers to not have a partly initialized font, using `new` buffers instead of vectors, and moving lastUsedLoc into the class, but nothing that should impact functionality

#### Where have you tested it?

- DSi (K) from Unlaunch and DSONE
- DS Lite (J) from DSONE

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
