### PR TITLE
Swap 1st and 2nd banner lines

### DIFF
--- a/booter/Makefile
+++ b/booter/Makefile
@@ -149,7 +149,7 @@ $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 
 $(TARGET)_rungame.nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET)_rungame.nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
-			-g SLRN 01 "TWLMENUPP-LR" -z 80040000 -u 00030015 -a 00000138 -b icon.bmp "TWiLight Menu++;Last-run ROM;Rocket Robz"
+			-g SLRN 01 "TWLMENUPP-LR" -z 80040000 -u 00030015 -a 00000138 -b icon.bmp "Last-run ROM;TWiLight Menu++;Rocket Robz"
 
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
 		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET).nds --twlTouch

--- a/gbapatcher/Makefile
+++ b/gbapatcher/Makefile
@@ -30,7 +30,7 @@ dist:	all
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g HBLA -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \
-  -b icon.bmp "TWiLight Menu++;GBA patcher;RocketRobz"
+  -b icon.bmp "GBA patcher;TWiLight Menu++;RocketRobz"
 
 clean:
 	@echo clean ...

--- a/manual/Makefile
+++ b/manual/Makefile
@@ -30,7 +30,7 @@ dist:	all
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g SRLA 01 "TWLMENUPP" -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \
-	-b icon.bmp "TWiLight Menu++;Instruction Manual;Rocket Robz, Evie & NightScript"
+	-b icon.bmp "Instruction Manual;TWiLight Menu++;Rocket Robz, Evie & NightScript"
 
 pages:
 	@$(MAKE) -C resources inifiles

--- a/quickmenu/Makefile
+++ b/quickmenu/Makefile
@@ -30,7 +30,7 @@ dist:	all
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g SRLA 01 "TWLMENUPP" -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \
-  -b icon.bmp "TWiLight Menu++;DS Classic Menu;Rocket Robz"
+  -b icon.bmp "DS Classic Menu;TWiLight Menu++;Rocket Robz"
 
 clean:
 	@echo clean ...

--- a/romsel_aktheme/Makefile
+++ b/romsel_aktheme/Makefile
@@ -30,7 +30,7 @@ dist:	all
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g SRLA 01 "TWLMENUPP" -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \
-  -b icon.bmp "TWiLight Menu++;Wood UI;Rocket Robz & chyyran"
+  -b icon.bmp "Wood UI;TWiLight Menu++;Rocket Robz & chyyran"
 
 clean:
 	@echo clean ...

--- a/romsel_dsimenutheme/Makefile
+++ b/romsel_dsimenutheme/Makefile
@@ -30,7 +30,7 @@ dist:	all
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g SRLA 01 "TWLMENUPP" -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \
-  -b icon.bmp "TWiLight Menu++;DSi-based themes;Rocket Robz"
+  -b icon.bmp "DSi-based themes;TWiLight Menu++;Rocket Robz"
 
 clean:
 	@echo clean ...

--- a/romsel_r4theme/Makefile
+++ b/romsel_r4theme/Makefile
@@ -30,7 +30,7 @@ dist:	all
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g SRLA 01 "TWLMENUPP" -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \
-  -b icon.bmp "TWiLight Menu++;R4 & GBC themes;Rocket Robz"
+  -b icon.bmp "R4 & GBC themes;TWiLight Menu++;Rocket Robz"
 
 clean:
 	@echo clean ...

--- a/rungame/Makefile
+++ b/rungame/Makefile
@@ -140,7 +140,7 @@ dist:	all
 
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-u 00030015 -g SLRN -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
-			-g SLRN 01 "TWLMENUPP-LR" -a 00000138 -z 80040000 -b icon.bmp "TWiLight Menu++;Last-run ROM;RocketRobz"
+			-g SLRN 01 "TWLMENUPP-LR" -a 00000138 -z 80040000 -b icon.bmp "Last-run ROM;TWiLight Menu++;RocketRobz"
 
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
 		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET).nds --twlTouch

--- a/settings/Makefile
+++ b/settings/Makefile
@@ -30,7 +30,7 @@ dist:	all
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g SRLA 01 "TWLMENUPP" -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \
-			-b icon.bmp "TWiLight Menu++;Settings;Rocket Robz"
+			-b icon.bmp "Settings;TWiLight Menu++;Rocket Robz"
 
 clean:
 	@echo clean ...

--- a/slot1launch/Makefile
+++ b/slot1launch/Makefile
@@ -31,7 +31,7 @@ dist:	all
 
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
-			-b $(CURDIR)/icon.bmp "TWiLight Menu++;Slot-1 Launcher;Apache Thunder & Rocket Robz" \
+			-b $(CURDIR)/icon.bmp "Slot-1 Launcher;TWiLight Menu++;Apache Thunder & Rocket Robz" \
 			-g TWL1 01 "TWLMENUPP-S1" -z 80040000 -u 00030004
 
 $(TARGET).arm7	: arm7/$(TARGET).elf

--- a/title/Makefile
+++ b/title/Makefile
@@ -30,7 +30,7 @@ dist:	all
 
 $(TARGET).nds:	makearm7 makearm9
 	ndstool	-u 00030004 -g SRLA 01 "TWLMENUPP" -c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf -d $(NITRODATA) \
-			-b icon.bmp "TWiLight Menu++;Main;Rocket Robz"
+			-b icon.bmp "Title Splash;TWiLight Menu++;Rocket Robz"
 
 clean:
 	@echo clean ...


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Swaps the 1st and 2nd lines of the banners on everything except booter so that you now have:
  > DSi-based themes
  > TWiLight Menu++
  > Rocket Robz

  instead of

  > TWiLight Menu++
  > DSi-based themes
  > Rocket Robz
  - This should hopefully reduce confusion in Unlaunch since there will only be one listing called `TWiLight Menu++`, instead of a dozen or so
- Also changed title's from `Main` to `Title Splash`

#### Where have you tested it?

- Haven't, actions will test building

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
