### PR TITLE
Simplify S8DS extraction and delete ZIP

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,10 +97,8 @@ jobs:
           curl -LO https://github.com/wavemotion-dave/A7800DS/releases/latest/download/A7800DS-LITE.nds
           curl -LO https://github.com/wavemotion-dave/NINTV-DS/releases/latest/download/NINTV-DS.nds
           curl -LO https://github.com/FluBBaOfWard/S8DS/releases/latest/download/S8DS.zip
-          7z x S8DS.zip
-          rm -rf __MACOSX
-          rm History.txt
-          rm README.md
+          7z x S8DS.zip S8DS.nds
+          rm S8DS.zip
           # PicoDriveTWL is a prerelease, so get the latest URL from the GH api
           curl -LO $(curl https://api.github.com/repos/DS-Homebrew/PicoDriveTWL/releases | jq --raw-output '.[0].assets[0].browser_download_url' -)
           cd ../../../..


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes it only extract S8DS.nds from S8DS.zip instead of extracting everything and deleting what's not needed
- Fixes that I think before it would leave the S8DS.zip behind, unless I'm missing something

#### Where have you tested it?

- It works on my MacBook, haven't tested actions

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
