### PR TITLE
Fix blacklists hiding options until reboot

### DIFF
--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -132,6 +132,9 @@ void loadPerGameSettings (std::string filename) {
 	perGameSettings_expandRomSpace = pergameini.GetInt("GAMESETTINGS", "EXTENDED_MEMORY", -1);
 
 	// Check if blacklisted
+	blacklisted_boostCpu = false;
+	blacklisted_cardReadDma = false;
+	blacklisted_asyncCardRead = false;
 	if(!ms().ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(twlClockExcludeList)/sizeof(twlClockExcludeList[0]); i++) {

--- a/romsel_r4theme/arm9/source/perGameSettings.cpp
+++ b/romsel_r4theme/arm9/source/perGameSettings.cpp
@@ -371,6 +371,9 @@ void perGameSettings (std::string filename) {
 	game_TID[4] = 0;
 
 	// Check if blacklisted
+	blacklisted_boostCpu = false;
+	blacklisted_cardReadDma = false;
+	blacklisted_asyncCardRead = false;
 	if(!ignoreBlacklists) {
 		// TODO: If the list gets large enough, switch to bsearch().
 		for (unsigned int i = 0; i < sizeof(twlClockExcludeList)/sizeof(twlClockExcludeList[0]); i++) {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes blacklists causing the blacklisted options to be hidden for all games until a reboot
- Fixes #1707

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
