### PR TITLE
Add DSiWare Booter to per-game settings

### DIFF
--- a/romsel_dsimenutheme/arm9/source/language.inl
+++ b/romsel_dsimenutheme/arm9/source/language.inl
@@ -119,6 +119,7 @@ STRING(DIRECT_BOOT, "Direct Boot")
 STRING(SCREEN_ASPECT_RATIO, "Screen Aspect Ratio")
 STRING(SET_AS_DONOR_ROM, "Set as Donor ROM")
 STRING(EXPAND_ROM_SPACE, "Ex. ROM space in RAM")
+STRING(DSIWAREBOOTER, "DSiWare Booter")
 STRING(DONE, "Done!")
 STRING(X_CHEATS_B_BACK, "\\X Cheats  \\B Back")
 

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1231,7 +1231,9 @@ int main(int argc, char **argv) {
 					fadeType = false; // Fade to white
 				}
 
-				if (ms().secondaryDevice && !bs().b4dsMode && (ms().dsiWareToSD || (!ms().dsiWareBooter && ms().consoleModel == 0)) && sdFound()) {
+				loadPerGameSettings(filename);
+
+				if (ms().secondaryDevice && !bs().b4dsMode && (ms().dsiWareToSD || (!(perGameSettings_dsiwareBooter == -1 ? ms().dsiWareBooter : perGameSettings_dsiwareBooter) && ms().consoleModel == 0)) && sdFound()) {
 					if (ms().theme != TWLSettings::EThemeHBL && ms().theme != TWLSettings::EThemeSaturn) {
 						while (!fadeType && !screenFadedOut()) {
 							swiWaitForVBlank();
@@ -1286,7 +1288,7 @@ int main(int argc, char **argv) {
 					fadeType = false;		  // Fade to black
 				}
 
-				if (ms().dsiWareBooter || (ms().secondaryDevice && bs().b4dsMode) || sys().arm7SCFGLocked() || ms().consoleModel > 0) {
+				if ((perGameSettings_dsiwareBooter == -1 ? ms().dsiWareBooter : perGameSettings_dsiwareBooter) || (ms().secondaryDevice && bs().b4dsMode) || sys().arm7SCFGLocked() || ms().consoleModel > 0) {
 					CheatCodelist codelist;
 					u32 gameCode, crc32;
 
@@ -1325,9 +1327,8 @@ int main(int argc, char **argv) {
 					}
 				}
 
-				if ((ms().dsiWareBooter || (ms().secondaryDevice && bs().b4dsMode) || sys().arm7SCFGLocked() || ms().consoleModel > 0) && !ms().homebrewBootstrap) {
+				if (((perGameSettings_dsiwareBooter == -1 ? ms().dsiWareBooter : perGameSettings_dsiwareBooter) || (ms().secondaryDevice && bs().b4dsMode) || sys().arm7SCFGLocked() || ms().consoleModel > 0) && !ms().homebrewBootstrap) {
 					// Use nds-bootstrap
-					loadPerGameSettings(filename);
 
 					char sfnSrl[62];
 					char sfnPub[62];

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.h
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.h
@@ -17,6 +17,7 @@ extern int perGameSettings_asyncCardRead;
 extern int perGameSettings_bootstrapFile;
 extern int perGameSettings_wideScreen;
 extern int perGameSettings_expandRomSpace;
+extern int perGameSettings_dsiwareBooter;
 
 extern char fileCounter[8];
 

--- a/romsel_dsimenutheme/nitrofiles/languages/en/language.ini
+++ b/romsel_dsimenutheme/nitrofiles/languages/en/language.ini
@@ -110,6 +110,7 @@ DIRECT_BOOT = Direct Boot
 SCREEN_ASPECT_RATIO = Screen Aspect Ratio
 SET_AS_DONOR_ROM = Set as Donor ROM
 EXPAND_ROM_SPACE = Ex. ROM space in RAM
+DSIWAREBOOTER = DSiWare Booter
 DONE = Done!
 X_CHEATS_B_BACK = \X Cheats  \B Back
 

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1489,7 +1489,9 @@ int main(int argc, char **argv) {
 					for (int i = 0; i < 60; i++) swiWaitForVBlank();
 				}
 
-				if (ms().secondaryDevice && !bs().b4dsMode && (ms().dsiWareToSD || (!ms().dsiWareBooter && ms().consoleModel == 0)) && sdFound()) {
+				loadPerGameSettings(filename);
+
+				if (ms().secondaryDevice && !bs().b4dsMode && (ms().dsiWareToSD || (!(perGameSettings_dsiwareBooter == -1 ? ms().dsiWareBooter : perGameSettings_dsiwareBooter) && ms().consoleModel == 0)) && sdFound()) {
 					clearText();
 					dialogboxHeight = 0;
 					showdialogbox = true;
@@ -1516,7 +1518,7 @@ int main(int argc, char **argv) {
 					}
 				}
 
-				if (ms().dsiWareBooter || (ms().secondaryDevice && bs().b4dsMode) || sys().arm7SCFGLocked() || ms().consoleModel > 0) {
+				if ((perGameSettings_dsiwareBooter == -1 ? ms().dsiWareBooter : perGameSettings_dsiwareBooter) || (ms().secondaryDevice && bs().b4dsMode) || sys().arm7SCFGLocked() || ms().consoleModel > 0) {
 					CheatCodelist codelist;
 					u32 gameCode, crc32;
 
@@ -1555,10 +1557,8 @@ int main(int argc, char **argv) {
 					}
 				}
 
-				if ((ms().dsiWareBooter || (ms().secondaryDevice && bs().b4dsMode) || sys().arm7SCFGLocked() || ms().consoleModel > 0) && !ms().homebrewBootstrap) {
+				if (((perGameSettings_dsiwareBooter == -1 ? ms().dsiWareBooter : perGameSettings_dsiwareBooter) || (ms().secondaryDevice && bs().b4dsMode) || sys().arm7SCFGLocked() || ms().consoleModel > 0) && !ms().homebrewBootstrap) {
 					// Use nds-bootstrap
-					loadPerGameSettings(filename);
-
 					char sfnSrl[62];
 					char sfnPub[62];
 					char sfnPrv[62];

--- a/romsel_r4theme/arm9/source/perGameSettings.h
+++ b/romsel_r4theme/arm9/source/perGameSettings.h
@@ -19,6 +19,7 @@ extern int perGameSettings_asyncCardRead;
 extern int perGameSettings_bootstrapFile;
 extern int perGameSettings_wideScreen;
 extern int perGameSettings_expandRomSpace;
+extern int perGameSettings_dsiwareBooter;
 
 void loadPerGameSettings(std::string filename);
 void savePerGameSettings(std::string filename);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Which settings are shown is only reloaded on closing and opening per-game settings, I think this is how the rest work? Might want to lock them when on Unlaunch though I suppose
- Closes #1724 

#### Where have you tested it?

- no$gba

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
