### PR TITLE
Fix failure webhook not sending

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -198,11 +198,11 @@ jobs:
             curl -XPOST -H "$AUTH_HEADER" -H "$CONTENT_LENGTH" -H "$CONTENT_TYPE" --upload-file "$file" "$UPLOAD_URL"
           done
 
-  send_webhook:
+  send_success_webhook:
     runs-on: ubuntu-latest
     needs: [publish_build, build]
-    name: Send Discord webhook
-    if: ${{ !startsWith(github.ref, 'refs/pull') }}
+    name: Send success webhook
+    if: ${{ !startsWith(github.ref, 'refs/pull') && success() }}
     env:
       CURRENT_DATE: ${{ needs.publish_build.outputs.current_date }}
       AUTHOR_NAME: ${{ needs.build.outputs.author_name }}
@@ -211,13 +211,18 @@ jobs:
       COMMIT_MESSAGE: ${{ needs.build.outputs.commit_message }}
     steps:
       - name: Send success webhook
-        if: ${{ success() }}
         run: |
           curl -o send.sh https://raw.githubusercontent.com/DS-Homebrew/discord-webhooks/master/send-ghactions.sh
           chmod +x send.sh
           ./send.sh success ${{ secrets.WEBHOOK_URL }}
+
+  send_failure_webhook:
+    runs-on: ubuntu-latest
+    needs: [publish_build, build]
+    name: Send failure webhook
+    if: ${{ !startsWith(github.ref, 'refs/pull') && failure() }}
+    steps:
       - name: Send failure webhook
-        if: ${{ failure() }}
         run: |
           curl -o send.sh https://raw.githubusercontent.com/DS-Homebrew/discord-webhooks/master/send-ghactions.sh
           chmod +x send.sh


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes the build webhook not being sent on failure
  ![スクリーンショット 2022-03-08 23 10 29](https://user-images.githubusercontent.com/41608708/157377101-1ee2db68-284b-4eba-8d26-fba77689a2ac.png)
  (I'll fix the embed to not have the `v -` in a sec)


#### Where have you tested it?

- On my fork, Actions is re-disabled though so I can't link the run

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
