### PR TITLE
Reset ROM folder if missing

### DIFF
--- a/universal/source/common/twlmenusettings.cpp
+++ b/universal/source/common/twlmenusettings.cpp
@@ -141,10 +141,10 @@ void TWLSettings::loadSettings()
 	// UI settings.
 	romfolder[0] = settingsini.GetString("SRLOADER", "ROM_FOLDER", romfolder[0]);
 	romfolder[1] = settingsini.GetString("SRLOADER", "SECONDARY_ROM_FOLDER", romfolder[1]);
-	if (strncmp(romfolder[0].c_str(), "sd:", 3) != 0) {
+	if (strncmp(romfolder[0].c_str(), "sd:", 3) != 0 || access(romfolder[0].c_str(), F_OK) != 0) {
 		romfolder[0] = "sd:/";
 	}
-	if (strncmp(romfolder[1].c_str(), "fat:", 4) != 0) {
+	if (strncmp(romfolder[1].c_str(), "fat:", 4) != 0 || access(romfolder[1].c_str(), F_OK) != 0) {
 		romfolder[1] = "fat:/";
 	}
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes it reset the ROM folder to root if the current folder doesn't exist
   - Should fix TWiLight failing to save if you were in a folder, delete it, and load a game from root

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
