### PR TITLE
Remove debug files from nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -63,13 +63,9 @@ jobs:
           # Make artifacts directory
           mkdir -p ~/artifacts
 
-          # Don't include fonts in nightlies
+          # Don't include fonts or debug files in nightlies
           rm -rf 7zfile/_nds/TWiLightMenu/extras/fonts
-
-          # Debug 7z
-          mv 7zfile/debug debug
-          7z a TWiLightMenu-debug.7z debug
-          mv TWiLightMenu-debug.7z ~/artifacts
+          rm -rf 7zfile/debug
 
           cp -r 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

TWLBot/Builds has filled up again and I think the debug files are probably a fairly large part of why it happened so quickly, so this makes them not be uploaded for nightlies as I honestly don't think they've ever been used. Release ELFs are still uploaded as I have used those once or twice.

#### Where have you tested it?

- Haven't

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
