### PR TITLE
Fix paths in workflows (#1)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,8 +80,8 @@ jobs:
           rm -rf TWiLightMenu/Flashcard\ users
           rm -rf TWiLightMenu/_nds/GBARunner2_arm7dldi_3ds.nds
           rm -rf TWiLightMenu/_nds/GBARunner2_arm7dldi_nodsp_3ds.nds
-          rm -rf TWiLightMenu/_nds/TwiLightMenu/bootplg.srldr
-          rm -rf TWiLightMenu/_nds/TwiLightMenu/gbaswitch.srldr
+          rm -rf TWiLightMenu/_nds/TWiLightMenu/bootplg.srldr
+          rm -rf TWiLightMenu/_nds/TWiLightMenu/gbaswitch.srldr
           7z a TWiLightMenu-DSi.7z TWiLightMenu
           mv TWiLightMenu-DSi.7z ~/artifacts
 
@@ -97,8 +97,8 @@ jobs:
           rm -rf TWiLightMenu/_nds/GBARunner2_arm7dldi_dsi.nds
           rm -rf TWiLightMenu/_nds/GBARunner2_arm7dldi_nodsp_dsi.nds
           rm -rf TWiLightMenu/_nds/TWiLightMenu/unlaunch
-          rm -rf TWiLightMenu/_nds/TwiLightMenu/bootplg.srldr
-          rm -rf TWiLightMenu/_nds/TwiLightMenu/gbaswitch.srldr
+          rm -rf TWiLightMenu/_nds/TWiLightMenu/bootplg.srldr
+          rm -rf TWiLightMenu/_nds/TWiLightMenu/gbaswitch.srldr
           7z a TWiLightMenu-3DS.7z TWiLightMenu
           mv TWiLightMenu-3DS.7z ~/artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,8 +132,8 @@ jobs:
           rm -rf Flashcard\ users
           rm -rf _nds/GBARunner2_arm7dldi_3ds.nds
           rm -rf _nds/GBARunner2_arm7dldi_nodsp_3ds.nds
-          rm -rf _nds/TwiLightMenu/bootplg.srldr
-          rm -rf _nds/TwiLightMenu/gbaswitch.srldr
+          rm -rf _nds/TWiLightMenu/bootplg.srldr
+          rm -rf _nds/TWiLightMenu/gbaswitch.srldr
           7z a TWiLightMenu-DSi.7z
           mv TWiLightMenu-DSi.7z ~/artifacts
 
@@ -150,9 +150,9 @@ jobs:
           rm -rf Flashcard\ users
           rm -rf _nds/GBARunner2_arm7dldi_dsi.nds
           rm -rf _nds/GBARunner2_arm7dldi_nodsp_dsi.nds
-          rm -rf _nds/TwiLightMenu/unlaunch
-          rm -rf _nds/TwiLightMenu/bootplg.srldr
-          rm -rf _nds/TwiLightMenu/gbaswitch.srldr
+          rm -rf _nds/TWiLightMenu/unlaunch
+          rm -rf _nds/TWiLightMenu/bootplg.srldr
+          rm -rf _nds/TWiLightMenu/gbaswitch.srldr
           7z a TWiLightMenu-3DS.7z
           mv TWiLightMenu-3DS.7z ~/artifacts
 


### PR DESCRIPTION
Paths weren't case-sensitive.
Fixes DS-Homebrew/TWiLightMenu#1881