### PR TITLE
Add support for Python 3, update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM devkitpro/devkitarm:20200528
+FROM devkitpro/devkitarm
 # ENV TWLNOPATCHSRLHEADER=1
 RUN \
   apt-get update && \

--- a/booter/Makefile
+++ b/booter/Makefile
@@ -7,6 +7,16 @@ ifeq ($(strip $(DEVKITARM)),)
 $(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
 endif
 
+ifneq (,$(shell which python3))
+PYTHON	:= python3
+else ifneq (,$(shell which python2))
+PYTHON	:= python2
+else ifneq (,$(shell which python))
+PYTHON	:= python
+else
+$(error "Python not found in PATH, please install it.")
+endif
+
 include $(DEVKITARM)/ds_rules
 
 export VERSION_MAJOR	:= 7
@@ -142,8 +152,8 @@ $(TARGET)_rungame.nds:	$(TARGET).arm7 $(TARGET).arm9
 			-g SLRN 01 "TWLMENUPP-LR" -z 80040000 -u 00030015 -a 00000138 -b icon.bmp "TWiLight Menu++;Last-run ROM;Rocket Robz"
 
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
-		python2 ../patch_ndsheader_dsiware.py $(TARGET).nds --twlTouch
-		python2 ../patch_ndsheader_dsiware.py $(TARGET)_rungame.nds --twlTouch
+		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET).nds --twlTouch
+		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET)_rungame.nds --twlTouch
 endif
 
 $(TARGET).arm7: arm7/$(TARGET).elf

--- a/resources/Makefile
+++ b/resources/Makefile
@@ -1,3 +1,13 @@
+ifneq (,$(shell which python3))
+PYTHON	:= python3
+else ifneq (,$(shell which python2))
+PYTHON	:= python2
+else ifneq (,$(shell which python))
+PYTHON	:= python
+else
+$(error "Python not found in PATH, please install it.")
+endif
+
 #---------------------------------------------------------------------------------
 # OUTPUT_DIR is the directory where final published files will be placed
 #---------------------------------------------------------------------------------
@@ -14,7 +24,7 @@ WIDEFILES	:= widescreen
 all:	$(OUTPUT_DIR)/apfix.pck $(OUTPUT_DIR)/widescreen.pck
 
 $(OUTPUT_DIR)/apfix.pck: $(APFILES)
-	python2 pack.py $^ -o $@
+	$(PYTHON) pack.py $^ -o $@
 
 $(OUTPUT_DIR)/widescreen.pck: $(WIDEFILES)
-	python2 pack.py $^ -o $@
+	$(PYTHON) pack.py $^ -o $@

--- a/rungame/Makefile
+++ b/rungame/Makefile
@@ -7,6 +7,16 @@ ifeq ($(strip $(DEVKITARM)),)
 $(error "Please set DEVKITARM in your environment. export DEVKITARM=<path to>devkitARM")
 endif
 
+ifneq (,$(shell which python3))
+PYTHON	:= python3
+else ifneq (,$(shell which python2))
+PYTHON	:= python2
+else ifneq (,$(shell which python))
+PYTHON	:= python
+else
+$(error "Python not found in PATH, please install it.")
+endif
+
 include $(DEVKITARM)/ds_rules
 
 export VERSION_MAJOR	:= 7
@@ -133,7 +143,7 @@ $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 			-g SLRN 01 "TWLMENUPP-LR" -a 00000138 -z 80040000 -b icon.bmp "TWiLight Menu++;Last-run ROM;RocketRobz"
 
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
-		python2 ../patch_ndsheader_dsiware.py $(TARGET).nds --twlTouch
+		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET).nds --twlTouch
 endif
 
 $(TARGET).arm7: arm7/$(TARGET).elf


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes `patch_ndsheader_dsiware.py` in Python 3 (2 still works) and updates the Makefiles to use python3 if found
- Updates the Dockerfile to use the latest, same as Actions

#### Where have you tested it?

- macOS 10.15, can't test docker

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
