### PR TITLE
DSi theme: Display bootstrap screenshot on top if no photos

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -1667,7 +1667,6 @@ void loadBootstrapScreenshot(FILE *file) {
 			u16 val = buffer[(row * 12 / 10) * 256 + (col * 12 / 10)];
 
 			// RGB 565 -> BGR 5551
-			// ((val >> 10) & 31) | ((val & (31 << 5)) << 1) | ((val & 31) << 11)
 			val = ((val >> 11) & 0x1F) | ((val & (0x1F << 6)) >> 1) | ((val & 0x1F) << 10) | BIT(15);
 
 			u8 y = photoHeight - row - 1;


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Makes the DSi theme show a random nds-bootstrap screenshot on the top screen if there are no photos in `sd:/_nds/TWiLightMenu/dsimenu/photos`.

![screenshot](https://user-images.githubusercontent.com/41608708/127726363-9d749c8d-6234-4ab3-8008-101fe9c36afa.png)

#### Where have you tested it?

- DSi (K) from Unlaunch and DSONE

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
