### PR TITLE
Calculate settings descriptions with small font

### DIFF
--- a/settings/arm9/source/settingsgui.cpp
+++ b/settings/arm9/source/settingsgui.cpp
@@ -205,7 +205,7 @@ void SettingsGUI::setTopText(const std::string &text)
     std::u16string temp;
     for(auto word : words) {
         // Split word if the word is too long for a line
-        int width = calcLargeFontWidth(word);
+        int width = calcSmallFontWidth(word);
         if(width > 240) {
             if(temp.length()) {
                 _topText += temp + u"\n";
@@ -220,7 +220,7 @@ void SettingsGUI::setTopText(const std::string &text)
             continue;
         }
 
-        width = calcLargeFontWidth(temp + u" " + word);
+        width = calcSmallFontWidth(temp + u" " + word);
         if(width > 240) {
             _topText += temp + u"\n";
             _topTextLines++;
@@ -289,7 +289,7 @@ void SettingsGUI::drawTopText()
     }
     if(_topTextLines < 6 || currentTheme == 4)
         printSmall(true, 256 - 4, 174, VER_NUMBER, Alignment::right);
-    printSmall(true, 0, (currentTheme == 4 ? 96 : 138) - (calcLargeFontHeight(_topText) / 2), _topText, Alignment::center);
+    printSmall(true, 0, (currentTheme == 4 ? 96 : 138) - (calcSmallFontHeight(_topText) / 2), _topText, Alignment::center);
 }
 
 void SettingsGUI::rotatePage(int rotateAmount)


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- cca1069c85764dec282348e3a373b67fb79fd7c7 changes to printing with small, but still calculates the size using the large font, this makes it calculate the size using the small font so it still warps correctly
   - Even german doesn't have anything overflow now
     ![big](https://user-images.githubusercontent.com/41608708/139514850-06dce313-c8e2-450f-8814-5f12a2d692d6.png)

#### Where have you tested it?

- no$gba

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
