### PR TITLE
Use YSMenu as flashcart loader for DSONE(i) SDHC

### DIFF
--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -678,7 +678,8 @@ void loadGameOnFlashcard (const char* ndsPath, bool dsGame) {
 		err = runNdsFile("fat:/_dstwo/autoboot.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram, -1);
 	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -591,7 +591,8 @@ void loadGameOnFlashcard (const char *ndsPath, bool dsGame) {
 		err = runNdsFile("fat:/_dstwo/autoboot.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram, -1);
 	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1024,7 +1024,8 @@ void loadGameOnFlashcard (const char* ndsPath, bool dsGame) {
 		err = runNdsFile("fat:/_dstwo/autoboot.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram, -1);
 	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/rungame/arm9/source/main.cpp
+++ b/rungame/arm9/source/main.cpp
@@ -419,7 +419,8 @@ TWL_CODE int lastRunROM() {
 					return runNdsFile("fat:/_dstwo/autoboot.nds", 0, NULL, true, true, true, runNds_boostCpu, runNds_boostVram, -1);
 				} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 						 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
-						 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)) {
+						 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
+						 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)) {
 					CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 					path = ReplaceAll(romPath[1], "fat:/", slashchar);
 					fcrompathini.SetString("YSMENU", "AUTO_BOOT", path);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Fixes #1447.
~~I think I covered everything~~ At any point a ROM is to be loaded with nds-bootstrap turned off on a DSONE SDHC or DSONEi, it should now load it through YSMenu.

**Only works on DSONE SDHC and DSONEi. YSMenu is incompatible with the original DSONE.** And, as far as I'm aware, the current autoboot doesn't work on the original DSONE anyway.

#### Where have you tested it?

2x DSONE SDHC. 

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
