### PR TITLE
Derp fix, restore Games and Apps settings string

### DIFF
--- a/settings/nitrofiles/languages/en/language.ini
+++ b/settings/nitrofiles/languages/en/language.ini
@@ -7,10 +7,10 @@ NDS_BOOTSTRAP_VER=nds-bootstrap Ver.
 
 MISC_SETTINGS=Misc. settings
 GUI_SETTINGS=GUI settings
-EMULATION_HB_SETTINGS=Emulation/HB settings
 GBARUNNER2_SETTINGS=GBARunner2 settings
 BOOTSTRAP_SETTINGS=nds-bootstrap settings
 UNLAUNCH_SETTINGS=Unlaunch settings
+GAMESAPPS_SETTINGS=Games and Apps settings
 PRESS_A=Press \A
 SELECT_SEE_DESC_VER=SELECT: Description and ver.
 SELECT_SETTING_LIST=SELECT/\B: Setting list


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Accidentally left the `Emulation/HB settings` string instead of the `Games and Apps settings` string
- Fixes #1829

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
