### PR TITLE
Whoops I added too much green to custom icons

### DIFF
--- a/quickmenu/arm9/source/iconTitle.cpp
+++ b/quickmenu/arm9/source/iconTitle.cpp
@@ -711,7 +711,7 @@ void getGameInfo(int num, bool isDir, const char* name)
 							b /= 8;
 							g /= 8;
 							r /= 8;
-							u16 color = 0x80 | b<<10 | g<<5 | r;
+							u16 color = 0x8000 | b<<10 | g<<5 | r;
 							// find color in palette
 							bool found = false;
 							for (uint palIdx = 1; palIdx < colorCount; palIdx++) {

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -285,7 +285,7 @@ void getGameInfo(bool isDir, const char *name, int num) {
 							b /= 8;
 							g /= 8;
 							r /= 8;
-							u16 color = 0x80 | b<<10 | g<<5 | r;
+							u16 color = 0x8000 | b<<10 | g<<5 | r;
 							// find color in palette
 							bool found = false;
 							for (uint palIdx = 1; palIdx < colorCount; palIdx++) {

--- a/romsel_r4theme/arm9/source/iconTitle.cpp
+++ b/romsel_r4theme/arm9/source/iconTitle.cpp
@@ -768,7 +768,7 @@ void getGameInfo(bool isDir, const char* name)
 							b /= 8;
 							g /= 8;
 							r /= 8;
-							u16 color = 0x80 | b<<10 | g<<5 | r;
+							u16 color = 0x8000 | b<<10 | g<<5 | r;
 							// find color in palette
 							bool found = false;
 							for (uint palIdx = 1; palIdx < colorCount; palIdx++) {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Small bug fix to the custom icon PNG conversion code to stop it from adding extra green to all the colors.

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
