### PR TITLE
Repack booter with animated banner

### DIFF
--- a/booter/Makefile
+++ b/booter/Makefile
@@ -137,6 +137,12 @@ $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004 -a 00000138 -b icon.bmp "TWiLight Menu++;RocketRobz"
 
+	# Unpack and repack with animated banner
+	mkdir -p NDS_UNPACK
+	ndstool -x $(TARGET).nds -9 NDS_UNPACK/arm9.bin -7 NDS_UNPACK/arm7.bin -y9 NDS_UNPACK/y9.bin -y7 NDS_UNPACK/y7.bin -d NDS_UNPACK/data -y NDS_UNPACK/overlay -h NDS_UNPACK/header.bin
+	ndstool -c $(TARGET).nds -9 NDS_UNPACK/arm9.bin -7 NDS_UNPACK/arm7.bin -y9 NDS_UNPACK/y9.bin -y7 NDS_UNPACK/y7.bin -d NDS_UNPACK/data -y NDS_UNPACK/overlay -h NDS_UNPACK/header.bin -t twl_banner.bin
+	rm -rf NDS_UNPACK
+
 $(TARGET)_rungame.nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET)_rungame.nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-g SLRN 01 "TWLMENUPP-LR" -z 80040000 -u 00030015 -a 00000138 -b icon.bmp "TWiLight Menu++;Last-run ROM;RocketRobz"


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes booter.nds be repacked with the animated banner
   - ndstool corrupts it when using `-t twl_banner.bin` directly, but for whatever reason it works when repacking

#### Where have you tested it?

- DSi (K) in TWiLight and n3DS (U) in HOME Menu

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
