### PR TITLE
Use faster DLDI for M3 DS Real

### DIFF
--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -197,7 +197,7 @@ autoboot:
 
 	#### M3 DS Real
 	ndstool -c SRESET.DAT -7 $(TARGET)_fc.arm7.elf -9 $(TARGET)_acekard2.arm9.elf -h 0x200 -b icon.bmp "TWiLight Menu++;Rocket Robz"
-	dlditool flashcart_specifics/DLDI/M3DS_DLDI_based_on_r4tf_v2.dldi SRESET.DAT
+	dlditool "flashcart_specifics/DLDI/M3-DS_(SD_Card).dldi" SRESET.DAT
 	./flashcart_specifics/dsbize/dsbize SRESET.DAT menu.xx 0x12
 	mv menu.xx "../7zfile/Flashcard users/Autoboot/M3 DS Real, M3i Zero (non-GMP-Z003)/SYSTEM/menu.xx"
 	mv SRESET.DAT "../7zfile/Flashcard users/Autoboot/M3 DS Real, M3i Zero (non-GMP-Z003)/SRESET.DAT"

--- a/quickmenu/arm9/source/main.cpp
+++ b/quickmenu/arm9/source/main.cpp
@@ -690,7 +690,8 @@ void loadGameOnFlashcard (const char* ndsPath, bool dsGame) {
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "M3-DS", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -592,7 +592,8 @@ void loadGameOnFlashcard (const char *ndsPath, bool dsGame) {
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "M3-DS", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1045,7 +1045,8 @@ void loadGameOnFlashcard (const char* ndsPath, bool dsGame) {
 			 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
 			 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
-			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
+			 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)
+			 || (memcmp(io_dldi_data->friendlyName, "M3-DS", 5) == 0)) {
 		CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 		fcPath = replaceAll(ndsPath, "fat:/", slashchar);
 		fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);

--- a/rungame/arm9/source/main.cpp
+++ b/rungame/arm9/source/main.cpp
@@ -434,7 +434,8 @@ TWL_CODE int lastRunROM() {
 						 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 						 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
 						 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
-						 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
+						 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)
+						 || (memcmp(io_dldi_data->friendlyName, "M3-DS", 5) == 0)) {
 					CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 					path = ReplaceAll(romPath[1], "fat:/", slashchar);
 					fcrompathini.SetString("YSMENU", "AUTO_BOOT", path);

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -589,7 +589,8 @@ void lastRunROM()
 					 || (memcmp(io_dldi_data->friendlyName, "DSTT", 4) == 0)
 					 || (memcmp(io_dldi_data->friendlyName, "DEMON", 5) == 0)
 					 || (memcmp(io_dldi_data->friendlyName, "DSONE", 5) == 0)
-					 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)) {
+					 || (memcmp(io_dldi_data->friendlyName, "M3DS DLDI", 9) == 0)
+					 || (memcmp(io_dldi_data->friendlyName, "M3-DS", 5) == 0)) {
 				CIniFile fcrompathini("fat:/TTMenu/YSMenu.ini");
 				fcPath = replaceAll(ms().romPath[ms().previousUsedDevice], "fat:/", slashchar);
 				fcrompathini.SetString("YSMENU", "AUTO_BOOT", fcPath);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

The DLDI that was initially used for the M3 DS Real autoboot (taken from YSMenu) is slower than the official M3 DS Real DLDI provided from Sakura. This has now been updated to use the faster DLDI as it turns out it fits in the max 16KB space.

There appears to be some actual improvements to B4DS performance, but I've only tested NFSU2 so far.

#### Where have you tested it?

M3 DS Real, DS Lite

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
