### PR TITLE
Fix instantly finishing for single infinite GIF

### DIFF
--- a/manual/arm9/source/graphics/gif.hpp
+++ b/manual/arm9/source/graphics/gif.hpp
@@ -72,7 +72,7 @@ class Gif {
 
 	std::vector<Frame> _frames;
 	std::vector<u16> _gct; // In DS format
-	u16 _loopCount = 0;
+	u16 _loopCount = 0xFFFF;
 	bool _top = false;
 	bool _compressed = false;
 

--- a/title/arm9/source/graphics/gif.hpp
+++ b/title/arm9/source/graphics/gif.hpp
@@ -71,7 +71,7 @@ class Gif {
 
 	std::vector<Frame> _frames;
 	std::vector<u16> _gct; // In DS format
-	u16 _loopCount = 0;
+	u16 _loopCount = 0xFFFF;
 	bool _top = false;
 	bool _compressed = false;
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This fixes instantly skipping the splash if you have only one GIF that loops infinitely

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
