### PR TITLE
Use regular arm7 specs for Ace3DS+ and co.

### DIFF
--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -9,13 +9,17 @@ export TARGET := booter
 
 include $(DEVKITARM)/ds_rules
 
-.PHONY: bootloader bootstub clean makearm7_fc makearm9_fc makearm9_r4idsn
+.PHONY: bootloader bootstub clean makearm7_fc makearm7_r4ils makearm9_fc makearm9_r4idsn
 
 all:	bootloader bootstub $(TARGET).nds
 
 makearm7_fc:
 	$(MAKE) -C arm7
 	cp arm7/$(TARGET).elf $(TARGET)_fc.arm7.elf
+
+makearm7_r4ils:
+	$(MAKE) -C flashcart_specifics/R4iLS/arm7
+	cp flashcart_specifics/r4ils/arm7/$(TARGET).elf $(TARGET)_r4ils.arm7.elf
 
 makearm9_fc:
 	$(MAKE) -C arm9
@@ -30,6 +34,7 @@ dist:	all autoboot
 	@cp $(TARGET)_fc.nds "../7zfile/Flashcard users/BOOT.NDS"
 	@cp $(TARGET)_fc.arm7.elf ../7zfile/debug/$(TARGET)_fc.arm7.elf
 	@cp $(TARGET)_fc.arm9.elf ../7zfile/debug/$(TARGET)_fc.arm9.elf
+	@cp $(TARGET)_r4ils.arm7.elf ../7zfile/debug/$(TARGET)_r4ils.arm7.elf
 	@cp $(TARGET)_r4idsn.arm9.elf ../7zfile/debug/$(TARGET)_r4idsn.arm9.elf
 
 .ONESHELL:
@@ -45,8 +50,11 @@ autoboot:
 	r4denc _DS_MENU.nds
 	mkdir -p "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/"
 	mv _DS_MENU.dat "../7zfile/Flashcard users/Autoboot/Original R4 & M3 Simply/_DS_MENU.DAT"
+	# delete _DS_MENU.nds for the next cart
+	rm -f _DS_MENU.nds
 	
 	#### Ace3DS+, Ace3DS X specific
+	ndstool -c _DS_MENU.nds -7 $(TARGET)_r4ils.arm7.elf -9 $(TARGET)_fc.arm9.elf -h 0x200 -b icon.bmp "TWiLight Menu++;Rocket Robz"
 	dlditool flashcart_specifics/DLDI/ace3ds_sd.dldi _DS_MENU.nds
 	r4denc -k 0x4002 _DS_MENU.nds _DS_MENU.dat
 	mkdir -p "../7zfile/Flashcard users/Autoboot/Ace3DS+, Ace3DS X/"
@@ -55,7 +63,7 @@ autoboot:
 	rm -f _DS_MENU.nds
 	
 	#### R4iLS, r4isdhc.com.cn cards, r4isdhc.hk 2021, R4infinity 2, R4i-XDS 2014 white version specific
-	ndstool -c _DSMENU.nds -7 $(TARGET)_fc.arm7.elf -9 $(TARGET)_fc.arm9.elf -h 0x200 -g "####" "##" "R4XX" -b icon.bmp "TWiLight Menu++;Rocket Robz"
+	ndstool -c _DSMENU.nds -7 $(TARGET)_r4ils.arm7.elf -9 $(TARGET)_fc.arm9.elf -h 0x200 -g "####" "##" "R4XX" -b icon.bmp "TWiLight Menu++;Rocket Robz"
 	dlditool flashcart_specifics/DLDI/ace3ds_sd.dldi _DSMENU.nds
 	r4denc -k 0x4002 _DSMENU.nds
 	mkdir -p "../7zfile/Flashcard users/Autoboot/R4iLS, r4isdhc.com.cn cards, r4isdhc.hk 2021, R4infinity 2, R4i-XDS 2014 white version/"
@@ -64,7 +72,7 @@ autoboot:
 	rm -f _DSMENU.nds
 	
 	#### Gateway Blue specific
-	ndstool -c _DSMENU.nds -7 $(TARGET)_fc.arm7.elf -9 $(TARGET)_fc.arm9.elf -h 0x200 -g "####" "##" "R4IT" -b icon.bmp "TWiLight Menu++;Rocket Robz"
+	ndstool -c _DSMENU.nds -7 $(TARGET)_r4ils.arm7.elf -9 $(TARGET)_fc.arm9.elf -h 0x200 -g "####" "##" "R4IT" -b icon.bmp "TWiLight Menu++;Rocket Robz"
 	dlditool flashcart_specifics/DLDI/ace3ds_sd.dldi _DSMENU.nds
 	r4denc -k 0x4002 _DSMENU.nds _DSMENU.dat
 	mkdir -p "../7zfile/Flashcard users/Autoboot/Gateway Blue"
@@ -178,7 +186,7 @@ autoboot:
 	dlditool flashcart_specifics/DLDI/M3DS_DLDI_based_on_r4tf_v2.dldi SRESET.DAT
 	mv SRESET.DAT "../7zfile/Flashcard users/Autoboot/M3 DS Real, M3i Zero (non-GMP-Z003)/SRESET.DAT"
 
-$(TARGET).nds:	makearm7_fc makearm9_fc makearm9_r4idsn
+$(TARGET).nds:	makearm7_fc makearm7_r4ils makearm9_fc makearm9_r4idsn
 	# simple nds srl without dsi extended header
 	ndstool -c $(TARGET)_fc.nds     -7 $(TARGET)_fc.arm7.elf -9 $(TARGET)_fc.arm9.elf     -h 0x200 -b icon.bmp "TWiLight Menu++;Rocket Robz"
 	ndstool -c $(TARGET)_r4idsn.nds -7 $(TARGET)_fc.arm7.elf -9 $(TARGET)_r4idsn.arm9.elf -h 0x200 -b icon.bmp "TWiLight Menu++;Rocket Robz"

