### PR TITLE
slot1launch: move to DSi&3DS SD card users folder

### DIFF
--- a/slot1launch/Makefile
+++ b/slot1launch/Makefile
@@ -25,7 +25,7 @@ all: cardengine_arm7 bootloader bootloaderAlt $(TARGET).nds
 
 dist:	all
 	@mkdir -p ../7zfile/debug
-	@cp $(TARGET).nds ../7zfile/_nds/TWiLightMenu/slot1launch.srldr
+	@cp $(TARGET).nds "../7zfile/DSi&3DS - SD card users/_nds/TWiLightMenu/slot1launch.srldr"
 	@cp $(TARGET).arm7.elf ../7zfile/debug/$(TARGET).arm7.elf
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

slot1launch is unused in flashcard mode but it is part of the flashcard download anyway. Thus moved to DSi/3DS only.

#### Where have you tested it?

N/A

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
