### PR TITLE
Fix DS Classic Menu error screen palette

### DIFF
--- a/quickmenu/arm9/source/errorScreen.cpp
+++ b/quickmenu/arm9/source/errorScreen.cpp
@@ -49,8 +49,8 @@ void checkSdEject(void) {
 		0xD6B5,
 		0xFFFF,
 	};
-	tonccpy(BG_PALETTE + 0xF8, palette, sizeof(palette));
-	tonccpy(BG_PALETTE_SUB + 0xF8, palette, sizeof(palette));
+	tonccpy(BG_PALETTE, palette, sizeof(palette));
+	tonccpy(BG_PALETTE_SUB, palette, sizeof(palette));
 
 	swiWaitForVBlank();
 	clearText();


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Sorry, didn't notice this was missed in the last commit until checking VS Code again after it was merged :sweat_smile:
- Simply fixes the error screen text palette so the text is actually visible

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
