### PR TITLE
Add Rune Factory games to TWL clock speed exclude list

### DIFF
--- a/universal/include/twlClockExcludeMap.h
+++ b/universal/include/twlClockExcludeMap.h
@@ -35,6 +35,9 @@ static const char twlClockExcludeList[][4] = {
 	"BZP", // Peppa Pig: Theme Park Fun
 	"AQW", // Puzzle Quest: Challenge of the Warlords
 	"BRJ", // Radiant Historia
+	"ARF", // Rune Factory: A Fantasy Harvest Moon
+	"AN6", // Rune Factory 2: A Fantasy Harvest Moon
+	"BRF", // Rune Factory 3: A Fantasy Harvest Moon
 	"ASC", // Sonic Rush
 	"ASM", // Super Mario 64 DS
 	"COZ", // The Wizard of Oz: Beyond the Yellow Brick Road


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

The Rune Factory games have been added to the TWL clock speed exclude map, according to reports from Lillie and the nds-bootstrap compatibility list.

#### Where have you tested it?

Only the exclusion map has been updated, and the game(s) have been tested with 67MHz and 133MHz.

#### Notes

- With this PR, [nds-bootstrap/1030](https://github.com/DS-Homebrew/nds-bootstrap/issues/1030) can be closed
- While only the first and second games have been found to have issues with TWL clock speed, and no reports have been given regarding the third game, it is logical that the third game is also affected

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
