### PR TITLE
Fix spacing of game icons in DSi-based themes

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -2130,7 +2130,7 @@ std::string browseForFile(const std::vector<std::string> extensionList) {
 				}
 
 				movingApp = -1;
-				titleboxXspacing = 64;
+				titleboxXspacing = 58;
 				titleboxXdest[ms().secondaryDevice] = titleboxXpos[ms().secondaryDevice] = CURPOS * titleboxXspacing;
 			} else if ((pressed & KEY_TOUCH) && touch.py > 171 && touch.px >= 30 && touch.px <= 227 && ms().theme == 0) { // Scroll bar (DSi theme)
 				touchPosition startTouch = touch;

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -131,7 +131,7 @@ int titleboxYpos = 85; // 85, when dropped down
 int titlewindowXpos[2] = {0};
 int titlewindowXdest[2] = {0};
 int titleboxXspeed = 3; // higher is SLOWER
-int titleboxXspacing = 64;
+int titleboxXspacing = 58;
 
 bool reloadDate = false;
 bool reloadTime = false;
@@ -676,6 +676,9 @@ void vBlankHandler() {
 			int spawnedboxXpos = 96;
 			int iconXpos = 112;
 
+			int realCurPos = (titleboxXpos[ms().secondaryDevice] + 32) / titleboxXspacing;
+			int titleboxOffset = (realCurPos * titleboxXspacing) - (titleboxXpos[ms().secondaryDevice]);
+
 			int maxIconNumber = (ms().theme == 4 ? 0 : 3);
 			for (int pos = std::max(CURPOS - maxIconNumber, 0); pos <= std::min(CURPOS + maxIconNumber, 39); pos++) {
 				int i = pos;
@@ -683,6 +686,23 @@ void vBlankHandler() {
 				if (movingApp == -1) {
 					spawnedboxXpos = 96 + pos * titleboxXspacing;
 					iconXpos = 112 + pos * titleboxXspacing;
+
+					if (titleboxOffset >= 22 && titleboxOffset <= 32 && (i == realCurPos || i == realCurPos - 1)) {
+						int adjust = 0;
+						if (i == realCurPos)
+							adjust = (titleboxOffset - 22) * 7 / 10;
+						else if (i == realCurPos - 1)
+							adjust = -((10 - (titleboxOffset - 22)) * 7 / 10);
+
+						spawnedboxXpos += adjust;
+						iconXpos += adjust;
+					} else if (i < realCurPos) {
+						spawnedboxXpos -= 7;
+						iconXpos -= 7;
+					} else if (i > realCurPos) {
+						spawnedboxXpos += 7;
+						iconXpos += 7;
+					}
 				} else {
 					spawnedboxXpos = 96 + 38 + pos * titleboxXspacing;
 					iconXpos = 112 + 38 + pos * titleboxXspacing;


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- I accidentally broke the spacing in #1578, this fixes it
- Also makes it move smoothly and fixed up the spacing in general bit more which is why this took a while. The spacing should be pixel perfect to the real DSi menu now I think, the movement isn't quite the same but this was a bit easier and looks at least as good imo.

   https://user-images.githubusercontent.com/41608708/128965353-044cfbe1-993f-4af1-b4a7-98119d8d6d0c.mp4


#### Where have you tested it?

- DSi (K) from Unlaunch, no$gba

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
