### PR TITLE
Allow custom icons under 32x32

### DIFF
--- a/quickmenu/arm9/source/iconTitle.cpp
+++ b/quickmenu/arm9/source/iconTitle.cpp
@@ -687,13 +687,17 @@ void getGameInfo(int num, bool isDir, const char* name)
 				std::vector<unsigned char> image;
 				uint imageWidth, imageHeight;
 				lodepng::decode(image, imageWidth, imageHeight, customIconPath);
-				if (imageWidth == 32 && imageHeight == 32) {
+				if (imageWidth <= 32 && imageHeight <= 32) {
 					customIconGood = true;
+
+					// if smaller than 32x32, center it
+					int xOfs = (32 - imageWidth) / 2;
+					int yOfs = (32 - imageHeight) / 2;
 
 					uint colorCount = 1;
 					for (uint i = 0; i < image.size()/4; i++) {
 						// calculate byte and nibble position of pixel in tiled banner icon
-						uint x = i%32, y = i/32;
+						uint x = xOfs + (i%imageWidth), y = yOfs + (i/imageWidth);
 						uint tileX = x/8, tileY = y/8;
 						uint offX = x%8, offY = y%8;
 						uint pos = tileX*32 + tileY*128 + offX/2 + offY*4;

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -261,13 +261,17 @@ void getGameInfo(bool isDir, const char *name, int num) {
 				std::vector<unsigned char> image;
 				uint imageWidth, imageHeight;
 				lodepng::decode(image, imageWidth, imageHeight, customIconPath);
-				if (imageWidth == 32 && imageHeight == 32) {
+				if (imageWidth <= 32 && imageHeight <= 32) {
 					customIconGood = true;
+
+					// if smaller than 32x32, center it
+					int xOfs = (32 - imageWidth) / 2;
+					int yOfs = (32 - imageHeight) / 2;
 
 					uint colorCount = 1;
 					for (uint i = 0; i < image.size()/4; i++) {
 						// calculate byte and nibble position of pixel in tiled banner icon
-						uint x = i%32, y = i/32;
+						uint x = xOfs + (i%imageWidth), y = yOfs + (i/imageWidth);
 						uint tileX = x/8, tileY = y/8;
 						uint offX = x%8, offY = y%8;
 						uint pos = tileX*32 + tileY*128 + offX/2 + offY*4;

--- a/romsel_r4theme/arm9/source/iconTitle.cpp
+++ b/romsel_r4theme/arm9/source/iconTitle.cpp
@@ -744,13 +744,17 @@ void getGameInfo(bool isDir, const char* name)
 				std::vector<unsigned char> image;
 				uint imageWidth, imageHeight;
 				lodepng::decode(image, imageWidth, imageHeight, customIconPath);
-				if (imageWidth == 32 && imageHeight == 32) {
+				if (imageWidth <= 32 && imageHeight <= 32) {
 					customIconGood = true;
+
+					// if smaller than 32x32, center it
+					int xOfs = (32 - imageWidth) / 2;
+					int yOfs = (32 - imageHeight) / 2;
 
 					uint colorCount = 1;
 					for (uint i = 0; i < image.size()/4; i++) {
 						// calculate byte and nibble position of pixel in tiled banner icon
-						uint x = i%32, y = i/32;
+						uint x = xOfs + (i%imageWidth), y = yOfs + (i/imageWidth);
 						uint tileX = x/8, tileY = y/8;
 						uint offX = x%8, offY = y%8;
 						uint pos = tileX*32 + tileY*128 + offX/2 + offY*4;


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Allows using any PNG up to 32x32 instead of just specifically 32x32 for custom icons

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
