### PR TITLE
Allow M3 DS Real to use YSMenu as flashcart loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ ipch/
 7zfile/Flashcard users/Autoboot/Ace3DS/3DSCARD.DAT
 7zfile/Flashcard users/Autoboot/Blue R4i Revolution v1.4.1, R4i Gold Upgrade Revolution v1.4.1, GoldR4 3DS (v4.301 kernel) & R4i SDHC Upgrade Revolution (www.r4i-sdhc.com.tw)/iLL.iL
 7zfile/Flashcard users/Autoboot/DSTT, DSTTi, DSTTi Gold, DSTT-Advance, R4Top Revolution, & R4i-SDHC v1.41 + v1.42/TTMenu.dat
+7zfile/Flashcard users/Autoboot/M3 DS Real, M3i Zero (non-GMP-Z003)/SRESET.DAT
 7zfile/Flashcard users/Autoboot/R4 Deluxe v1.20/_DS_MENU.DAT
 7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/iLL.iL
 7zfile/Flashcard users/Autoboot/R4i DSi XL & R4V-R4i v2.2 + v2.5/R4i.TP

--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -188,6 +188,11 @@ autoboot:
 	dlditool flashcart_specifics/DLDI/DSONESlot-1.dldi TTMenu.DAT
 	mv TTMenu.DAT "../7zfile/Flashcard users/Autoboot/SuperCard DSONE & SuperCard DSONEi/TTMenu.DAT"
 
+	#### M3 DS Real (for YSMenu reset)
+	cp booter_fc.nds SRESET.DAT
+	dlditool flashcart_specifics/DLDI/M3DS_DLDI_based_on_r4tf_v2.dldi SRESET.DAT
+	mv SRESET.DAT "../7zfile/Flashcard users/Autoboot/M3 DS Real, M3i Zero (non-GMP-Z003)/SRESET.DAT"
+
 $(TARGET).nds:	makearm7_fc makearm7_cyclodsi makearm9_fc makearm9_cyclodsi
 	# simple nds srl without dsi extended header
 	ndstool -c $(TARGET)_fc.nds       -7 $(TARGET)_fc.arm7.elf       -9 $(TARGET)_fc.arm9.elf       -h 0x200 -b icon.bmp "TWiLight Menu++;RocketRobz"

--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -688,7 +688,8 @@ void loadGameOnFlashcard (const char* ndsPath, bool dsGame) {
 	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -590,7 +590,8 @@ void loadGameOnFlashcard (const char *ndsPath, bool dsGame) {
 	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1044,7 +1044,8 @@ void loadGameOnFlashcard (const char* ndsPath, bool dsGame) {
 	} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/rungame/arm9/source/main.cpp
+++ b/rungame/arm9/source/main.cpp
@@ -420,7 +420,8 @@ TWL_CODE int lastRunROM() {
 				} else if ((memcmp(io_dldi_data->friendlyName, "TTCARD", 6) == 0)
 						 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 						 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
-						 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)) {
+						 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
+						 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
 					CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 					path = ReplaceAll(romPath[1], "fat:/", slashchar);
 					fcrompathini.SetString("YSMENU", "AUTO_BOOT", path);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

M3 DS Real can now use YSMenu as flashcart loader.
DLDI submodule was also updated to include the DLDI driver required `booter_fc` to be compiled as YSMenu's soft-reset target.

#### Where have you tested it?

M3 DS Real, DS phat.

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.


Some notes to consider:
- This will only work when also using the provided Autoboot, or by loading TWiLight from YSMenu directly.
  - I could not think of another way to avoid accidentally having any other cart using the "M3DS" DLDI name launch YSMenu. The DLDI name must match either the one used in TWiLight Menu++, or YSMenu.
  - Also, the original M3 DS DLDI does not work on TWiLight Menu++ anyway. The DLDI has a 32KB section and TWiLight Menu++ expects 16KB or less.
  - A workaround for this is to, well, not use the original M3 DS DLDI when launching TWiLight using the official kernel. This was already added to the Sakura kernel in DS-Homebrew/flashcard-archive, but obviously not everyone uses this. (but considering you cannot autoboot to the Sakura kernel, this point is moot. You're basically going from Sakura -> TWL -> YSMenu. Just use YSMenu or TWiLight at that point.)
  - As a result of the points above, I just decided to limit this to the M3 DS carts that support YSMenu. This was done by setting `friendlyName` to detect `M3DS DLDI` as opposed to `M3DS`. 