### PR TITLE
autoboot: support R4iTT 3DS based clones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ ipch/
 7zfile/Flashcard users/Autoboot/Ace3DS+, Ace3DS X, R4iLS, r4isdhc.com.cn cards, r4isdhc.hk 2021, R4infinity 2, R4i-XDS 2014 white version
 7zfile/Flashcard users/Autoboot/Gateway Blue
 7zfile/Flashcard users/Autoboot/Acekard 2i & Acekard 2.1
+7zfile/Flashcard users/Autoboot/R4iTT 3DS, R4i3D 2012+, r4isdhc.com NEW cards, r4isdhc.com 2013 cards, r4isdhc.hk cards before 2019, r4igold.cc 3DS translucent, r4i-gold.me 2013+
 
 7zfile/_nds/TWiLightMenu/extras/apfix.pck
 7zfile/_nds/TWiLightMenu/extras/widescreen.pck

--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -207,6 +207,12 @@ autoboot:
 	mkdir -p "../7zfile/Flashcard users/Autoboot/Acekard 2i & Acekard 2.1"
 	mv booter_acekard2.nds "../7zfile/Flashcard users/Autoboot/Acekard 2i & Acekard 2.1/akmenu4.nds"
 
+	#### R4iTT 3DS, R4i3D 2012+, r4isdhc.com NEW cards, r4isdhc.com 2013 cards, r4isdhc.hk cards before 2019, r4igold.cc 3DS translucent, r4i-gold.me 2013+
+	cp booter_fc.nds _DS_MENU.dat
+	dlditool flashcart_specifics/DLDI/r4itt.dldi _DS_MENU.dat
+	mkdir -p "../7zfile/Flashcard users/Autoboot/R4iTT 3DS, R4i3D 2012+, r4isdhc.com NEW cards, r4isdhc.com 2013 cards, r4isdhc.hk cards before 2019, r4igold.cc 3DS translucent, r4i-gold.me 2013+"
+	mv _DS_MENU.dat "../7zfile/Flashcard users/Autoboot/R4iTT 3DS, R4i3D 2012+, r4isdhc.com NEW cards, r4isdhc.com 2013 cards, r4isdhc.hk cards before 2019, r4igold.cc 3DS translucent, r4i-gold.me 2013+/_DS_MENU.DAT"
+
 $(TARGET).nds:	makearm7_fc makearm7_r4ils makearm9_fc makearm9_r4idsn makearm9_acekard2
 	# simple nds srl without dsi extended header
 	ndstool -c $(TARGET)_fc.nds       -7 $(TARGET)_fc.arm7.elf -9 $(TARGET)_fc.arm9.elf       -h 0x200 -b icon.bmp "TWiLight Menu++;Rocket Robz"


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Added autoboot payloads for R4iTT 3DS based clone flashcarts. At the moment only the ones specified in the folder name are tested, but that much should be obvious.

#### Where have you tested it?

R4i3D 2012, r4isdhc.com Silver RTS Lite NEW, DS Lite

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
