### PR TITLE
Hide ramdisks folder

### DIFF
--- a/romsel_aktheme/arm9/source/windows/mainlist.cpp
+++ b/romsel_aktheme/arm9/source/windows/mainlist.cpp
@@ -339,10 +339,10 @@ bool MainList::enterDir(const std::string &dirName)
 
             dbg_printf("%s: %s %s\n", (st.st_mode & S_IFDIR ? " DIR" : "FILE"), lfnBuf, extName.c_str());
             cwl();
-            bool showThis = (st.st_mode & S_IFDIR) ? ((lfn != "." && lfn != ".." && lfn != "_nds" && lfn != "saves") && ms().showDirectories)   // directory filter
-                                                   : extnameFilter(_showAllFiles ? std::vector<std::string>() : _extnameFilter, extName);       // extension name filter
-            showThis = showThis && (ms().showHidden || (strncmp(".", direntry->d_name, 1)));                                                    // Hide dotfiles
-            showThis = showThis && (ms().showHidden || !(FAT_getAttr((dirName + lfn).c_str()) & ATTR_HIDDEN));                                  // Hide if the hidden FAT attribute is true
+            bool showThis = (st.st_mode & S_IFDIR) ? ((lfn != "." && lfn != ".." && lfn != "_nds" && lfn != "saves" && lfn != "ramdisks") && ms().showDirectories)  // directory filter
+                                                   : extnameFilter(_showAllFiles ? std::vector<std::string>() : _extnameFilter, extName);                           // extension name filter
+            showThis = showThis && (ms().showHidden || (strncmp(".", direntry->d_name, 1)));                                                                        // Hide dotfiles
+            showThis = showThis && (ms().showHidden || !(FAT_getAttr((dirName + lfn).c_str()) & ATTR_HIDDEN));                                                      // Hide if the hidden FAT attribute is true
             cwl();
             nocashMessage("mainlist:338");
 

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -275,7 +275,7 @@ void getDirectoryContents(std::vector<DirEntry> &dirContents, const std::vector<
 
 			if (ms().showDirectories) {
 				if (strcmp(pent->d_name, ".") != 0 && strcmp(pent->d_name, "_nds") != 0
-					&& strcmp(pent->d_name, "saves") != 0
+					&& strcmp(pent->d_name, "saves") != 0 && strcmp(pent->d_name, "ramdisks") !=0
 					&& (pent->d_type == DT_DIR || nameEndsWith(pent->d_name, extensionList))) {
 					if (ms().showHidden || !(FAT_getAttr(pent->d_name) & ATTR_HIDDEN || (pent->d_name[0] == '.' && strcmp(pent->d_name, "..") != 0))) {
 						dirContents.emplace_back(pent->d_name, pent->d_type == DT_DIR, currentPos, false);

--- a/romsel_r4theme/arm9/source/fileBrowse.cpp
+++ b/romsel_r4theme/arm9/source/fileBrowse.cpp
@@ -171,7 +171,7 @@ void getDirectoryContents(std::vector<DirEntry> &dirContents, const std::vector<
 
 			if (ms().showDirectories) {
 				if (strcmp(pent->d_name, ".") != 0 && strcmp(pent->d_name, "_nds") != 0
-					&& strcmp(pent->d_name, "saves") != 0
+					&& strcmp(pent->d_name, "saves") != 0 && strcmp(pent->d_name, "ramdisks") !=0
 					&& (pent->d_type == DT_DIR || nameEndsWith(pent->d_name, extensionList))) {
 					if (ms().showHidden || !(FAT_getAttr(pent->d_name) & ATTR_HIDDEN || (pent->d_name[0] == '.' && strcmp(pent->d_name, "..") != 0))) {
 						dirContents.emplace_back(pent->d_name, pent->d_type == DT_DIR, currentPos, false);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

The `ramdisks` folder generated by TWiLight Menu++ when launching a homebrew ROM is no longer displayed on the three themes (DSi, R4, and AKMenu). Like the `saves` folder, this will never contain anything useful for the user while using TWiLight Menu++, so it just adds clutter.

#### Where have you tested it?

On my DSi, I tested with the DSi and R4 themes.

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
