### PR TITLE
nds-bootstrap version files stay with nds-bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,13 +80,11 @@ jobs:
           curl -LO https://github.com/DS-Homebrew/nds-bootstrap/releases/latest/download/nds-bootstrap.7z
           7z x nds-bootstrap.7z
           mv nds-bootstrap.* ..
-          mkdir -p TWiLightMenu
-          mv release-bootstrap.ver TWiLightMenu
           cd ..
           curl -L https://github.com/TWLBot/Builds/blob/master/nds-bootstrap.7z?raw=true -o nds-bootstrap.7z
           7z x nds-bootstrap.7z
-          mv nds-bootstrap/TWiLightMenu/release-bootstrap.ver 7zfile/_nds/TWiLightMenu
-          mv nds-bootstrap/TWiLightMenu/nightly-bootstrap.ver 7zfile/_nds/TWiLightMenu
+          mv nds-bootstrap/release-bootstrap.ver 7zfile/_nds/
+          mv nds-bootstrap/nightly-bootstrap.ver 7zfile/_nds/
           mv nds-bootstrap/nds-bootstrap-release.nds 7zfile/_nds/
           mv nds-bootstrap/nds-bootstrap-nightly.nds 7zfile/_nds/
           mv nds-bootstrap/nds-bootstrap-hb-release.nds 7zfile/DSi\&3DS\ -\ SD\ card\ users/_nds/
@@ -117,7 +115,7 @@ jobs:
           cd ../../../..
 
           # version.txt
-          printf "TWiLight Menu++: $(git describe --tags)\nnds-bootstrap: $(cat 7zfile/_nds/TWiLightMenu/release-bootstrap.ver)\n\nRocketRobz, ahezard\n" > 7zfile/version.txt
+          printf "TWiLight Menu++: $(git describe --tags)\nnds-bootstrap: $(cat 7zfile/_nds/release-bootstrap.ver)\n\nRocketRobz, ahezard\n" > 7zfile/version.txt
 
           # Main 7z
           cp -r 7zfile TWiLightMenu

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -517,15 +517,15 @@ void begin_update(int opt)
 	if (opt == 1) {
 		// Slot-1 microSD > Console SD
 		fcopy("fat:/_nds/nds-bootstrap-release.nds", "sd:/_nds/nds-bootstrap-release.nds");
-		fcopy("fat:/_nds/TWiLightMenu/release-bootstrap.ver", "sd:/_nds/TWiLightMenu/release-bootstrap.ver");
+		fcopy("fat:/_nds/release-bootstrap.ver", "sd:/_nds/release-bootstrap.ver");
 		fcopy("fat:/_nds/nds-bootstrap-nightly.nds", "sd:/_nds/nds-bootstrap-nightly.nds");
-		fcopy("fat:/_nds/TWiLightMenu/nightly-bootstrap.ver", "sd:/_nds/TWiLightMenu/nightly-bootstrap.ver");
+		fcopy("fat:/_nds/nightly-bootstrap.ver", "sd:/_nds/nightly-bootstrap.ver");
 	} else {
 		// Console SD > Slot-1 microSD
 		fcopy("sd:/_nds/nds-bootstrap-release.nds", "fat:/_nds/nds-bootstrap-release.nds");
-		fcopy("sd:/_nds/TWiLightMenu/release-bootstrap.ver", "fat:/_nds/TWiLightMenu/release-bootstrap.ver");
+		fcopy("sd:/_nds/release-bootstrap.ver", "fat:/_nds/release-bootstrap.ver");
 		fcopy("sd:/_nds/nds-bootstrap-nightly.nds", "fat:/_nds/nds-bootstrap-nightly.nds");
-		fcopy("sd:/_nds/TWiLightMenu/nightly-bootstrap.ver", "fat:/_nds/TWiLightMenu/nightly-bootstrap.ver");
+		fcopy("sd:/_nds/nightly-bootstrap.ver", "fat:/_nds/nightly-bootstrap.ver");
 	}
 
 	fadeType = false;

--- a/settings/arm9/source/settingsgui.h
+++ b/settings/arm9/source/settingsgui.h
@@ -24,9 +24,9 @@ public:
     FILE* bsVerFile;
     for (int i = 0; i < 2; i++) {
       if (i == 1) {
-        bsVerFile = fopen("/_nds/TWiLightMenu/nightly-bootstrap.ver", "rb");
+        bsVerFile = fopen("/_nds/nightly-bootstrap.ver", "rb");
       } else {
-        bsVerFile = fopen("/_nds/TWiLightMenu/release-bootstrap.ver", "rb");
+        bsVerFile = fopen("/_nds/release-bootstrap.ver", "rb");
       }
       if (bsVerFile) {
         fseek(bsVerFile, 0, SEEK_END);


### PR DESCRIPTION
Bigger part of the changes needed so nds-bootstrap version files stay together with nds-bootstrap nds files.

This should make it possible to not have a TWiLightMenu folder at all if one just uses nds-bootstrap with a forwarder