--- a/booter_fc/flashcart_specifics/R4iLS/arm7/Makefile
+++ b/booter_fc/flashcart_specifics/R4iLS/arm7/Makefile
@@ -1,0 +1,135 @@
+export ARM7_MAJOR	:= 0
+export ARM7_MINOR	:= 6
+export ARM7_PATCH	:= 0
+
+VERSTRING	:=	$(ARM7_MAJOR).$(ARM7_MINOR).$(ARM7_PATCH)
+#---------------------------------------------------------------------------------
+.SUFFIXES:
+#---------------------------------------------------------------------------------
+ifeq ($(strip $(DEVKITARM)),)
+$(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM)
+endif
+
+include $(DEVKITARM)/ds_rules
+#---------------------------------------------------------------------------------
+# TARGET is the name of the output
+# BUILD is the directory where object files & intermediate files will be placed
+# SOURCES is a list of directories containing source code
+# INCLUDES is a list of directories containing extra header files
+#---------------------------------------------------------------------------------
+TARGET		:=	booter
+BUILD		:=	build
+SOURCES		:=	../../../arm7/source
+INCLUDES	:=	../../../arm7/include build
+
+#---------------------------------------------------------------------------------
+# options for code generation
+#---------------------------------------------------------------------------------
+ARCH	:=	-march=armv4t -mthumb -mthumb-interwork
+
+CFLAGS	:=	-g -Wall -O2\
+ 		-mcpu=arm7tdmi -mtune=arm7tdmi -fomit-frame-pointer\
+		-ffast-math \
+		$(ARCH)
+
+CFLAGS	+=	$(INCLUDE) -DARM7 -DNO_SDMMC
+
+ASFLAGS	:=	-g $(ARCH)
+LDFLAGS	=	-specs=ds_arm7.specs -g $(ARCH) -Wl,--nmagic -Wl,-Map,$(notdir $*).map
+
+
+#---------------------------------------------------------------------------------
+# any extra libraries we wish to link with the project
+#---------------------------------------------------------------------------------
+LIBS	:= -lnds7
+
+
+#---------------------------------------------------------------------------------
+# list of directories containing libraries, this must be the top level containing
+# include and lib
+#---------------------------------------------------------------------------------
+LIBDIRS	:=	$(LIBNDS)
+
+
+#---------------------------------------------------------------------------------
+# no real need to edit anything past this point unless you need to add additional
+# rules for different file extensions
+#---------------------------------------------------------------------------------
+ifneq ($(BUILD),$(notdir $(CURDIR)))
+#---------------------------------------------------------------------------------
+
+export VPATH	:=	$(foreach dir,$(SOURCES),$(CURDIR)/$(dir))
+
+CFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.c)))
+CPPFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.cpp)))
+SFILES		:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.s)))
+
+export OFILES	:=	$(CPPFILES:.cpp=.o) $(CFILES:.c=.o) $(SFILES:.s=.o)
+
+export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
+			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
+			-I$(CURDIR)/$(BUILD)
+
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+
+export DEPSDIR	:=	$(CURDIR)/$(BUILD)
+
+export OUTPUT	:=	$(CURDIR)/$(TARGET)
+
+#---------------------------------------------------------------------------------
+# use CXX for linking C++ projects, CC for standard C
+#---------------------------------------------------------------------------------
+ifeq ($(strip $(CPPFILES)),)
+#---------------------------------------------------------------------------------
+	export LD	:=	$(CC)
+#---------------------------------------------------------------------------------
+else
+#---------------------------------------------------------------------------------
+	export LD	:=	$(CXX)
+#---------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------
+
+.PHONY: all $(BUILD) clean
+
+all : $(BUILD)
+
+#---------------------------------------------------------------------------------
+$(BUILD):
+	@[ -d $@ ] || mkdir -p $@
+	@$(MAKE) -C $(BUILD) -f $(CURDIR)/Makefile
+
+
+#---------------------------------------------------------------------------------
+dist: all
+#---------------------------------------------------------------------------------
+	@tar --exclude=*CVS* --exclude=.svn -cvjf default_arm7-src-$(VERSTRING).tar.bz2 source Makefile
+	@tar -cvjf default_arm7-$(VERSTRING).tar.bz2 default.elf
+
+#---------------------------------------------------------------------------------
+install: all
+#---------------------------------------------------------------------------------
+	cp $(TARGET).elf $(LIBNDS)
+
+#---------------------------------------------------------------------------------
+clean:
+	@echo clean ...
+	@rm -fr $(BUILD) $(TARGET).elf  $(TARGET).arm7
+
+
+#---------------------------------------------------------------------------------
+else
+
+DEPENDS	:=	$(OFILES:.o=.d)
+
+#---------------------------------------------------------------------------------
+# main targets
+#---------------------------------------------------------------------------------
+
+$(OUTPUT).elf	:	$(OFILES) $(LIBNDS)/lib/libnds7.a
+
+-include $(DEPENDS)
+
+#---------------------------------------------------------------------------------------
+endif
+#---------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Apparently the Ace3DS+ and clones (R4iLS-related, and Gateway Blue) does not like the arm7 iwram. It appeared to have broken as of this commit: https://github.com/DS-Homebrew/TWiLightMenu/commit/bfa8e3024401b59e0300ccf8cabe5d6097176cb3

Made a flashcart-specific again, this time using the regular specs for arm7 only. The arm9 works fine as-is.

#### Where have you tested it?

theSpaceHero#8783: Ace3DS+
@lifehackerhansol: r4isdhc.com.cn PLUS, DSi XL

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
