### PR TITLE
Add LEGO Harry Potter games to async exclude list

### DIFF
--- a/universal/include/asyncReadExcludeMap.h
+++ b/universal/include/asyncReadExcludeMap.h
@@ -21,6 +21,8 @@ static const char asyncReadExcludeList[][4] = {
 	"V2G", // Mario vs. Donkey Kong: Mini-Land Mayhem!
 	"BKI", // The Legend of Zelda: Spirit Tracks (Keeps AP-fix in effect)
 	"Y7S", // The Legend of Zelda: Spirit Tracks (Demo)
+	"BLH", // LEGO Harry Potter: Years 1-4
+	"B83", // LEGO Harry Potter: Years 5-7
 	"AWV", // Nervous Brickdown
 	"B2K", // Ni no Kuni: The Jet Black Mage
 	"IRB", // Pokemon Black Version (Keeps AP-fix in effect)


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- They freeze with black screens when trying to play videos (on loading levels) with it on
- LEGO Star Wars: The Complete Saga and LEGO Indiana Jones: The Original Adventures work fine with async, I don't have any other LEGO games to test though
- Sorry if I messed something up, haven't touched these lists before lol

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
