### PR TITLE
Default Unlaunch's launcher patches to on

### DIFF
--- a/quickmenu/arm9/source/common/dsimenusettings.cpp
+++ b/quickmenu/arm9/source/common/dsimenusettings.cpp
@@ -8,7 +8,7 @@
 
 extern const char *settingsinipath;
 const char *charUnlaunchBg;
-bool removeLauncherPatches = true;
+bool removeLauncherPatches = false;
 
 extern bool isRegularDS;
 

--- a/romsel_aktheme/arm9/source/common/dsimenusettings.cpp
+++ b/romsel_aktheme/arm9/source/common/dsimenusettings.cpp
@@ -9,7 +9,7 @@
 static const char* settingsinipath = DSIMENUPP_INI;
 
 const char *charUnlaunchBg;
-bool removeLauncherPatches = true;
+bool removeLauncherPatches = false;
 
 TWLSettings::TWLSettings()
 {

--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
@@ -8,7 +8,7 @@
 
 extern const char *settingsinipath;
 const char *charUnlaunchBg;
-bool removeLauncherPatches = true;
+bool removeLauncherPatches = false;
 
 TWLSettings::TWLSettings()
 {

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -81,7 +81,7 @@ std::string homebrewArg;
 const char *charUnlaunchBg;
 std::string gbaBorder = "default.png";
 std::string unlaunchBg = "default.gif";
-bool removeLauncherPatches = true;
+bool removeLauncherPatches = false;
 
 const char *unlaunchAutoLoadID = "AutoLoadInfo";
 static char16_t hiyaNdsPath[] = u"sdmc:/hiya.dsi";

--- a/rungame/arm9/source/main.cpp
+++ b/rungame/arm9/source/main.cpp
@@ -37,7 +37,7 @@ std::string filename;
 
 const char *charUnlaunchBg;
 std::string unlaunchBg = "default.gif";
-bool removeLauncherPatches = true;
+bool removeLauncherPatches = false;
 
 static const char *unlaunchAutoLoadID = "AutoLoadInfo";
 

--- a/settings/arm9/source/common/dsimenusettings.cpp
+++ b/settings/arm9/source/common/dsimenusettings.cpp
@@ -105,7 +105,7 @@ TWLSettings::TWLSettings()
 
     gbaBorder = "default.png";
     unlaunchBg = "default.gif";
-    removeLauncherPatches = true;
+    removeLauncherPatches = false;
     font = "default";
     dsClassicCustomFont = false;
 

--- a/title/arm9/source/common/dsimenusettings.cpp
+++ b/title/arm9/source/common/dsimenusettings.cpp
@@ -8,7 +8,7 @@
 extern const char *settingsinipath;
 
 const char *charUnlaunchBg;
-bool removeLauncherPatches = true;
+bool removeLauncherPatches = false;
 
 TWLSettings::TWLSettings()
 {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Please comment on this PR if anyone disagrees with this change. I think it makes much more sense to have them on as imo removing the flashcard blacklist, region locks, and RSA checks is generally worth losing the sound and splash, I don't even mind it removing those.

Ofc having it as an option is good, I just don't see why we should disable that fairly useful Unlaunch feature by default.

#### Where have you tested it?

- N/A

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
