### PR TITLE
Fix R4 theme loading language before settings

### DIFF
--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1251,8 +1251,6 @@ int main(int argc, char **argv) {
 		settingsinipath = "fat:/_nds/TWiLightMenu/settings.ini";		// Fallback to .ini path on flashcard, if not found on SD card, or if SD access is disabled
 	}
 
-	langInit();
-
 	std::string filename;
 
 	fifoWaitValue32(FIFO_USER_06);
@@ -1262,6 +1260,9 @@ int main(int argc, char **argv) {
 	fifoSendValue32(FIFO_USER_07, 0);
 
 	LoadSettings();
+
+	langInit();
+
 	if (theme == 6) {
 		extern int screenBrightness;
 		screenBrightness = 31;


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes the R4 theme loading the language before the settings, resulting in resetting the bootstrap in-game menu to the system language
- Fixes #1630

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
