### PR TITLE
Hide blacklisted settings from per-game settings

### DIFF
--- a/quickmenu/arm9/source/common/dsimenusettings.cpp
+++ b/quickmenu/arm9/source/common/dsimenusettings.cpp
@@ -118,6 +118,7 @@ TWLSettings::TWLSettings()
     wideScreen = false;
 
     dontShowClusterWarning = false;
+    ignoreBlacklists = false;
 }
 
 void TWLSettings::loadSettings()
@@ -247,6 +248,7 @@ void TWLSettings::loadSettings()
     wideScreen = settingsini.GetInt("SRLOADER", "WIDESCREEN", wideScreen);
 
     dontShowClusterWarning = settingsini.GetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
+    ignoreBlacklists = settingsini.GetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
 }
 
 void TWLSettings::saveSettings()
@@ -284,6 +286,7 @@ void TWLSettings::saveSettings()
         settingsini.SetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
     }
 
+    settingsini.SetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
     settingsini.SetInt("SRLOADER", "SORT_METHOD", sortMethod);
 
     settingsini.SaveIniFile(settingsinipath);

--- a/quickmenu/arm9/source/common/dsimenusettings.h
+++ b/quickmenu/arm9/source/common/dsimenusettings.h
@@ -272,6 +272,7 @@ class TWLSettings
     bool wideScreen;
 
     bool dontShowClusterWarning;
+    bool ignoreBlacklists;
 };
 
 typedef singleton<TWLSettings> menuSettings_s;

