### PR TITLE
Fix booter_fc poweroff fail on DS

### DIFF
--- a/booter_fc/arm7/source/main.c
+++ b/booter_fc/arm7/source/main.c
@@ -109,12 +109,15 @@ int main() {
 
 	setPowerButtonCB(powerButtonCB);
 
-	fifoSendValue32(FIFO_USER_07, SNDEXCNT);
-
+	bool isRegularDS = true; 
+	if(SNDEXCNT != 0) isRegularDS = false; // If sound frequency setting is found, then the console is not a DS Phat/Lite
+	fifoSendValue32(FIFO_USER_07, isRegularDS);
 	// Keep the ARM7 mostly idle
 	while (!exitflag) {
 		if(fifoCheckValue32(FIFO_USER_01)) {
-			ReturntoDSiMenu();
+			if (!isRegularDS) {
+				ReturntoDSiMenu(); // reboot into System Menu (power-off/sleep mode screen skipped)
+			} else exitflag = true; // poweroff if DS
 		}
 		swiWaitForVBlank();
 	}

--- a/booter_fc/arm9/source/main.cpp
+++ b/booter_fc/arm9/source/main.cpp
@@ -53,9 +53,7 @@ int main(int argc, char **argv) {
 	REG_SCFG_CLK = 0x85;					// TWL clock speed
 	REG_SCFG_EXT = 0x8307F100;				// Extended memory, extended VRAM, etc.
 
-	bool isRegularDS = true;
-	u16 arm7_SNDEXCNT = fifoGetValue32(FIFO_USER_07);
-	if (arm7_SNDEXCNT != 0) isRegularDS = false;	// If sound frequency setting is found, then the console is not a DS Phat/Lite
+	bool isRegularDS = fifoGetValue32(FIFO_USER_07);
 
 	/*bool sdFound = false;
 	#ifndef CYCLODSI
@@ -86,12 +84,8 @@ int main(int argc, char **argv) {
 
 	while (1) {
 		scanKeys();
-		if (keysHeld() & KEY_B) {
-			if (isRegularDS) {
-				systemShutDown();
-			} else {
-				fifoSendValue32(FIFO_USER_01, 1);	// Tell ARM7 to reboot into System Menu (power-off/sleep mode screen skipped)
-			}
+		if (keysDown() & KEY_B) {
+			fifoSendValue32(FIFO_USER_01, 1);	// Tell ARM7 to reboot or poweroff depending on whether DS or DSi
 			break;
 		}
 		swiWaitForVBlank();


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

This PR:
- Fixes #1735
- Does the `isRegularDS` check on arm7 and passes it to arm9 as the arm7 requires this distinction now. This could probably be done by using different FIFO values.


#### Where have you tested it?

DSONE SDHC, DS Lite
DSONE SDHC, DSi XL / Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
