### PR TITLE
MPEG4/FV mainly

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,10 +5,24 @@ contact_links:
     about: "Please use #nds-modding-help on the Discord server to for support-related questions, such as needing assistance to launch TWiLight Menu++"
   - name: DS game issue
     url: https://github.com/ahezard/nds-bootstrap/issues/new
-    about: Please use the nds-bootstrap GitHub repository to report issues related to running Nintendo DS applications as `.nds` files (not as a retail cart) via B4DS/nds-bootstrap (and not via Unlaunch)
+    about: Please use the nds-bootstrap GitHub repository to report issues related to running Nintendo DS applications as `.nds` files (not as a retail Game Card) via nds-bootstrap (and not via Unlaunch)
   - name: GBA game issue
     url: https://github.com/Gericom/GBARunner2/issues/new
     about: Please use the GBARunner2 GitHub repository to report issues related to running Game Boy Advance applications as `.gba` files (not as Slot-2 for DS Phat/Lite consoles), or the GBARunner2 GUI
-  - name: MPEG4 issue
-    url: https://github.com/Gericom/YouTubeDS/issues/new
-    about: Please use the MPEG4Player/YouTubeDS GitHub repository to report issues related to .mp4 playback
+  - name: Atari 2600 game issue
+    url: https://github.com/wavemotion-dave/StellaDS/issues/new
+    about: Please use the StellaDS GitHub repository to report issues related to running Atari 2600 applications as `.a26` files, or the StellaDS GUI
+  - name: Atari 5200 game issue
+    url: https://github.com/wavemotion-dave/A5200DS/issues/new
+    about: Please use the A5200DS GitHub repository to report issues related to running Atari 5200 applications as `.a52` files, or the A5200DS GUI
+  - name: Atari 7800 game issue
+    url: https://github.com/wavemotion-dave/A7800DS/issues/new
+    about: Please use the A7800DS GitHub repository to report issues related to running Atari 7800 applications as `.a78` files, or the A7800DS GUI
+  - name: Atari XEGS game issue
+    url: https://github.com/wavemotion-dave/XEGS-DS/issues/new
+    about: Please use the XEGS-DS GitHub repository to report issues related to running Atari XEGS applications as `.xex` or `.atr` files, or the XEGS-DS GUI
+  - name: Intellivision game issue
+    url: https://github.com/wavemotion-dave/NINTV-DS/issues/new
+    about: Please use the Nintellivision (NINTV-DS) GitHub repository to report issues related to running Intellivision applications as `.int` files, or the NINTV-DS GUI
+  - name: Other emulator issue
+    about: The emulators of other systems supported by TWiLight Menu++ are not currently maintained. You can find their GitHub repositories or webpages in the [TWiLight Menu++ README](https://github.com/DS-Homebrew/TWiLightMenu#app-launchers), but it is unlikely that your issue will be resolved there.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,7 +5,7 @@ contact_links:
     about: "Please use #nds-modding-help on the Discord server to for support-related questions, such as needing assistance to launch TWiLight Menu++"
   - name: DS game issue
     url: https://github.com/ahezard/nds-bootstrap/issues/new
-    about: Please use the nds-bootstrap GitHub repository to report issues related to running Nintendo DS applications as `.nds` files (not as a retail Game Card) via nds-bootstrap (and not via Unlaunch)
+    about: Please use the nds-bootstrap GitHub repository to report issues related to running Nintendo DS applications as `.nds`, `.dsi`, `.srl`, or `.app` files (not as a retail Game Card) via nds-bootstrap (and not via Unlaunch or a homebrew with Direct Boot turned on)
   - name: GBA game issue
     url: https://github.com/Gericom/GBARunner2/issues/new
     about: Please use the GBARunner2 GitHub repository to report issues related to running Game Boy Advance applications as `.gba` files (not as Slot-2 for DS Phat/Lite consoles), or the GBARunner2 GUI

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </p>
 
 TWiLight Menu++ is an open-source DSi Menu upgrade/replacement for the Nintendo DSi, the Nintendo 3DS, and Nintendo DS flashcards.
-It can launch Nintendo DS(i), SNES, NES, GameBoy (Color), GameBoy Advance, Sega GameGear/Master System & Mega Drive/Genesis, and Atari 2600/5200/7800/XEGS ROMs, as well as DSTWO plugins (if you use a DSTWO).
+It can launch Nintendo DS(i), SNES, NES, GameBoy (Color), GameBoy Advance, Sega GameGear/Master System & Mega Drive/Genesis, and Atari 2600/5200/7800/XEGS ROMs, Intellivision ROMs, as well as DSTWO plugins (if you use a DSTWO).
 
 # Compiling
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
      - [therealteamplayer](https://github.com/therealteamplayer): Hicode+DSP merged builds included.
 - [FluBBa](https://gbatemp.net/members/flubba.19963/): [S8DS](https://gbatemp.net/threads/s8ds.392855/) (used to launch Sega Master System/Game Gear ROMs)
 - Alekmaul & [wavemotion](https://github.com/wavemotion-dave): [StellaDS](https://github.com/wavemotion-dave/StellaDS), [A5200DS](https://github.com/wavemotion-dave/A5200DS), [A7800DS](https://github.com/wavemotion-dave/A7800DS), and [XEGS-DS](https://github.com/wavemotion-dave/XEGS-DS) (used to launch Atari 2600/5200/7800/XEGS ROMs)
+- [wavemotion](https://github.com/wavemotion-dave): [Nintellivision/NINTV-DS](https://github.com/wavemotion-dave/NINTV-DS) (used to launch Intellivision ROMs)
 ## Graphics & Themes
 - [spinal_cord](https://gbatemp.net/members/spinal_cord.90607/): [DSi4DS](https://gbatemp.net/threads/dsi4ds.173617/) and [DSision2](https://gbatemp.net/threads/dsision2.92740/) graphics
 - [StarvingArtist](https://www.deviantart.com/starvingartist/): Game Console icons
@@ -71,7 +72,7 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
 - [FlameKat53](https://github.com/FlameKat53): Manual icon for DSi theme's `SELECT` menu
 - [fail0verflow](https://github.com/fail0verflow/), Fluto, and Arkhandar: Homebrew Channel/Launcher graphics
 - davi: Border for GBC theme (originally for GameYob)
-- [NightScript](https://github.com/NightYoshi370/): Reworked Manual pages
+- [NightScript](https://github.com/NightScript370/): Reworked Manual pages
 ## Music
 - IkaMusumeYiyaRoxie: General N64 MIDI Soundfont, used for the title splash fanfare
 - BlastoiseVeteran: Remastered version of Nintendo DSi Shop music
@@ -86,7 +87,7 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
 - Nikokaro: Found no-tilt patches for *WarioWare: Twisted!*, and *Yoshi Topsy-Turvy*. ([GBAtemp thread](https://gbatemp.net/threads/gba-no-tilt-patches-for-ds-users.584128/))
 - [devkitPro](https://github.com/devkitPro): Code used in nds-hb-menu, and the use of the bootloader, devkitARM, libnds, and libfat
 - Another World & Yellow Wood Goblin: The original akMenu/Wood UI
-- [NightScript](https://github.com/NightYoshi370): Code cleanup, added functionality for Acekard theme in regards to flashcards
+- [NightScript](https://github.com/NightScript370): Code cleanup, added functionality for Acekard theme in regards to flashcards
 - [SNBeast](https://github.com/SNBeast): Unlaunch patches
 - retrogamefan & Rudolph: Included AP-patches for nds-bootstrap
    - [enler](https://github.com/enler): Fixing AP-patch for Pokemon Black 2 (Japan) for DS⁽ⁱ⁾ mode compatibility
@@ -98,7 +99,7 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
 - Chinese Traditional: [ccccchoho](https://crowdin.com/profile/ccccchoho), [James-Makoto](https://crowdin.com/profile/VCMOD55), [Rintim](https://crowdin.com/profile/Rintim), [奇诺比奥](https://crowdin.com/profile/Counta6_233)
 - Danish: [jonata](https://github.com/Jonatan6), [Nadia Pedersen](https://crowdin.com/profile/nadiaholmquist)
 - Dutch: [Arthur](https://crowdin.com/profile/arthurr2014.tl), [guusbuk](https://crowdin.com/profile/guusbuk), [Mikosu](https://crowdin.com/profile/miko303), [Xtremegamer007](https://crowdin.com/profile/xtremegamer007)
-- French: [Arcky](https://github.com/ArckyTV), [Benjamin](https://crowdin.com/profile/sombrabsol), [cooolgamer](https://crowdin.com/profile/cooolgamer), [Dhalian](https://crowdin.com/profile/DHALiaN3630), [maximesharp](https://crowdin.com/profile/maximesharp), [Ghost0159](https://crowdin.com/profile/Ghost0159), [Léo](https://crowdin.com/profile/leeo97one), [LinuxCat](https://github.com/L-i-n-u-x-C-a-t), [Martinez](https://github.com/flutterbrony), [NightScript](https://github.com/NightYoshi370), [SLG3](https://crowdin.com/profile/slg3), [TM-47](https://crowdin.com/profile/-tm-), [Yolopix](https://crowdin.com/profile/yolopix)
+- French: [Arcky](https://github.com/ArckyTV), [Benjamin](https://crowdin.com/profile/sombrabsol), [cooolgamer](https://crowdin.com/profile/cooolgamer), [Dhalian](https://crowdin.com/profile/DHALiaN3630), [maximesharp](https://crowdin.com/profile/maximesharp), [Ghost0159](https://crowdin.com/profile/Ghost0159), [Léo](https://crowdin.com/profile/leeo97one), [LinuxCat](https://github.com/L-i-n-u-x-C-a-t), [Martinez](https://github.com/flutterbrony), [NightScript](https://github.com/NightScript370), [SLG3](https://crowdin.com/profile/slg3), [TM-47](https://crowdin.com/profile/-tm-), [Yolopix](https://crowdin.com/profile/yolopix)
 - German: [ariebe9115](https://crowdin.com/profile/ariebe9115), [Christian Schuhmann](https://github.com/c-schuhmann), [Dubsenbert Reaches](https://crowdin.com/profile/Bierjunge), [İlke Hür Eyiol](https://crowdin.com/profile/ilkecan51), [Julian](https://crowdin.com/profile/nailujx86), [Kazuto](https://crowdin.com/profile/Marcmario), [malekairmaroc7](https://github.com/malekairmaroc7), [Oleh Hatsenko](https://github.com/IRONKAGE), [SkilLP](https://github.com/SkilLP), [SuperSaiyajinStackZ](https://github.com/SuperSaiyajinStackZ), [Tcm0](https://github.com/Tcm0), [TheDude](https://crowdin.com/profile/the6771), [TM-47](https://crowdin.com/profile/-tm-), [Uriki](https://github.com/Uriki)
 - Greek: [Anestis1403](https://crowdin.com/profile/anestis1403)
 - Hebrew: [Barawer](https://crowdin.com/profile/barawer), [Yaniv](https://crowdin.com/profile/y4niv)

--- a/settings/nitrofiles/languages/en/language.ini
+++ b/settings/nitrofiles/languages/en/language.ini
@@ -125,7 +125,7 @@ GBARUNNER2_ONLY=GBARunner2 only
 
 DESCRIPTION_SHOW_NDS=Display Nintendo DS/DSi ROMs in the ROM list.
 DESCRIPTION_SHOW_GBA=Display GameBoy Advance ROMs in the ROM list.
-DESCRIPTION_SHOW_VIDEO=Display Rocket Video and MPEG4 files in the ROM list.
+DESCRIPTION_SHOW_VIDEO=Display Rocket Video and FastVideo files in the ROM list.
 DESCRIPTION_SHOW_XEX=Display Atari XEGS ROMs in the ROM list.
 DESCRIPTION_SHOW_A26=Display Atari 2600 ROMs in the ROM list.
 DESCRIPTION_SHOW_A52=Display Atari 5200 ROMs in the ROM list.

--- a/settings/nitrofiles/languages/en/language.ini
+++ b/settings/nitrofiles/languages/en/language.ini
@@ -106,7 +106,7 @@ DESCRIPTION_ZOOMING_ICON=Display a zoom effect for the selected icon in the Wood
 ; Emulation / HB settings
 NDS_ROMS=NDS ROMs
 GBA_ROMS=GBA ROMs
-VIDEOS=Videos (.RVID and .MP4)
+VIDEOS=Videos (.RVID and .FV)
 XEX_ROMS=Atari XEGS ROMs
 A26_ROMS=Atari 2600 ROMs
 A52_ROMS=Atari 5200 ROMs


### PR DESCRIPTION
#### What's changed?

-  Changed mentions of MPEG4Player/mp4 to FastVideo/fv in settings
   - Perhaps these should just be removed anyways since it's not out yet?
- Fixed links to NightScript's GitHub (he changed his name) in README
- Added mentions of (N)Intellivision to README
- Removed mention of MPEG4Player and B4DS, and added Atari/Intellivision to issue chooser or whatever it's called, as well as added info on other emulators
   - I don't actually know if this is formatted correctly, because there's no way (that I know of) to test this on a branch

#### Where have you tested it?

No code changes were made in this PR.

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
