### PR TITLE
Ensure old banner data is always cleared

### DIFF
--- a/quickmenu/arm9/source/iconTitle.cpp
+++ b/quickmenu/arm9/source/iconTitle.cpp
@@ -651,6 +651,7 @@ void getGameInfo(int num, bool isDir, const char* name)
 	infoFound[num] = false;
 
 	if (ms().showCustomIcons) {
+		toncset(&ndsBanner, 0, sizeof(sNDSBannerExt));
 		bool customIconGood = false;
 
 		// First try banner bin

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -216,6 +216,7 @@ void getGameInfo(bool isDir, const char *name, int num) {
 
 	if (ms().showCustomIcons) {
 		sNDSBannerExt &banner = bnriconTile[num];
+		toncset(&banner, 0, sizeof(sNDSBannerExt));
 		bool customIconGood = false;
 
 		// First try banner bin

--- a/romsel_r4theme/arm9/source/iconTitle.cpp
+++ b/romsel_r4theme/arm9/source/iconTitle.cpp
@@ -30,6 +30,7 @@
 #include "common/bootstrapsettings.h"
 #include "common/flashcard.h"
 #include "common/systemdetails.h"
+#include "common/tonccpy.h"
 #include "common/twlmenusettings.h"
 #include "fileBrowse.h"
 #include "graphics/fontHandler.h"
@@ -712,6 +713,7 @@ void getGameInfo(bool isDir, const char* name)
 	requiresDonorRom = false;
 
 	if (ms().showCustomIcons) {
+		toncset(&ndsBanner, 0, sizeof(sNDSBannerExt));
 		bool customIconGood = false;
 
 		// First try banner bin


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- When a custom banner PNG was below 32×32 it could leave part a previously loaded icon behind, this fixes that

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
