### PR TITLE
Make icons dir in release builds & bug fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           mv TWiLightMenu-debug-release.7z ~/artifacts
 
           mkdir -p 7zfile/_nds/TWiLightMenu/boxart/
+          mkdir -p 7zfile/_nds/TWiLightMenu/icons/
           mkdir -p 7zfile/_nds/TWiLightMenu/extras/
           mkdir -p 7zfile/_nds/TWiLightMenu/gamesettings/
 

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -1823,7 +1823,7 @@ void getFileInfo(SwitchState scrn, vector<vector<DirEntry>> dirContents, bool re
 	// Load correct icons depending on cursor position
 	if (CURPOS <= 1) {
 		for (int i = 0; i < 5; i++) {
-			if (bnrRomType[i] == 0 && i + PAGENUM * 40 < file_count) {
+			if ((bnrRomType[i] == 0 || customIcon[i]) && i + PAGENUM * 40 < file_count) {
 				snd().updateStream();
 				swiWaitForVBlank();
 				iconUpdate(dirContents[scrn].at(i + PAGENUM * 40).isDirectory,
@@ -1832,7 +1832,7 @@ void getFileInfo(SwitchState scrn, vector<vector<DirEntry>> dirContents, bool re
 		}
 	} else if (CURPOS >= 2 && CURPOS <= 36) {
 		for (int i = 0; i < 6; i++) {
-			if (bnrRomType[i] == 0 && (CURPOS - 2 + i) + PAGENUM * 40 < file_count) {
+			if ((bnrRomType[i] == 0 || customIcon[CURPOS - 2 + i]) && (CURPOS - 2 + i) + PAGENUM * 40 < file_count) {
 				snd().updateStream();
 				swiWaitForVBlank();
 				iconUpdate(dirContents[scrn].at((CURPOS - 2 + i) + PAGENUM * 40).isDirectory,
@@ -1842,7 +1842,7 @@ void getFileInfo(SwitchState scrn, vector<vector<DirEntry>> dirContents, bool re
 		}
 	} else if (CURPOS >= 37 && CURPOS <= 39) {
 		for (int i = 0; i < 5; i++) {
-			if (bnrRomType[i] == 0 && (35 + i) + PAGENUM * 40 < file_count) {
+			if ((bnrRomType[i] == 0 || customIcon[35 + i]) && (35 + i) + PAGENUM * 40 < file_count) {
 				snd().updateStream();
 				swiWaitForVBlank();
 				iconUpdate(dirContents[scrn].at((35 + i) + PAGENUM * 40).isDirectory,


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Noticed that making the `icons` folder wasn't added to the release.yml in #1800 so this adds that
- Also fixed a minor bug I noticed where it would fail to load the icon if it was one of the games that showed up immedietly on load (instead of scrolling over to it/entering a folder)

#### Where have you tested it?

- DSi LL (J) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
