### PR TITLE
Fix getTitleLanguage() returning gameLangauge

### DIFF
--- a/quickmenu/arm9/source/common/dsimenusettings.cpp
+++ b/quickmenu/arm9/source/common/dsimenusettings.cpp
@@ -322,7 +322,7 @@ TWLSettings::TLanguage TWLSettings::getTitleLanguage()
     {
         return (TLanguage)PersonalData->language;
     }
-    return (TLanguage)gameLanguage;
+    return (TLanguage)titleLanguage;
 }
 
 std::string TWLSettings::getGuiLanguageString()

--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
@@ -320,7 +320,7 @@ TWLSettings::TLanguage TWLSettings::getTitleLanguage()
 	{
 		return (TLanguage)PersonalData->language;
 	}
-	return (TLanguage)gameLanguage;
+	return (TLanguage)titleLanguage;
 }
 
 std::string TWLSettings::getGuiLanguageString()


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes `getTitleLanguage()` returning `gameLanguage` when not default
   - This would cause the "negative first" title to be loaded when the "game language" was default but the "game title language" wasn't, resulting in a lot of � and usually a few CJK characters
- Fixes #1442 I think, oddly people have been fixing it by changing the "game title language" to anything *besides* system which should be exactly the cause... Perhaps they actually changed the "game language"?

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
