### PR TITLE
Fix SD inserted check

### DIFF
--- a/universal/sdmmc/arm7/source/my_sdmmc.c
+++ b/universal/sdmmc/arm7/source/my_sdmmc.c
@@ -572,7 +572,7 @@ void my_sdmmcHandler() {
     switch(*(u32*)0x02FFFA0C) {
 
     case 0x56484453: // SDMMC_HAVE_SD
-		result = sdmmc_read16(REG_SDSTATUS0);
+		result = (sdmmc_read16(REG_SDSTATUS0) & BIT(5)) != 0;
         break;
 
     case 0x54534453: // SDMMC_SD_START


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Fixes the SD inserted check so that it shows the FAT init failed screen instead of hanging on white screens forever if booted without an SD card.

#### Where have you tested it?

- DSi (K) from wifiboot and DSi (U) from SysNAND DSi Menu

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
