### PR TITLE
Animated banner patch

### DIFF
--- a/booter/Makefile
+++ b/booter/Makefile
@@ -144,7 +144,7 @@ dist:	all
 	@cp $(TARGET).arm9.elf ../7zfile/debug/$(TARGET).arm9.elf
 
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
-	ndstool	-c $(TARGET).nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
+	ndstool	-c $@ -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004 -a 00000138 -b icon.bmp "TWiLight Menu++;Rocket Robz"
 
 $(TARGET)_rungame.nds:	$(TARGET).arm7 $(TARGET).arm9
@@ -153,6 +153,7 @@ $(TARGET)_rungame.nds:	$(TARGET).arm7 $(TARGET).arm9
 
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
 		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET).nds --twlTouch
+		$(PYTHON) animatedbannerpatch.py $(TARGET).nds twl_banner.bin
 		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET)_rungame.nds --twlTouch
 endif
 

--- a/booter/animatedbannerpatch.py
+++ b/booter/animatedbannerpatch.py
@@ -1,0 +1,54 @@
+import os
+from argparse import ArgumentParser
+from struct import pack
+
+
+# GBATEK swiCRC16 pseudocode
+# https://problemkaputt.de/gbatek-bios-misc-functions.htm
+def crc16(data):
+    crc = 0xFFFF
+    for byte in bytearray(data):
+        crc ^= byte
+        for i in range(8):
+            carry = (crc & 0x0001) > 0
+            crc = crc >> 1
+            if carry:
+                crc = crc ^ 0xA001
+    return pack("<H", crc)
+
+
+def patch(path, banner):
+    # we're going to make this look nice
+    filesize = os.path.getsize(path)
+    while(filesize % 16 != 0):
+        filesize += 1
+    with open(path, "rb+") as outfile:
+        # new animated banner location
+        outfile.seek(0x68, 0)
+        outfile.write(pack("<I", filesize))
+        outfile.seek(filesize, 0)
+        infile = open(banner, "rb")
+        outfile.write(infile.read())
+        infile.close()
+        # update header CRC
+        outfile.seek(0, 0)
+        crc = crc16(outfile.read(0x15E))
+        outfile.seek(0x15E, 0)
+        outfile.write(crc)
+        outfile.close()
+    return 0
+
+
+if __name__ == "__main__":
+    description = "Animated banner injector tool\n\
+        This must have a prepared animated banner binary!"
+    parser = ArgumentParser(description=description)
+    parser.add_argument("input", metavar="input.nds", type=str, nargs=1, help="DS ROM path")
+    parser.add_argument("banner", metavar="banner.bin", type=str, nargs=1, help="Animated banner path")
+    args = parser.parse_args()
+    print(description)
+    path = args.input[0]
+    banner = args.banner[0]
+
+    if(patch(path, banner)) == 0:
+        print("\nSuccess.")


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Actually made the animated banner work.

Only `booter` is patched. There is no need for any other titles to be patched considering they are not meant to be loaded from the DSi/HOME menu. The only other title we may consider patching is Last-run ROM, I guess, but I've left it out for now.

#### Where have you tested it?

DSi XL, 1.4.5, hiyaCFW 1.4.0, installed via TMFH
New 3DS XL, 11.15.0, Luma3DS 10.3

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
