### PR TITLE
Default color de-band to off

### DIFF
--- a/universal/source/common/twlmenusettings.cpp
+++ b/universal/source/common/twlmenusettings.cpp
@@ -48,7 +48,7 @@ TWLSettings::TWLSettings()
 	theme = EThemeDSi;
 	settingsMusic = ESMusicTheme;
 	dsiMusic = EMusicRegular;
-	boxArtColorDeband = true;
+	boxArtColorDeband = false;
 
 	gbaBooter = isDSiMode() ? EGbaGbar2 : EGbaNativeGbar2;
 	colEmulator = EColSegaColecoDS;


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

It causes a lot of graphical issues on the bottom screen in exchange for an improvement to the box art/photos that honestly isn't all that noticeable imo. I'm fine with it staying an option for the people who like it but there's been quite a few people recently concerned about the graphical glitches so imo it'd be better to default to off.

If others have thoughts on this, please comment.

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
