### PR TITLE
booter: improve animated banner patch for other header entries

### DIFF
--- a/booter/Makefile
+++ b/booter/Makefile
@@ -146,14 +146,14 @@ dist:	all
 $(TARGET).nds:	$(TARGET).arm7 $(TARGET).arm9
 	ndstool	-c $@ -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-g SRLA 01 "TWLMENUPP" -z 80040000 -u 00030004 -a 00000138 -b icon.bmp "TWiLight Menu++;Rocket Robz"
+	$(PYTHON) animatedbannerpatch.py $@ twl_banner.bin
 
 $(TARGET)_rungame.nds:	$(TARGET).arm7 $(TARGET).arm9
-	ndstool	-c $(TARGET)_rungame.nds -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
+	ndstool	-c $@ -7 $(TARGET).arm7.elf -9 $(TARGET).arm9.elf \
 			-g SLRN 01 "TWLMENUPP-LR" -z 80040000 -u 00030015 -a 00000138 -b icon.bmp "Last-run ROM;TWiLight Menu++;Rocket Robz"
 
 ifneq ($(strip $(TWLNOPATCHSRLHEADER)), 1)
 		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET).nds --twlTouch
-		$(PYTHON) animatedbannerpatch.py $(TARGET).nds twl_banner.bin
 		$(PYTHON) ../patch_ndsheader_dsiware.py $(TARGET)_rungame.nds --twlTouch
 endif
 


### PR DESCRIPTION
#### What's changed?

- total NTR ROM size entry updated
- total TWL ROM size entry updated
- use total ROM size instead of the actual file size
    - now actually compatible with patch_ndsheader_dsiware.py. I guess the total size does matter...
- further improvements to overall system stability and other minor adjustments to enhance the user experience


#### Where have you tested it?

DSi XL, 1.4.5, hiyaCFW / TMFH
New 3DS XL, 11.15.0, Luma3DS 10.3

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
