### PR TITLE
Fix DSi icon palettes in DSi-based themes

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/iconHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/iconHandler.cpp
@@ -277,6 +277,13 @@ void glLoadIcon(int num, const u16 *_palette, const u8 *_tiles, int texHeight, b
 			      init);
 }
 
+void glLoadPalette(int num, const u16 *_palette) {
+	if (!BAD_ICON_IDX(num))
+		swiCopy(_palette, _paletteCache[num], 4 * sizeof(u16) | COPY_MODE_COPY | COPY_MODE_WORD);
+
+	glReloadIconPalette(num);
+}
+
 /**
  * Reloads the palette in the given slot from
  * the palette cache.

--- a/romsel_dsimenutheme/arm9/source/graphics/iconHandler.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/iconHandler.h
@@ -57,6 +57,14 @@ void iconManagerInit();
  */
 void glLoadIcon(int num, const u16 *palette, const u8 *tiles, int texHeight = 32);
 
+/**
+ * Loads an icon's palette into one of 6 existing banks,
+ * overwritting the previous data.
+ * num must be in the range [0, 5] else this function
+ * does nothing.
+ */
+void glLoadPalette(int num, const u16 *palette);
+
 
 /**
  * Clears an icon in the bank.

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -128,8 +128,16 @@ static inline void clearIcon(int num) { glClearIcon(num); }
 void drawIcon(int Xpos, int Ypos, int num) {
 	if(num == -1) { // Moving app icon
 		glSprite(Xpos, Ypos, bannerFlip[40], &getIcon(6)[bnriconframenumY[40]]);
+		if(bnriconPalLine[40] != bnriconPalLoaded[40]) {
+			glLoadPalette(6, bnriconTile[40].dsi_palette[bnriconPalLine[40]]);
+			bnriconPalLoaded[40] = bnriconPalLine[40];
+		}
 	} else {
 		glSprite(Xpos, Ypos, bannerFlip[num], &getIcon(num % 6)[bnriconframenumY[num]]);
+		if(bnriconPalLine[num] != bnriconPalLoaded[num]) {
+			glLoadPalette(num % 6, bnriconTile[num].dsi_palette[bnriconPalLine[num]]);
+			bnriconPalLoaded[num] = bnriconPalLine[num];
+		}
 	}
 }
 
@@ -205,6 +213,7 @@ void getGameInfo(bool isDir, const char *name, int num) {
 		num = 40;
 
 	bnriconPalLine[num] = 0;
+	bnriconPalLoaded[num] = 0;
 	bnriconframenumY[num] = 0;
 	bannerFlip[num] = GL_FLIP_NONE;
 	bnriconisDSi[num] = false;
@@ -613,7 +622,8 @@ void iconUpdate(bool isDir, const char *name, int num) {
 		if (customIcon[num] == -1) {
 			loadUnkIcon(spriteIdx);
 		} else if (bnriconisDSi[num]) {
-			loadIcon(ndsBanner.dsi_icon[0], ndsBanner.dsi_palette[0], spriteIdx, true);
+			loadIcon(ndsBanner.dsi_icon[0], ndsBanner.dsi_palette[bnriconPalLine[num]], spriteIdx, true);
+			bnriconPalLoaded[num] = bnriconPalLine[num];
 		} else {
 			loadIcon(ndsBanner.icon, ndsBanner.palette, spriteIdx, false);
 		}
@@ -682,7 +692,8 @@ void iconUpdate(bool isDir, const char *name, int num) {
 		// this is an nds/app file!
 		sNDSBannerExt &ndsBanner = bnriconTile[num];
 		if (bnriconisDSi[num]) {
-			loadIcon(ndsBanner.dsi_icon[0], ndsBanner.dsi_palette[0], spriteIdx, true);
+			loadIcon(ndsBanner.dsi_icon[0], ndsBanner.dsi_palette[bnriconPalLine[num]], spriteIdx, true);
+			bnriconPalLoaded[num] = bnriconPalLine[num];
 		} else {
 			loadIcon(ndsBanner.icon, ndsBanner.palette, spriteIdx, false);
 		}

--- a/romsel_dsimenutheme/arm9/source/ndsheaderbanner.cpp
+++ b/romsel_dsimenutheme/arm9/source/ndsheaderbanner.cpp
@@ -531,6 +531,7 @@ sNDSBannerExt bnriconTile[41];
 static u16 bnriconframeseq[41][64] = {0x0000};
 
 // bnriconframenum[]
+int bnriconPalLoaded[41] = {0};
 int bnriconPalLine[41] = {0};
 int bnriconframenumY[41] = {0};
 int bannerFlip[41] = {GL_FLIP_NONE};

--- a/romsel_dsimenutheme/arm9/source/ndsheaderbanner.h
+++ b/romsel_dsimenutheme/arm9/source/ndsheaderbanner.h
@@ -279,6 +279,7 @@ extern u32 a7mbk6[40];
 extern sNDSBannerExt bnriconTile[41];
 
 // bnriconframenum[]
+extern int bnriconPalLoaded[41];
 extern int bnriconPalLine[41];
 extern int bnriconframenumY[41];
 extern int bannerFlip[41];


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixes the DSi-based themes only using palette 0 of DSi icons regardless of what the animation sequence said to use
   - I don't think any retail ROMs ever used more than 1 palette, but my new icon for Wordle DS uses this feature and this makes it match the DSi Menu for behaviour (though oddly the 3DS HOME Menu doesn't support this either)

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