--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -176,7 +176,7 @@ void stop (void) {
  * Disable TWL clock speed for a specific game.
  */
 bool setClockSpeed() {
-	if (perGameSettings_boostCpu == -1) {
+	if (!ms().ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(twlClockExcludeList)/sizeof(twlClockExcludeList[0]); i++) {
 			if (memcmp(gameTid[ms().secondaryDevice], twlClockExcludeList[i], 3) == 0) {
@@ -193,7 +193,7 @@ bool setClockSpeed() {
  * Disable card read DMA for a specific game.
  */
 bool setCardReadDMA() {
-	if (perGameSettings_cardReadDMA == -1) {
+	if (!ms().ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(cardReadDMAExcludeList)/sizeof(cardReadDMAExcludeList[0]); i++) {
 			if (memcmp(gameTid[ms().secondaryDevice], cardReadDMAExcludeList[i], 3) == 0) {
@@ -210,7 +210,7 @@ bool setCardReadDMA() {
  * Disable asynch card read for a specific game.
  */
 bool setAsyncReadDMA() {
-	if (perGameSettings_asyncCardRead == -1) {
+	if (!ms().ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(asyncReadExcludeList)/sizeof(asyncReadExcludeList[0]); i++) {
 			if (memcmp(gameTid[ms().secondaryDevice], asyncReadExcludeList[i], 3) == 0) {

--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.cpp
@@ -118,6 +118,7 @@ TWLSettings::TWLSettings()
 	wideScreen = false;
 
 	dontShowClusterWarning = false;
+	ignoreBlacklists = false;
 }
 
 void TWLSettings::loadSettings()
@@ -247,6 +248,7 @@ void TWLSettings::loadSettings()
 	wideScreen = settingsini.GetInt("SRLOADER", "WIDESCREEN", wideScreen);
 
 	dontShowClusterWarning = settingsini.GetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
+	ignoreBlacklists = settingsini.GetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
 }
 
 void TWLSettings::saveSettings()
@@ -284,6 +286,7 @@ void TWLSettings::saveSettings()
 		settingsini.SetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
 	}
 	
+	settingsini.SetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
 	settingsini.SetInt("SRLOADER", "SORT_METHOD", sortMethod);
 
 	settingsini.SaveIniFile(settingsinipath);

--- a/romsel_dsimenutheme/arm9/source/common/dsimenusettings.h
+++ b/romsel_dsimenutheme/arm9/source/common/dsimenusettings.h
@@ -275,6 +275,7 @@ public:
 	bool wideScreen;
 
 	bool dontShowClusterWarning;
+	bool ignoreBlacklists;
 };
 
 typedef singleton<TWLSettings> menuSettings_s;

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -172,7 +172,7 @@ int SetDonorSDK() {
  * Disable TWL clock speed for a specific game.
  */
 bool setClockSpeed() {
-	if (perGameSettings_boostCpu == -1) {
+	if (!ms().ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(twlClockExcludeList)/sizeof(twlClockExcludeList[0]); i++) {
 			if (memcmp(gameTid[CURPOS], twlClockExcludeList[i], 3) == 0) {
@@ -189,7 +189,7 @@ bool setClockSpeed() {
  * Disable card read DMA for a specific game.
  */
 bool setCardReadDMA() {
-	if (perGameSettings_cardReadDMA == -1) {
+	if (!ms().ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(cardReadDMAExcludeList)/sizeof(cardReadDMAExcludeList[0]); i++) {
 			if (memcmp(gameTid[CURPOS], cardReadDMAExcludeList[i], 3) == 0) {
@@ -206,7 +206,7 @@ bool setCardReadDMA() {
  * Disable asynch card read for a specific game.
  */
 bool setAsyncReadDMA() {
-	if (perGameSettings_asyncCardRead == -1) {
+	if (!ms().ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(asyncReadExcludeList)/sizeof(asyncReadExcludeList[0]); i++) {
 			if (memcmp(gameTid[CURPOS], asyncReadExcludeList[i], 3) == 0) {

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -179,6 +179,7 @@ bool dsiWareBooter = true;
 bool dsiWareToSD = true;
 
 bool dontShowClusterWarning = false;
+bool ignoreBlacklists = false;
 
 int updateRecentlyPlayedList = true;
 int sortMethod = 0;
@@ -300,6 +301,7 @@ void LoadSettings(void) {
 	wideScreen = settingsini.GetInt("SRLOADER", "WIDESCREEN", wideScreen);
 
 	dontShowClusterWarning = settingsini.GetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
+	ignoreBlacklists = settingsini.GetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
 
 	updateRecentlyPlayedList = settingsini.GetInt("SRLOADER", "UPDATE_RECENTLY_PLAYED_LIST", updateRecentlyPlayedList);
 	sortMethod = settingsini.GetInt("SRLOADER", "SORT_METHOD", sortMethod);
@@ -336,6 +338,7 @@ void SaveSettings(void) {
 		settingsini.SetInt("SRLOADER", "HOMEBREW_HAS_WIDE", homebrewHasWide);
 		settingsini.SetInt("SRLOADER", "DONT_SHOW_CLUSTER_WARNING", dontShowClusterWarning);
 	}
+	settingsini.SetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
 	//settingsini.SetInt("SRLOADER", "THEME", theme);
 	settingsini.SaveIniFile(settingsinipath);
 }
@@ -556,7 +559,7 @@ void stop (void) {
  * Disable TWL clock speed for a specific game.
  */
 bool setClockSpeed(const char* filename) {
-	if (perGameSettings_boostCpu == -1) {
+	if (!ignoreBlacklists) {
 		FILE *f_nds_file = fopen(filename, "rb");
 
 		char game_TID[5];
@@ -580,7 +583,7 @@ bool setClockSpeed(const char* filename) {
  * Disable card read DMA for a specific game.
  */
 bool setCardReadDMA(const char* filename) {
-	if (perGameSettings_cardReadDMA == -1) {
+	if (!ignoreBlacklists) {
 		FILE *f_nds_file = fopen(filename, "rb");
 
 		char game_TID[5];
@@ -604,7 +607,7 @@ bool setCardReadDMA(const char* filename) {
  * Disable asynch card read for a specific game.
  */
 bool setAsyncReadDMA(const char* filename) {
-	if (perGameSettings_asyncCardRead == -1) {
+	if (!ignoreBlacklists) {
 		FILE *f_nds_file = fopen(filename, "rb");
 
 		char game_TID[5];

--- a/rungame/arm9/source/main.cpp
+++ b/rungame/arm9/source/main.cpp
@@ -85,6 +85,8 @@ static int gameRegion = -2;
 static bool dsiWareBooter = true;
 static bool dsiWareToSD = true;
 
+static bool ignoreBlacklists = false;
+
 TWL_CODE void LoadSettings(void) {
 	// GUI
 	CIniFile settingsini( settingsinipath );
@@ -123,6 +125,7 @@ TWL_CODE void LoadSettings(void) {
 	homebrewHasWide = settingsini.GetInt("SRLOADER", "HOMEBREW_HAS_WIDE", 0);
 
 	wideScreen = settingsini.GetInt("SRLOADER", "WIDESCREEN", wideScreen);
+	ignoreBlacklists = settingsini.GetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
 
 	// nds-bootstrap
 	CIniFile bootstrapini( bootstrapinipath );
@@ -144,7 +147,7 @@ void stop (void) {
  * Disable TWL clock speed for a specific game.
  */
 bool setClockSpeed(char gameTid[]) {
-	if (perGameSettings_boostCpu == -1) {
+	if (!ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(twlClockExcludeList)/sizeof(twlClockExcludeList[0]); i++) {
 			if (memcmp(gameTid, twlClockExcludeList[i], 3) == 0) {

--- a/slot1launch/arm9/source/main.cpp
+++ b/slot1launch/arm9/source/main.cpp
@@ -38,8 +38,8 @@ sNDSHeader ndsHeader;
 /**
  * Disable TWL clock speed for a specific game.
  */
-bool setClockSpeed(int setting, char gameTid[]) {
-	if (setting == -1) {
+bool setClockSpeed(int setting, char gameTid[], bool ignoreBlacklists) {
+	if(!ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(twlClockExcludeList)/sizeof(twlClockExcludeList[0]); i++) {
 			if (memcmp(gameTid, twlClockExcludeList[i], 3) == 0) {
@@ -82,6 +82,7 @@ int main() {
 	bool soundFreq = false;
 	bool runCardEngine = false;
 	bool EnableSD = false;
+	bool ignoreBlacklists = false;
 	int language = -1;
 
 	// If slot is powered off, tell Arm7 slot power on is required.
@@ -114,8 +115,9 @@ int main() {
 			CIniFile pergameini(pergamefilepath);
 			CIniFile settingsini("/_nds/TWiLightMenu/settings.ini");
 
+			ignoreBlacklists = settingsini.GetInt("SRLOADER","IGNORE_BLACKLISTS",false);
 			TWLMODE = pergameini.GetInt("GAMESETTINGS","DSI_MODE",-1);
-			TWLCLK = setClockSpeed(pergameini.GetInt("GAMESETTINGS","BOOST_CPU",-1), gameTid);
+			TWLCLK = setClockSpeed(pergameini.GetInt("GAMESETTINGS","BOOST_CPU",-1), gameTid, ignoreBlacklists);
 			TWLVRAM = pergameini.GetInt("GAMESETTINGS","BOOST_VRAM",-1);
 			TWLTOUCH = settingsini.GetInt("SRLOADER","SLOT1_TOUCH_MODE",0);
 			soundFreq = settingsini.GetInt("NDS-BOOTSTRAP","SOUND_FREQ",0);

--- a/title/arm9/source/common/dsimenusettings.cpp
+++ b/title/arm9/source/common/dsimenusettings.cpp
@@ -87,6 +87,7 @@ TWLSettings::TWLSettings()
 	autostartSlot1 = false;
 
 	wideScreen = false;
+    ignoreBlacklists = false;
 }
 
 void TWLSettings::loadSettings()
@@ -186,6 +187,8 @@ void TWLSettings::loadSettings()
     autostartSlot1 = settingsini.GetInt("SRLOADER", "AUTORUNSLOT1", autostartSlot1);
 
     wideScreen = settingsini.GetInt("SRLOADER", "WIDESCREEN", wideScreen);
+
+    ignoreBlacklists = settingsini.GetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
 }
 
 void TWLSettings::saveSettings()
@@ -235,6 +238,8 @@ void TWLSettings::saveSettings()
     settingsini.SetInt("SRLOADER", "AK_ZOOM_ICONS", ak_zoomIcons);
 
     settingsini.SetInt("SRLOADER", "SHOW_12H_CLOCK", show12hrClock);
+
+    settingsini.SetInt("SRLOADER", "IGNORE_BLACKLISTS", ignoreBlacklists);
 
     settingsini.SaveIniFile(settingsinipath);
 }

--- a/title/arm9/source/common/dsimenusettings.h
+++ b/title/arm9/source/common/dsimenusettings.h
@@ -236,6 +236,7 @@ class TWLSettings
     std::string font;
 
     bool wideScreen;
+    bool ignoreBlacklists;
 };
 
 typedef singleton<TWLSettings> menuSettings_s;

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -470,7 +470,7 @@ void lastRunROM()
 						}
 					}
 
-					if (perGameSettings_boostCpu == -1) {
+					if (!ms().ignoreBlacklists) {
 						// TODO: If the list gets large enough, switch to bsearch().
 						for (unsigned int i = 0; i < sizeof(twlClockExcludeList)/sizeof(twlClockExcludeList[0]); i++) {
 							if (memcmp(game_TID, twlClockExcludeList[i], 3) == 0) {
@@ -479,8 +479,7 @@ void lastRunROM()
 								break;
 							}
 						}
-					}
-					if (perGameSettings_cardReadDMA == -1) {
+
 						// TODO: If the list gets large enough, switch to bsearch().
 						for (unsigned int i = 0; i < sizeof(cardReadDMAExcludeList)/sizeof(cardReadDMAExcludeList[0]); i++) {
 							if (memcmp(game_TID, cardReadDMAExcludeList[i], 3) == 0) {
@@ -489,8 +488,7 @@ void lastRunROM()
 								break;
 							}
 						}
-					}
-					if (perGameSettings_asyncCardRead == -1) {
+
 						// TODO: If the list gets large enough, switch to bsearch().
 						for (unsigned int i = 0; i < sizeof(asyncReadExcludeList)/sizeof(asyncReadExcludeList[0]); i++) {
 							if (memcmp(game_TID, asyncReadExcludeList[i], 3) == 0) {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes it so that blacklisted settings are just completely hidden from per-game settings and ignored if an old value was set
- Can be disabled by setting `IGNORE_BLACKLISTS` to `1` in `settings.ini`, this is intentionally not added into the settings menu so that it won't be turned on by people who don't know what they're doing

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
