### PR TITLE
Fix DS mode username

### DIFF
--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -795,7 +795,11 @@ int main(int argc, char **argv) {
 	}
 
 	//printf("Username copied\n");
-	tonccpy(usernameRendered, (useTwlCfg ? (s16*)0x02000448 : PersonalData->name), sizeof(s16) * 10);
+	if(useTwlCfg) {
+		tonccpy(usernameRendered, (s16*)0x02000448, sizeof(s16) * 10);
+	} else {
+		tonccpy(usernameRendered, PersonalData->name, sizeof(s16) * PersonalData->nameLen);
+	}
 
 	if (sdFound()) statvfs("sd:/", &st[0]);
 	if (flashcardFound()) statvfs("fat:/", &st[1]);

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -744,25 +744,10 @@ int main(int argc, char **argv)
 
 	useTwlCfg = (dsiFeatures() && (*(u8*)0x02000400 & 0x0F) && (*(u8*)0x02000401 == 0) && (*(u8*)0x02000402 == 0) && (*(u8*)0x02000404 == 0) && (*(u8*)0x02000448 != 0));
 
-	if (!sys().fatInitOk())
-	{
-		// Read user name
-		char usernameRendered[16];
-		char *username = (useTwlCfg ? (char*)0x02000448 : (char*)PersonalData->name);
-
-		// text
-		for (int i = 0; i < 10; i++)
-		{
-			if (username[i * 2] == 0x00)
-				usernameRendered[i * 2 / 2] = 0;
-			else
-				usernameRendered[i * 2 / 2] = username[i * 2];
-		}
-
+	if (!sys().fatInitOk()) {
 		graphicsInit();
 		fontInit();
 		fadeType = true;
-		printSmall(true, 28, 1, usernameRendered);
 		printSmall(false, 4, 4, "fatinitDefault failed!");
 		stop();
 	}


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes the DS mode username in the DSi theme sometimes picking up garbage leftovers from old names at the end
   - The username has the length specified right after it and I guess sometimes when using a shorter name it doesn't actually overwrite the end to null so that'll show up if you just show all 10
- Also removes settings printing the name to the top screen when FAT init fails as that seems unnecessary and was doing the length wrong there too, if there's a reason that's done let me know and I can undo it

#### Where have you tested it?

- Tested by @SNBeast (I'm not having the issue)

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
