### PR TITLE
Speed up directory loading a bit

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -228,7 +228,6 @@ void updateDirectoryContents(vector<DirEntry> &dirContents) {
 	int currentPos = PAGENUM*40;
 	for (int i = 0; i < 40; i++) {
 		sprintf(str, "%d", i+(PAGENUM*40));
-		DirEntry dirEntry;
 		std::string filename = twlmDirInfo.GetString("LIST", str, "");
 
 		if (filename != "") {
@@ -351,7 +350,7 @@ void getDirectoryContents(std::vector<DirEntry> &dirContents, const std::vector<
 					else if (lhs.isDirectory && !rhs.isDirectory)
 						return true;
 
-					int extCmp = strcasecmp(lhs.name.substr(lhs.name.find_last_of('.') + 1).c_str(), rhs.name.substr(rhs.name.find_last_of('.') + 1).c_str()) == 0;
+					int extCmp = strcasecmp(lhs.name.substr(lhs.name.find_last_of('.') + 1).c_str(), rhs.name.substr(rhs.name.find_last_of('.') + 1).c_str());
 					if(extCmp == 0)
 						return strcasecmp(lhs.name.c_str(), rhs.name.c_str()) < 0;
 					else

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.h
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.h
@@ -29,6 +29,6 @@
 
 bool extension(const std::string_view filename, const std::vector<std::string_view> extensions);
 
-std::string browseForFile(const std::vector<std::string> extensionList);
+std::string browseForFile(const std::vector<std::string_view> extensionList);
 
 #endif //FILE_BROWSE_H

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -57,7 +57,8 @@ extern int movingApp;
 #define TITLE_CACHE_SIZE 0x80
 
 static bool infoFound[41] = {false};
-static char16_t cachedTitle[41][TITLE_CACHE_SIZE];
+static const char16_t *cachedTitle[41];
+static const char16_t *blankTitle = u"";
 
 static u32 arm9StartSig[4];
 
@@ -239,7 +240,7 @@ void loadFixedBanner(sNDSBannerExt &ndsBanner) {
 }
 
 void clearTitle(int num) {
-	toncset(cachedTitle[num], 0, TITLE_CACHE_SIZE);
+	cachedTitle[num] = blankTitle;
 }
 
 void getGameInfo(bool isDir, const char *name, int num) {
@@ -480,12 +481,12 @@ void getGameInfo(bool isDir, const char *name, int num) {
 
 			if (ndsBanner.version == NDS_BANNER_VER_ZH || ndsBanner.version == NDS_BANNER_VER_ZH_KO || ndsBanner.version == NDS_BANNER_VER_DSi) {
 				if (ndsBanner.titles[ms().getGameLanguage()][0] == 0) {
-					tonccpy(cachedTitle[num], ndsBanner.titles[ms().getTitleLanguage()], TITLE_CACHE_SIZE);
+					cachedTitle[num] = (char16_t*)&ndsBanner.titles[ms().getTitleLanguage()];
 				} else {
-					tonccpy(cachedTitle[num], ndsBanner.titles[ms().getGameLanguage()], TITLE_CACHE_SIZE);
+					cachedTitle[num] = (char16_t*)&ndsBanner.titles[ms().getGameLanguage()];
 				}
 			} else {
-				tonccpy(cachedTitle[num], ndsBanner.titles[ms().getTitleLanguage()], TITLE_CACHE_SIZE);
+				cachedTitle[num] = (char16_t*)&ndsBanner.titles[ms().getTitleLanguage()];
 			}
 
 			return;
@@ -511,7 +512,7 @@ void getGameInfo(bool isDir, const char *name, int num) {
 				fread(&ndsBanner, 1, NDS_BANNER_SIZE_ZH_KO, bannerFile);
 				fclose(bannerFile);
 
-				tonccpy(cachedTitle[num], ndsBanner.titles[ms().getGameLanguage()], TITLE_CACHE_SIZE);
+				cachedTitle[num] = (char16_t*)&ndsBanner.titles[ms().getGameLanguage()];
 
 				return;
 			}
@@ -533,7 +534,7 @@ void getGameInfo(bool isDir, const char *name, int num) {
 			currentLang--;
 		}
 
-		tonccpy(cachedTitle[num], ndsBanner.titles[currentLang], TITLE_CACHE_SIZE);
+		cachedTitle[num] = (char16_t*)&ndsBanner.titles[currentLang];
 
 		infoFound[num] = true;
 

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -862,7 +862,7 @@ int main(int argc, char **argv) {
 
 	keysSetRepeat(10, 2);
 
-	std::vector<std::string> extensionList;
+	std::vector<std::string_view> extensionList;
 	if (ms().showNds) {
 		extensionList.emplace_back(".nds");
 		extensionList.emplace_back(".dsi");

--- a/romsel_r4theme/arm9/source/fileBrowse.cpp
+++ b/romsel_r4theme/arm9/source/fileBrowse.cpp
@@ -144,9 +144,15 @@ struct DirEntry {
 	bool customPos;
 };
 
-bool nameEndsWith (const string& name, const vector<string> extensionList) {
+bool extension(const std::string_view filename, const std::vector<std::string_view> extensions) {
+	for(std::string_view extension : extensions) {
+		if(strcasecmp(filename.substr(filename.size() - extension.size()).data(), extension.data()) == 0) {
+			return true;
+		}
+	}
 
-	if (name.substr(0,2) == "._")	return false;	// Don't show macOS's index files
+	return false;
+}
 
 	if (name.size() == 0) return false;
 
@@ -637,8 +643,6 @@ void cannotLaunchMsg(void) {
 	for (int i = 0; i < 25; i++) swiWaitForVBlank();
 }
 
-extern bool extention(const std::string& filename, const char* ext);
-
 string browseForFile(const vector<string> extensionList) {
 	if (macroMode) {
 		lcdMainOnTop();
@@ -698,37 +702,31 @@ string browseForFile(const vector<string> extensionList) {
 			isDirectory = false;
 			std::string std_romsel_filename = dirContents.at(fileOffset).name.c_str();
 
-			if (extention(std_romsel_filename, ".nds")
-			 || extention(std_romsel_filename, ".dsi")
-			 || extention(std_romsel_filename, ".ids")
-			 || extention(std_romsel_filename, ".srl")
-			 || extention(std_romsel_filename, ".app")
-			 || extention(std_romsel_filename, ".argv"))
+			if (extension(std_romsel_filename, {".nds", ".dsi", ".ids", ".srl", ".app", ".argv"}))
 			{
 				getGameInfo(isDirectory, dirContents.at(fileOffset).name.c_str());
 				bnrRomType = 0;
-			} else if (extention(std_romsel_filename, ".pce")) {
+			} else if (extension(std_romsel_filename, {".pce"})) {
 				bnrRomType = 11;
-			} else if (extention(std_romsel_filename, ".xex") || extention(std_romsel_filename, ".atr")
-			 || extention(std_romsel_filename, ".a26") || extention(std_romsel_filename, ".a52") || extention(std_romsel_filename, ".a78")) {
+			} else if (extension(std_romsel_filename, {".xex", ".atr", ".a26", ".a52", ".a78"})) {
 				bnrRomType = 10;
-			} else if (extention(std_romsel_filename, ".plg") || extention(std_romsel_filename, ".rvid") || extention(std_romsel_filename, ".fv")) {
+			} else if (extension(std_romsel_filename, {".plg", ".rvid", ".fv"})) {
 				bnrRomType = 9;
-			} else if (extention(std_romsel_filename, ".agb") || extention(std_romsel_filename, ".gba") || extention(std_romsel_filename, ".mb")) {
+			} else if (extension(std_romsel_filename, {".agb", ".gba", ".mb"})) {
 				bnrRomType = 1;
-			} else if (extention(std_romsel_filename, ".gb") || extention(std_romsel_filename, ".sgb")) {
+			} else if (extension(std_romsel_filename, {".gb", ".sgb"})) {
 				bnrRomType = 2;
-			} else if (extention(std_romsel_filename, ".gbc")) {
+			} else if (extension(std_romsel_filename,{ ".gbc"})) {
 				bnrRomType = 3;
-			} else if (extention(std_romsel_filename, ".nes") || extention(std_romsel_filename, ".fds")) {
+			} else if (extension(std_romsel_filename, {".nes", ".fds"})) {
 				bnrRomType = 4;
-			} else if(extention(std_romsel_filename, ".sms")) {
+			} else if(extension(std_romsel_filename, {".sms"})) {
 				bnrRomType = 5;
-			} else if(extention(std_romsel_filename, ".gg")) {
+			} else if(extension(std_romsel_filename, {".gg"})) {
 				bnrRomType = 6;
-			} else if(extention(std_romsel_filename, ".gen")) {
+			} else if(extension(std_romsel_filename, {".gen"})) {
 				bnrRomType = 7;
-			} else if(extention(std_romsel_filename, ".smc") || extention(std_romsel_filename, ".sfc")) {
+			} else if(extension(std_romsel_filename, {".smc", ".sfc"})) {
 				bnrRomType = 8;
 			}
 		}

--- a/romsel_r4theme/arm9/source/fileBrowse.h
+++ b/romsel_r4theme/arm9/source/fileBrowse.h
@@ -27,6 +27,8 @@
 
 //#define EMULATE_FILES
 
+bool extension(const std::string_view filename, const std::vector<std::string_view> extensions);
+
 std::string browseForFile(const std::vector<std::string> extensionList);
 
 

--- a/romsel_r4theme/arm9/source/fileBrowse.h
+++ b/romsel_r4theme/arm9/source/fileBrowse.h
@@ -29,7 +29,7 @@
 
 bool extension(const std::string_view filename, const std::vector<std::string_view> extensions);
 
-std::string browseForFile(const std::vector<std::string> extensionList);
+std::string browseForFile(const std::vector<std::string_view> extensionList);
 
 
 

--- a/romsel_r4theme/arm9/source/iconTitle.cpp
+++ b/romsel_r4theme/arm9/source/iconTitle.cpp
@@ -27,6 +27,7 @@
 #include <ctype.h>
 #include <sys/stat.h>
 #include <gl2d.h>
+#include "fileBrowse.h"
 #include "graphics/fontHandler.h"
 #include "language.h"
 #include "ndsheaderbanner.h"
@@ -53,8 +54,6 @@
 #include "icon_gg.h"
 #include "icon_md.h"
 #include "icon_snes.h"
-
-extern bool extention(const std::string& filename, const char* ext);
 
 extern bool arm7SCFGLocked;
 extern bool secondaryDevice;
@@ -643,7 +642,7 @@ void getGameInfo(bool isDir, const char* name)
 	if (isDir) {
 		// banner sequence
 		clearBannerSequence();
-	} else if (extention(name, ".argv")) {
+	} else if (extension(name, {".argv"})) {
 		// look through the argv file for the corresponding nds file
 		FILE *fp;
 		char *line = NULL, *p = NULL;
@@ -683,11 +682,7 @@ void getGameInfo(bool isDir, const char* name)
 			// truncate everything after first argument
 			strtok(p, "\n\r\t ");
 
-			if (extention(p, ".nds")
-			 || extention(p, ".dsi")
-			 || extention(p, ".ids")
-			 || extention(p, ".srl")
-			 || extention(p, ".app"))
+			if (extension(p, {".nds", ".dsi", ".ids", ".srl", ".app"}))
 			{
 				// let's see if this is a file or directory
 				rc = stat(p, &st);
@@ -719,11 +714,7 @@ void getGameInfo(bool isDir, const char* name)
 		// clean up the allocated line
 		free(line);
 	}
-	else if (extention(name, ".nds")
-			 || extention(name, ".dsi")
-			 || extention(name, ".ids")
-			 || extention(name, ".srl")
-			 || extention(name, ".app"))
+	else if (extension(name, {".nds", ".dsi", ".ids", ".srl", ".app"}))
 	{
 		// this is an nds/app file!
 		FILE *fp;
@@ -899,7 +890,7 @@ void iconUpdate(bool isDir, const char* name)
 		// icon
 		clearIcon();
 	}
-	else if (extention(name, ".argv"))
+	else if (extension(name, {".argv"}))
 	{
 		// look through the argv file for the corresponding nds/app file
 		FILE *fp;
@@ -942,11 +933,7 @@ void iconUpdate(bool isDir, const char* name)
 			// truncate everything after first argument
 			strtok(p, "\n\r\t ");
 
-			if (extention(p, ".nds")
-			 || extention(p, ".dsi")
-			 || extention(p, ".ids")
-			 || extention(p, ".srl")
-			 || extention(p, ".app"))
+			if (extension(p, {".nds", ".dsi", ".ids", ".srl", ".app"}))
 			{
 				// let's see if this is a file or directory
 				rc = stat(p, &st);
@@ -978,11 +965,7 @@ void iconUpdate(bool isDir, const char* name)
 		// clean up the allocated line
 		free(line);
 	}
-	else if (extention(name, ".nds")
-			 || extention(name, ".dsi")
-			 || extention(name, ".ids")
-			 || extention(name, ".srl")
-			 || extention(name, ".app"))
+	else if (extension(name, {".nds", ".dsi", ".ids", ".srl", ".app"}))
 	{
 		// this is an nds/app file!
 		FILE *fp;
@@ -1074,31 +1057,11 @@ void titleUpdate(bool isDir, const char* name)
 			writeBannerText(0, name, "", "");
 		}
 	}
-	else if (extention(name, ".plg")
-		  || extention(name, ".rvid")
-		  || extention(name, ".agb")
-		  || extention(name, ".gba")
-		  || extention(name, ".mb")
-		  || extention(name, ".gb")
-		  || extention(name, ".sgb")
-		  || extention(name, ".gbc")
-		  || extention(name, ".nes")
-		  || extention(name, ".fds")
-		  || extention(name, ".sms")
-		  || extention(name, ".gg")
-		  || extention(name, ".gen")
-		  || extention(name, ".smc")
-		  || extention(name, ".sfc")
-		  || extention(name, ".xex")
-		  || extention(name, ".atr")
-		  || extention(name, ".a26")
-		  || extention(name, ".a52")
-		  || extention(name, ".a78")
-		  || extention(name, ".pce"))
+	else if (!extension(name, {".nds", ".dsi", ".ids", ".srl", ".app", ".argv"}))
 	{
 		writeBannerText(0, name, "", "");
 	}
-	else if (extention(name, ".argv"))
+	else if (extension(name, {".argv"}))
 	{
 		// look through the argv file for the corresponding nds/app file
 		FILE *fp;
@@ -1141,11 +1104,7 @@ void titleUpdate(bool isDir, const char* name)
 			// truncate everything after first argument
 			strtok(p, "\n\r\t ");
 
-			if (extention(p, ".nds")
-			 || extention(p, ".dsi")
-			 || extention(p, ".ids")
-			 || extention(p, ".srl")
-			 || extention(p, ".app"))
+			if (extension(p, {".nds", ".dsi", ".ids", ".srl", ".app"}))
 			{
 				// let's see if this is a file or directory
 				rc = stat(p, &st);
@@ -1176,11 +1135,8 @@ void titleUpdate(bool isDir, const char* name)
 		}
 		// clean up the allocated line
 		free(line);
-	} else if (extention(name, ".nds")
-			 || extention(name, ".dsi")
-			 || extention(name, ".ids")
-			 || extention(name, ".srl")
-			 || extention(name, ".app"))
+	}
+	else if (extension(name, {".nds", ".dsi", ".ids", ".srl", ".app"}))
 	{
 		// this is an nds/app file!
 		FILE *fp;

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1307,7 +1307,7 @@ int main(int argc, char **argv) {
 
 	keysSetRepeat(10, 2);
 
-	vector<string> extensionList;
+	std::vector<std::string_view> extensionList;
 	if (showNds) {
 		extensionList.push_back(".nds");
 		extensionList.push_back(".dsi");

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -97,14 +97,6 @@ bool isRegularDS = true;
 extern bool showdialogbox;
 extern int dialogboxHeight;
 
-bool extention(const std::string& filename, const char* ext) {
-	if(strcasecmp(filename.c_str() + filename.size() - strlen(ext), ext)) {
-		return false;
-	} else {
-		return true;
-	}
-}
-
 /**
  * Remove trailing slashes from a pathname, if present.
  * @param path Pathname to modify.
@@ -1004,16 +996,7 @@ void loadGameOnFlashcard (const char* ndsPath, bool dsGame) {
 	}
 	if (dsGame) {
 		// Move .sav outside of "saves" folder for flashcard kernel usage
-		const char *typeToReplace = ".nds";
-		if (extention(filename, ".dsi")) {
-			typeToReplace = ".dsi";
-		} else if (extention(filename, ".ids")) {
-			typeToReplace = ".ids";
-		} else if (extention(filename, ".srl")) {
-			typeToReplace = ".srl";
-		} else if (extention(filename, ".app")) {
-			typeToReplace = ".app";
-		}
+		std::string typeToReplace = filename.substr(filename.rfind('.'));
 
 		std::string savename = replaceAll(filename, typeToReplace, getSavExtension());
 		std::string savenameFc = replaceAll(filename, typeToReplace, ".sav");
@@ -1689,7 +1672,7 @@ int main(int argc, char **argv) {
 			vector<char*> argarray;
 
 			bool isArgv = false;
-			if (extention(filename, ".argv"))
+			if (extension(filename, {".argv"}))
 			{
 				FILE *argfile = fopen(filename.c_str(),"rb");
 					char str[PATH_MAX], *pstr;
@@ -1719,16 +1702,7 @@ int main(int argc, char **argv) {
 
 			// Launch DSiWare .nds via Unlaunch
 			if ((isDSiMode() || sdFound()) && isDSiWare) {
-				const char *typeToReplace = ".nds";
-				if (extention(filename, ".dsi")) {
-					typeToReplace = ".dsi";
-				} else if (extention(filename, ".ids")) {
-					typeToReplace = ".ids";
-				} else if (extention(filename, ".srl")) {
-					typeToReplace = ".srl";
-				} else if (extention(filename, ".app")) {
-					typeToReplace = ".app";
-				}
+				std::string typeToReplace = filename.substr(filename.rfind('.'));
 
 				char *name = argarray.at(0);
 				strcpy (filePath + pathLen, name);
@@ -1996,19 +1970,8 @@ int main(int argc, char **argv) {
 			} else
 
 			// Launch .nds directly or via nds-bootstrap
-			if (extention(filename, ".nds") || extention(filename, ".dsi")
-			 || extention(filename, ".ids") || extention(filename, ".srl")
-			 || extention(filename, ".app")) {
-				const char *typeToReplace = ".nds";
-				if (extention(filename, ".dsi")) {
-					typeToReplace = ".dsi";
-				} else if (extention(filename, ".ids")) {
-					typeToReplace = ".ids";
-				} else if (extention(filename, ".srl")) {
-					typeToReplace = ".srl";
-				} else if (extention(filename, ".app")) {
-					typeToReplace = ".app";
-				}
+			if (extension(filename, {".nds", ".dsi", ".ids", ".srl", ".app"})) {
+				std::string typeToReplace = filename.substr(filename.rfind('.'));
 
 				bool dsModeSwitch = false;
 				bool dsModeDSiWare = false;
@@ -2391,7 +2354,7 @@ int main(int argc, char **argv) {
 				homebrewBootstrap = true;
 
 				const char *ndsToBoot = "sd:/_nds/nds-bootstrap-release.nds";
-				if (extention(filename, ".plg")) {
+				if (extension(filename, {".plg"})) {
 					ndsToBoot = "fat:/_nds/TWiLightMenu/bootplg.srldr";
 					dsModeSwitch = true;
 
@@ -2410,7 +2373,7 @@ int main(int argc, char **argv) {
 					CIniFile dstwobootini( "fat:/_dstwo/twlm.ini" );
 					dstwobootini.SetString("boot_settings", "file", ROMpathDS2);
 					dstwobootini.SaveIniFile( "fat:/_dstwo/twlm.ini" );
-				} else if (extention(filename, ".rvid")) {
+				} else if (extension(filename, {".rvid"})) {
 					launchType[secondaryDevice] = 7;
 
 					ndsToBoot = "sd:/_nds/TWiLightMenu/apps/RocketVideoPlayer.nds";
@@ -2418,7 +2381,7 @@ int main(int argc, char **argv) {
 						ndsToBoot = "fat:/_nds/TWiLightMenu/apps/RocketVideoPlayer.nds";
 						boostVram = true;
 					}
-				} else if (extention(filename, ".fv")) {
+				} else if (extension(filename, {".fv"})) {
 					launchType[secondaryDevice] = 8;
 
 					ndsToBoot = "sd:/_nds/TWiLightMenu/apps/FastVideoDS.nds";
@@ -2426,9 +2389,7 @@ int main(int argc, char **argv) {
 						ndsToBoot = "fat:/_nds/TWiLightMenu/apps/FastVideoDS.nds";
 						boostVram = true;
 					}
-				} else if (extention(filename, ".agb")
-						|| extention(filename, ".gba")
-						|| extention(filename, ".mb")) {
+				} else if (extension(filename, {".agb", ".gba", ".mb"})) {
 					launchType[secondaryDevice] = (showGba == 1) ? 11 : 1;
 
 					if (showGba == 1) {
@@ -2539,8 +2500,7 @@ int main(int argc, char **argv) {
 
 						bootstrapini.SaveIniFile("sd:/_nds/nds-bootstrap.ini");
 					}
-				} else if (extention(filename, ".xex")
-						 || extention(filename, ".atr")) {
+				} else if (extension(filename, {".xex", ".atr"})) {
 					launchType[secondaryDevice] = 15;
 					
 					ndsToBoot = "sd:/_nds/TWiLightMenu/emulators/XEGS-DS.nds";
@@ -2548,7 +2508,7 @@ int main(int argc, char **argv) {
 						ndsToBoot = "fat:/_nds/TWiLightMenu/emulators/XEGS-DS.nds";
 						boostVram = true;
 					}
-				} else if (extention(filename, ".a26")) {
+				} else if (extension(filename, {".a26"})) {
 					launchType[secondaryDevice] = 9;
 					
 					ndsToBoot = "sd:/_nds/TWiLightMenu/emulators/StellaDS.nds";
@@ -2556,7 +2516,7 @@ int main(int argc, char **argv) {
 						ndsToBoot = "fat:/_nds/TWiLightMenu/emulators/StellaDS.nds";
 						boostVram = true;
 					}
-				} else if (extention(filename, ".a52")) {
+				} else if (extension(filename, {".a52"})) {
 					launchType[secondaryDevice] = 13;
 					
 					ndsToBoot = "sd:/_nds/TWiLightMenu/emulators/A5200DS.nds";
@@ -2564,7 +2524,7 @@ int main(int argc, char **argv) {
 						ndsToBoot = "fat:/_nds/TWiLightMenu/emulators/A5200DS.nds";
 						boostVram = true;
 					}
-				} else if (extention(filename, ".a78")) {
+				} else if (extension(filename, {".a78"})) {
 					launchType[secondaryDevice] = 12;
 					
 					ndsToBoot = "sd:/_nds/TWiLightMenu/emulators/A7800DS.nds";
@@ -2575,7 +2535,7 @@ int main(int argc, char **argv) {
 						ndsToBoot = "fat:/_nds/TWiLightMenu/emulators/A7800DS.nds";
 						boostVram = true;
 					}
-				} else if (extention(filename, ".gb") || extention(filename, ".sgb") || extention(filename, ".gbc")) {
+				} else if (extension(filename, {".gb", ".sgb", ".gbc"})) {
 					launchType[secondaryDevice] = 5;
 					
 					ndsToBoot = "sd:/_nds/TWiLightMenu/emulators/gameyob.nds";
@@ -2584,7 +2544,7 @@ int main(int argc, char **argv) {
 						dsModeSwitch = !isDSiMode();
 						boostVram = true;
 					}
-				} else if (extention(filename, ".nes") || extention(filename, ".fds")) {
+				} else if (extension(filename, {".nes", ".fds"})) {
 					launchType[secondaryDevice] = 4;
 
 					ndsToBoot = (secondaryDevice ? "sd:/_nds/TWiLightMenu/emulators/nesds.nds" : "sd:/_nds/TWiLightMenu/emulators/nestwl.nds");
@@ -2592,7 +2552,7 @@ int main(int argc, char **argv) {
 						ndsToBoot = "fat:/_nds/TWiLightMenu/emulators/nesds.nds";
 						boostVram = true;
 					}
-				} else if (extention(filename, ".sms") || extention(filename, ".gg")) {
+				} else if (extension(filename, {".sms", ".gg"})) {
 					mkdir(secondaryDevice ? "fat:/data" : "sd:/data", 0777);
 					mkdir(secondaryDevice ? "fat:/data/s8ds" : "sd:/data/s8ds", 0777);
 
@@ -2623,7 +2583,7 @@ int main(int argc, char **argv) {
 							boostVram = true;
 						}
 					}
-				} else if (extention(filename, ".gen")) {
+				} else if (extension(filename, {".gen"})) {
 					bool usePicoDrive = ((isDSiMode() && sdFound() && arm7SCFGLocked)
 						|| showMd==2 || (showMd==3 && getFileSize(filename.c_str()) > 0x300000));
 					launchType[secondaryDevice] = (usePicoDrive ? 10 : 1);
@@ -2652,7 +2612,7 @@ int main(int argc, char **argv) {
 						bootstrapini.SetString("NDS-BOOTSTRAP", "RAM_DRIVE_PATH", ROMpath);
 						bootstrapini.SaveIniFile("sd:/_nds/nds-bootstrap.ini");
 					}
-				} else if (extention(filename, ".smc") || extention(filename, ".sfc")) {
+				} else if (extension(filename, {".smc", ".sfc"})) {
 					launchType[secondaryDevice] = 1;
 
 					if (secondaryDevice) {
@@ -2680,7 +2640,7 @@ int main(int argc, char **argv) {
 						bootstrapini.SetString("NDS-BOOTSTRAP", "RAM_DRIVE_PATH", ROMpath);
 						bootstrapini.SaveIniFile("sd:/_nds/nds-bootstrap.ini");
 					}
-				} else if (extention(filename, ".pce")) {
+				} else if (extension(filename, {".pce"})) {
 					mkdir(secondaryDevice ? "fat:/data" : "sd:/data", 0777);
 					mkdir(secondaryDevice ? "fat:/data/NitroGrafx" : "sd:/data/NitroGrafx", 0777);
 
@@ -2715,7 +2675,7 @@ int main(int argc, char **argv) {
 
 				homebrewArg = useNDSB ? "" : romPath[secondaryDevice];
 				SaveSettings();
-				if (!isDSiMode() && !secondaryDevice && !extention(filename, ".plg")) {
+				if (!isDSiMode() && !secondaryDevice && !extension(filename, {".plg"})) {
 					ntrStartSdGame();
 				}
 				argarray.push_back(ROMpath);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Speeds up directory loading a bit, I think it cuts the directory load time about in half, but game info loading is only slightly improved
   - A folder with 300 copies of BOOT.NDS goes from 8s to 4.5s for me
   - My DS ROM folder goes from 2s to 1.5s for me
- The main slow part now is checking if files are hidden, with hidden files shown it's only about 1.5s for any folder with 40+ items for me
- Also updates the R4 theme extension() function

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
