### PR TITLE
Multiple font palettes for themes

### DIFF
--- a/romsel_dsimenutheme/arm9/source/cheat.cpp
+++ b/romsel_dsimenutheme/arm9/source/cheat.cpp
@@ -261,24 +261,24 @@ std::vector<u32> CheatCodelist::getCheats()
 
 void CheatCodelist::drawCheatList(std::vector<CheatCodelist::cParsedItem *>& list, uint curPos, uint screenPos, uint scrollPos) {
   // Print Cheats at the top
-  printLarge(false, 0, 30, STR_CHEATS, Alignment::center);
+  printLarge(false, 0, 30, STR_CHEATS, Alignment::center, FontPalette::dialog);
 
   // Print bottom text
   if(list[curPos]->_comment != "") {
     if(list[curPos]->_flags&cParsedItem::EFolder) {
-      printSmall(false, 0, 160, STR_CHEATS_FOLDER_INFO, Alignment::center);
+      printSmall(false, 0, 160, STR_CHEATS_FOLDER_INFO, Alignment::center, FontPalette::dialog);
     } else if(list[curPos]->_flags&cParsedItem::ESelected) {
-      printSmall(false, 0, 160, STR_CHEATS_SELECTED_INFO, Alignment::center);
+      printSmall(false, 0, 160, STR_CHEATS_SELECTED_INFO, Alignment::center, FontPalette::dialog);
     } else {
-      printSmall(false, 0, 160, STR_CHEATS_DESELECTED_INFO, Alignment::center);
+      printSmall(false, 0, 160, STR_CHEATS_DESELECTED_INFO, Alignment::center, FontPalette::dialog);
     }
   } else {
     if(list[curPos]->_flags&cParsedItem::EFolder) {
-      printSmall(false, 0, 160, STR_CHEATS_FOLDER, Alignment::center);
+      printSmall(false, 0, 160, STR_CHEATS_FOLDER, Alignment::center, FontPalette::dialog);
     } else if(list[curPos]->_flags&cParsedItem::ESelected) {
-      printSmall(false, 0, 160, STR_CHEATS_SELECTED, Alignment::center);
+      printSmall(false, 0, 160, STR_CHEATS_SELECTED, Alignment::center, FontPalette::dialog);
     } else {
-      printSmall(false, 0, 160, STR_CHEATS_DESELECTED, Alignment::center);
+      printSmall(false, 0, 160, STR_CHEATS_DESELECTED, Alignment::center, FontPalette::dialog);
     }
   }
 
@@ -288,14 +288,14 @@ void CheatCodelist::drawCheatList(std::vector<CheatCodelist::cParsedItem *>& lis
   // Print the list
   for(uint i=0;i<8 && i<list.size();i++) {
     if(list[screenPos+i]->_flags&cParsedItem::EFolder) {
-      printSmall(false, (ms().rtl() ? 256 - 15 : 15) + ((screenPos+i == curPos) ? 5 * rtlNegative : 0), 60+(i*12), ms().rtl() ? "<" : ">", align);
-      printSmall(false, (ms().rtl() ? 256 - 28 : 28) + ((screenPos+i == curPos) ? 4 * rtlNegative : 0), 60+(i*12), list[screenPos+i]->_title.substr((screenPos+i == curPos) ? scrollPos : 0, 30), align);
+      printSmall(false, (ms().rtl() ? 256 - 15 : 15) + ((screenPos+i == curPos) ? 5 * rtlNegative : 0), 60+(i*12), ms().rtl() ? "<" : ">", align, FontPalette::dialog);
+      printSmall(false, (ms().rtl() ? 256 - 28 : 28) + ((screenPos+i == curPos) ? 4 * rtlNegative : 0), 60+(i*12), list[screenPos+i]->_title.substr((screenPos+i == curPos) ? scrollPos : 0, 30), align, FontPalette::dialog);
     } else {
       if(list[screenPos+i]->_flags&cParsedItem::ESelected) {
-        printSmall(false, (ms().rtl() ? 256 - 13 : 13), 60+(i*12), "x", align);
+        printSmall(false, (ms().rtl() ? 256 - 13 : 13), 60+(i*12), "x", align, FontPalette::dialog);
       }
-      printSmall(false, (ms().rtl() ? 256 - 21 : 21) + ((screenPos+i == curPos) ? 4 * rtlNegative : 0), 60+(i*12), "-", align);
-      printSmall(false, (ms().rtl() ? 256 - 28 : 28) + ((screenPos+i == curPos) ? 7 * rtlNegative : 0), 60+(i*12), list[screenPos+i]->_title.substr((screenPos+i == curPos) ? scrollPos : 0, 30), align);
+      printSmall(false, (ms().rtl() ? 256 - 21 : 21) + ((screenPos+i == curPos) ? 4 * rtlNegative : 0), 60+(i*12), "-", align, FontPalette::dialog);
+      printSmall(false, (ms().rtl() ? 256 - 28 : 28) + ((screenPos+i == curPos) ? 7 * rtlNegative : 0), 60+(i*12), list[screenPos+i]->_title.substr((screenPos+i == curPos) ? scrollPos : 0, 30), align, FontPalette::dialog);
     }
   }
 }
@@ -309,8 +309,8 @@ void CheatCodelist::selectCheats(std::string filename)
 
   dbox_showIcon = true;
 
-  printLarge(false, 0, 30, STR_CHEATS, Alignment::center);
-  printSmall(false, 0, 100, STR_LOADING, Alignment::center);
+  printLarge(false, 0, 30, STR_CHEATS, Alignment::center, FontPalette::dialog);
+  printSmall(false, 0, 100, STR_LOADING, Alignment::center, FontPalette::dialog);
   updateText(false);
   
   parse(filename);
@@ -321,9 +321,9 @@ void CheatCodelist::selectCheats(std::string filename)
     snd().playWrong();
     cheatsFound = false;
     clearText();
-    printLarge(false, 0, 30, STR_CHEATS, Alignment::center);
-    printSmall(false, 0, 100, STR_NO_CHEATS_FOUND, Alignment::center);
-    printSmall(false, 0, 160, STR_B_BACK, Alignment::center);
+    printLarge(false, 0, 30, STR_CHEATS, Alignment::center, FontPalette::dialog);
+    printSmall(false, 0, 100, STR_NO_CHEATS_FOUND, Alignment::center, FontPalette::dialog);
+    printSmall(false, 0, 160, STR_B_BACK, Alignment::center, FontPalette::dialog);
 	updateText(false);
 
     while(1) {
@@ -456,8 +456,8 @@ void CheatCodelist::selectCheats(std::string filename)
     } else if(pressed & KEY_X) {
       snd().playLaunch();
       clearText();
-      printLarge(false, 0, 30, STR_CHEATS, Alignment::center);
-      printSmall(false, 0, 100, STR_SAVING, Alignment::center);
+      printLarge(false, 0, 30, STR_CHEATS, Alignment::center, FontPalette::dialog);
+      printSmall(false, 0, 100, STR_SAVING, Alignment::center, FontPalette::dialog);
 	  updateText(false);
       onGenerate();
       break;
@@ -465,7 +465,7 @@ void CheatCodelist::selectCheats(std::string filename)
       if(currentList[cheatWnd_cursorPosition]->_comment != "") {
         (ms().theme == TWLSettings::EThemeSaturn) ? snd().playLaunch() : snd().playSelect();
         clearText();
-        printLarge(false, 0, 30, STR_CHEATS, Alignment::center);
+        printLarge(false, 0, 30, STR_CHEATS, Alignment::center, FontPalette::dialog);
 
         std::string _topText = "";
         std::string _topTextStr(currentList[cheatWnd_cursorPosition]->_comment);
@@ -505,10 +505,10 @@ void CheatCodelist::selectCheats(std::string filename)
           _topText += temp;
         
         // Print comment
-        printSmall(false, 0, 60, _topText, Alignment::center);
+        printSmall(false, 0, 60, _topText, Alignment::center, FontPalette::dialog);
 
         // Print 'Back' text
-        printSmall(false, 0, 160, STR_B_BACK, Alignment::center);
+        printSmall(false, 0, 160, STR_B_BACK, Alignment::center, FontPalette::dialog);
 
         updateText(false);
         while(1) {

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -447,12 +447,12 @@ void moveCursor(bool right, const std::vector<DirEntry> dirContents, int maxEntr
 					currentBg = 0;
 			}
 			if (ms().theme == TWLSettings::EThemeHBL) {
-				printLarge(false, 0, 142, "^", Alignment::center);
-				printSmall(false, 4, 174, (showLshoulder ? STR_L_PREV : STR_L));
-				printSmall(false, 256-4, 174, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+				printLarge(false, 0, 142, "^", Alignment::center, FontPalette::overlay);
+				printSmall(false, 4, 174, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+				printSmall(false, 256-4, 174, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 			} else if (ms().macroMode && ms().theme != TWLSettings::EThemeSaturn) {
-				printSmall(false, 4, 152, (showLshoulder ? STR_L_PREV : STR_L));
-				printSmall(false, 256-4, 152, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+				printSmall(false, 4, 152, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+				printSmall(false, 256-4, 152, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 			}
 			updateText(false);
 		}
@@ -838,8 +838,8 @@ void mdRomTooBig(void) {
 	} else {
 		for (int i = 0; i < 30; i++) { bgOperations(true); }
 	}
-	printSmall(false, 0, 64, STR_MD_ROM_TOO_BIG, Alignment::center);
-	printSmall(false, 0, 160, STR_A_OK, Alignment::center);
+	printSmall(false, 0, 64, STR_MD_ROM_TOO_BIG, Alignment::center, FontPalette::dialog);
+	printSmall(false, 0, 160, STR_A_OK, Alignment::center, FontPalette::dialog);
 	int pressed = 0;
 	do {
 		scanKeys();
@@ -951,9 +951,9 @@ void ramDiskMsg(const char *filename) {
 		dirContName = dirContName.substr(first, (last - first + 1));
 		dirContName.append("...");
 	}
-	printSmall(false, 16, 66, dirContName);
-	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 24 : 112), STR_RAM_DISK_REQUIRED, Alignment::center);
-	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), STR_A_OK, Alignment::center);
+	printSmall(false, 16, 66, dirContName, Alignment::left, FontPalette::dialog);
+	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 24 : 112), STR_RAM_DISK_REQUIRED, Alignment::center, FontPalette::dialog);
+	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), STR_A_OK, Alignment::center, FontPalette::dialog);
 	updateText(false);
 	int pressed = 0;
 	do {
@@ -996,10 +996,10 @@ bool dsiBinariesMissingMsg(const char *filename) {
 			dirContName = dirContName.substr(first, (last - first + 1));
 			dirContName.append("...");
 		}
-		printSmall(false, 16, 66, dirContName);
+		printSmall(false, 16, 66, dirContName, Alignment::left, FontPalette::dialog);
 	}
-	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 8 : 96), STR_DSIBINARIES_MISSING, Alignment::center);
-	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), STR_Y_DS_MODE_B_BACK, Alignment::center);
+	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 8 : 96), STR_DSIBINARIES_MISSING, Alignment::center, FontPalette::dialog);
+	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), STR_Y_DS_MODE_B_BACK, Alignment::center, FontPalette::dialog);
 	updateText(false);
 	int pressed = 0;
 	while (1) {
@@ -1067,46 +1067,46 @@ bool donorRomMsg(const char *filename) {
 			clearText();
 			if (ms().theme != TWLSettings::EThemeSaturn) {
 				titleUpdate(false, filename, CURPOS);
-				printSmall(false, 16, 66, dirContName.c_str());
+				printSmall(false, 16, 66, dirContName.c_str(), Alignment::left, FontPalette::dialog);
 			}
 			if (msgPage == 1) {
 				switch (requiresDonorRom[CURPOS]) {
 					default:
 						break;
 					case 51:
-						printSmall(false, 0, yPos, STR_HOW_TO_SET_DONOR_ROM_SDK5TWL, Alignment::center);
+						printSmall(false, 0, yPos, STR_HOW_TO_SET_DONOR_ROM_SDK5TWL, Alignment::center, FontPalette::dialog);
 						break;
 					case 52:
-						printSmall(false, 0, yPos, STR_HOW_TO_SET_DONOR_ROM_SDK5TWLONLY, Alignment::center);
+						printSmall(false, 0, yPos, STR_HOW_TO_SET_DONOR_ROM_SDK5TWLONLY, Alignment::center, FontPalette::dialog);
 						break;
 					case 151:
-						printSmall(false, 0, yPos, STR_HOW_TO_SET_DONOR_ROM_SDK50TWL, Alignment::center);
+						printSmall(false, 0, yPos, STR_HOW_TO_SET_DONOR_ROM_SDK50TWL, Alignment::center, FontPalette::dialog);
 						break;
 					case 152:
-						printSmall(false, 0, yPos, STR_HOW_TO_SET_DONOR_ROM_SDK50TWLONLY, Alignment::center);
+						printSmall(false, 0, yPos, STR_HOW_TO_SET_DONOR_ROM_SDK50TWLONLY, Alignment::center, FontPalette::dialog);
 						break;
 				}
-				printSmall(false, 12, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), "<", Alignment::left);
+				printSmall(false, 12, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), "<", Alignment::left, FontPalette::dialog);
 			} else {
 				switch (requiresDonorRom[CURPOS]) {
 					default:
 						break;
 					case 51:
-						printSmall(false, 0, yPos, STR_DONOR_ROM_MSG_SDK5TWL, Alignment::center);
+						printSmall(false, 0, yPos, STR_DONOR_ROM_MSG_SDK5TWL, Alignment::center, FontPalette::dialog);
 						break;
 					case 52:
-						printSmall(false, 0, yPos, !isDSiWare[CURPOS] ? STR_DONOR_ROM_MSG_SDK5TWLONLY_DSI_MODE : STR_DONOR_ROM_MSG_SDK5TWLONLY, Alignment::center);
+						printSmall(false, 0, yPos, !isDSiWare[CURPOS] ? STR_DONOR_ROM_MSG_SDK5TWLONLY_DSI_MODE : STR_DONOR_ROM_MSG_SDK5TWLONLY, Alignment::center, FontPalette::dialog);
 						break;
 					case 151:
-						printSmall(false, 0, yPos, STR_DONOR_ROM_MSG_SDK50TWL, Alignment::center);
+						printSmall(false, 0, yPos, STR_DONOR_ROM_MSG_SDK50TWL, Alignment::center, FontPalette::dialog);
 						break;
 					case 152:
-						printSmall(false, 0, yPos, STR_DONOR_ROM_MSG_SDK50TWLONLY, Alignment::center);
+						printSmall(false, 0, yPos, STR_DONOR_ROM_MSG_SDK50TWLONLY, Alignment::center, FontPalette::dialog);
 						break;
 				}
-				printSmall(false, 256 - 12, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), ">", Alignment::right);
+				printSmall(false, 256 - 12, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), ">", Alignment::right, FontPalette::dialog);
 			}
-			printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), dsModeAllowed ? STR_Y_DS_MODE_B_BACK : STR_B_BACK, Alignment::center);
+			printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), dsModeAllowed ? STR_Y_DS_MODE_B_BACK : STR_B_BACK, Alignment::center, FontPalette::dialog);
 			updateText(false);
 			pageLoaded = true;
 		}
@@ -1215,8 +1215,8 @@ bool checkForCompatibleGame(const char *filename) {
 		for (int i = 0; i < 30; i++) { bgOperations(true); }
 	}
 	titleUpdate(false, filename, CURPOS);
-	printSmall(false, 0, 72, STR_GAME_INCOMPATIBLE_MSG, Alignment::center);
-	printSmall(false, 0, 160, STR_A_IGNORE_B_DONT_LAUNCH, Alignment::center);
+	printSmall(false, 0, 72, STR_GAME_INCOMPATIBLE_MSG, Alignment::center, FontPalette::dialog);
+	printSmall(false, 0, 160, STR_A_IGNORE_B_DONT_LAUNCH, Alignment::center, FontPalette::dialog);
 	updateText(false);
 	int pressed = 0;
 	while (1) {
@@ -1318,8 +1318,8 @@ bool dsiWareRAMLimitMsg(std::string filename) {
 	}
 	titleUpdate(false, filename.c_str(), CURPOS);
 	int yPos = (ms().theme == TWLSettings::EThemeSaturn ? 30 : 102);
-	printSmall(false, 0, yPos - ((calcSmallFontHeight(STR_RAM_LIMIT_GAME_PART_ONLY) - smallFontHeight()) / 2), STR_RAM_LIMIT_GAME_PART_ONLY, Alignment::center);
-	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), STR_B_A_OK_X_DONT_SHOW, Alignment::center);
+	printSmall(false, 0, yPos - ((calcSmallFontHeight(STR_RAM_LIMIT_GAME_PART_ONLY) - smallFontHeight()) / 2), STR_RAM_LIMIT_GAME_PART_ONLY, Alignment::center, FontPalette::dialog);
+	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), STR_B_A_OK_X_DONT_SHOW, Alignment::center, FontPalette::dialog);
 	updateText(false);
 	int pressed = 0;
 	while (1) {
@@ -1424,9 +1424,9 @@ void cannotLaunchMsg(const char *filename) {
 		str = /*isDSiMode() ? &STR_CANNOT_LAUNCH_WITHOUT_SD :*/ &STR_CANNOT_LAUNCH_IN_DS_MODE;
 	}
 	int yPos = (ms().theme == TWLSettings::EThemeSaturn ? 30 : (bnrRomType[CURPOS] == 0 ? 102 : 82));
-	printSmall(false, 0, yPos - ((calcSmallFontHeight(*str) - smallFontHeight()) / 2), *str, Alignment::center);
+	printSmall(false, 0, yPos - ((calcSmallFontHeight(*str) - smallFontHeight()) / 2), *str, Alignment::center, FontPalette::dialog);
 
-	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), STR_A_OK, Alignment::center);
+	printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 64 : 160), STR_A_OK, Alignment::center, FontPalette::dialog);
 	updateText(false);
 	int pressed = 0;
 	do {
@@ -1517,32 +1517,33 @@ bool selectMenu(void) {
 		int textYpos = selIconYpos + 4;
 		int textXpos = ms().rtl() ? 256 - 64 : 64;
 		Alignment align = ms().rtl() ? Alignment::right : Alignment::left;
+		FontPalette pal = FontPalette::dialog;
 		clearText();
-		printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 8 : 16), STR_SELECT_MENU, Alignment::center);
-		printSmall(false, ms().rtl() ? 256 - 24: 24, -2 + textYpos + (28 * selCursorPosition), ms().rtl() ? "<" : ">", align);
+		printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 8 : 16), STR_SELECT_MENU, Alignment::center, pal);
+		printSmall(false, ms().rtl() ? 256 - 24: 24, -2 + textYpos + (28 * selCursorPosition), ms().rtl() ? "<" : ">", align, pal);
 		for (int i = 0; i <= maxCursors; i++) {
 			if (assignedOp[i] == 0) {
-				printSmall(false, textXpos, textYpos, (ms().consoleModel < 2) ? STR_DSI_MENU : STR_3DS_HOME_MENU, align);
+				printSmall(false, textXpos, textYpos, (ms().consoleModel < 2) ? STR_DSI_MENU : STR_3DS_HOME_MENU, align, pal);
 			} else if (assignedOp[i] == 1) {
-				printSmall(false, textXpos, textYpos, STR_TWLMENU_SETTINGS, align);
+				printSmall(false, textXpos, textYpos, STR_TWLMENU_SETTINGS, align, pal);
 			} else if (assignedOp[i] == 2) {
 				if (bothSDandFlashcard()) {
 					if (ms().secondaryDevice) {
-						printSmall(false, textXpos, textYpos, ms().showMicroSd ? STR_SWITCH_TO_MICRO_SD : STR_SWITCH_TO_SD, align);
+						printSmall(false, textXpos, textYpos, ms().showMicroSd ? STR_SWITCH_TO_MICRO_SD : STR_SWITCH_TO_SD, align, pal);
 					} else {
-						printSmall(false, textXpos, textYpos, STR_SWITCH_TO_SLOT_1, align);
+						printSmall(false, textXpos, textYpos, STR_SWITCH_TO_SLOT_1, align, pal);
 					}
 				} else if ((isDSiMode() && memcmp(io_dldi_data->friendlyName, "CycloDS iEvolution", 18) != 0) || (io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA)) {
-					printSmall(false, textXpos, textYpos, (REG_SCFG_MC == 0x11) ? STR_NO_SLOT_1 : STR_LAUNCH_SLOT_1, align);
+					printSmall(false, textXpos, textYpos, (REG_SCFG_MC == 0x11) ? STR_NO_SLOT_1 : STR_LAUNCH_SLOT_1, align, pal);
 				}
 			} else if (assignedOp[i] == 3) {
-				printSmall(false, textXpos, textYpos, "Start GBA Mode", align);
+				printSmall(false, textXpos, textYpos, "Start GBA Mode", align, pal);
 			} else if (assignedOp[i] == 4) {
-				printSmall(false, textXpos, textYpos, STR_OPEN_MANUAL, align);
+				printSmall(false, textXpos, textYpos, STR_OPEN_MANUAL, align, pal);
 			}
 			textYpos += 28;
 		}
-		printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 164 : 160), STR_SELECT_B_BACK_A_SELECT, Alignment::center);
+		printSmall(false, 0, (ms().theme == TWLSettings::EThemeSaturn ? 164 : 160), STR_SELECT_B_BACK_A_SELECT, Alignment::center, pal);
 		updateText(false);
 		u8 current_SCFG_MC = REG_SCFG_MC;
 		do {
@@ -1925,8 +1926,8 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 				dbox_selectMenu = false;
 
 				if (ms().macroMode && ms().theme == TWLSettings::EThemeSaturn) {
-					printSmall(false, 4, 4, (showLshoulder ? STR_L_PREV : STR_L));
-					printSmall(false, 256-4, 4, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+					printSmall(false, 4, 4, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+					printSmall(false, 256-4, 4, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 				}
 				if (CURPOS + PAGENUM * 40 < ((int)dirContents[scrn].size())) {
 					currentBg = (ms().theme == TWLSettings::EThemeSaturn ? 0 : 1), displayBoxArt = ms().showBoxArt;
@@ -1947,12 +1948,12 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 					showSTARTborder = rocketVideo_playVideo = (ms().theme == TWLSettings::ETheme3DS ? true : false);
 				}
 				if (ms().theme == TWLSettings::EThemeHBL) {
-					printLarge(false, 0, 142, "^", Alignment::center);
-					printSmall(false, 4, 174, (showLshoulder ? STR_L_PREV : STR_L));
-					printSmall(false, 256-4, 174, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+					printLarge(false, 0, 142, "^", Alignment::center, FontPalette::overlay);
+					printSmall(false, 4, 174, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+					printSmall(false, 256-4, 174, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 				} else if (ms().macroMode && ms().theme != TWLSettings::EThemeSaturn) {
-					printSmall(false, 4, 152, (showLshoulder ? STR_L_PREV : STR_L));
-					printSmall(false, 256-4, 152, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+					printSmall(false, 4, 152, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+					printSmall(false, 256-4, 152, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 				}
 				updateText(false);
 				buttonArrowTouched[0] = ((keysHeld() & KEY_TOUCH) && touch.py > 171 && touch.px < 19);
@@ -2304,12 +2305,12 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 										currentBg = 0;
 									}
 									if (ms().theme == TWLSettings::EThemeHBL) {
-										printLarge(false, 0, 142, "^", Alignment::center);
-										printSmall(false, 4, 174, (showLshoulder ? STR_L_PREV : STR_L));
-										printSmall(false, 256-4, 174, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+										printLarge(false, 0, 142, "^", Alignment::center, FontPalette::overlay);
+										printSmall(false, 4, 174, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+										printSmall(false, 256-4, 174, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 									} else if (ms().macroMode && ms().theme != TWLSettings::EThemeSaturn) {
-										printSmall(false, 4, 152, (showLshoulder ? STR_L_PREV : STR_L));
-										printSmall(false, 256-4, 152, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+										printSmall(false, 4, 152, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+										printSmall(false, 256-4, 152, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 									}
 									updateText(false);
 								}
@@ -2357,12 +2358,12 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 							currentBg = 0;
 						}
 						if (ms().theme == TWLSettings::EThemeHBL) {
-							printLarge(false, 0, 142, "^", Alignment::center);
-							printSmall(false, 4, 174, (showLshoulder ? STR_L_PREV : STR_L));
-							printSmall(false, 256-4, 174, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+							printLarge(false, 0, 142, "^", Alignment::center, FontPalette::overlay);
+							printSmall(false, 4, 174, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+							printSmall(false, 256-4, 174, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 						} else if (ms().macroMode && ms().theme != TWLSettings::EThemeSaturn) {
-							printSmall(false, 4, 152, (showLshoulder ? STR_L_PREV : STR_L));
-							printSmall(false, 256-4, 152, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right);
+							printSmall(false, 4, 152, (showLshoulder ? STR_L_PREV : STR_L), Alignment::left, FontPalette::overlay);
+							printSmall(false, 256-4, 152, (showRshoulder ? STR_NEXT_R : STR_R), Alignment::right, FontPalette::overlay);
 						}
 						updateText(false);
 
@@ -2534,11 +2535,11 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 								dirContents[scrn].at(CURPOS + PAGENUM * 40).name,
 								CURPOS);
 						if (hasAP == 2) {
-							printSmall(false, 0, 80, STR_AP_PATCH_RGF, Alignment::center);
+							printSmall(false, 0, 80, STR_AP_PATCH_RGF, Alignment::center, FontPalette::dialog);
 						} else {
-							printSmall(false, 0, 72, STR_AP_USE_LATEST, Alignment::center);
+							printSmall(false, 0, 72, STR_AP_USE_LATEST, Alignment::center, FontPalette::dialog);
 						}
-						printSmall(false, 0, 160, STR_B_A_OK_X_DONT_SHOW, Alignment::center);
+						printSmall(false, 0, 160, STR_B_A_OK_X_DONT_SHOW, Alignment::center, FontPalette::dialog);
 						updateText(false);
 						pressed = 0;
 						while (1) {
@@ -2613,8 +2614,8 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 							for (int i = 0; i < 30; i++) { snd().updateStream(); swiWaitForVBlank(); }
 						}
 
-						printSmall(false, 0, 40, STR_BAD_CLUSTER_SIZE, Alignment::center);
-						printSmall(false, 0, 160, STR_B_A_OK_X_DONT_SHOW, Alignment::center);
+						printSmall(false, 0, 40, STR_BAD_CLUSTER_SIZE, Alignment::center, FontPalette::dialog);
+						printSmall(false, 0, 160, STR_B_A_OK_X_DONT_SHOW, Alignment::center, FontPalette::dialog);
 						updateText(false);
 						pressed = 0;
 						while (1) {
@@ -2899,27 +2900,27 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 					dirContName = dirContName.substr(first, (last - first + 1));
 					dirContName.append("...");
 				}
-				printSmall(false, 16, 66, dirContName);
-				printSmall(false, 16, 160, fileCounter);
+				printSmall(false, 16, 66, dirContName, Alignment::left, FontPalette::dialog);
+				printSmall(false, 16, 160, fileCounter, Alignment::left, FontPalette::dialog);
 				if (isDirectory[CURPOS]) {
 					if (unHide)
-						printSmall(false, 0, 112, STR_ARE_YOU_SURE_UNHIDE, Alignment::center);
+						printSmall(false, 0, 112, STR_ARE_YOU_SURE_UNHIDE, Alignment::center, FontPalette::dialog);
 					else
-						printSmall(false, 0, 112, STR_ARE_YOU_SURE_HIDE, Alignment::center);
+						printSmall(false, 0, 112, STR_ARE_YOU_SURE_HIDE, Alignment::center, FontPalette::dialog);
 				} else {
 					if (unHide)
-						printSmall(false, 0, 112, STR_ARE_YOU_SURE_DELETE_UNHIDE, Alignment::center);
+						printSmall(false, 0, 112, STR_ARE_YOU_SURE_DELETE_UNHIDE, Alignment::center, FontPalette::dialog);
 					else
-						printSmall(false, 0, 112, STR_ARE_YOU_SURE_DELETE_HIDE, Alignment::center);
+						printSmall(false, 0, 112, STR_ARE_YOU_SURE_DELETE_HIDE, Alignment::center, FontPalette::dialog);
 				}
 				updateText(false);
 				for (int i = 0; i < 90; i++) {
 					bgOperations(true);
 				}
 				if (isDirectory[CURPOS]) {
-					printSmall(false, 240, 160, (unHide ? STR_Y_UNHIDE : STR_Y_HIDE) + "  " + STR_B_NO, Alignment::right);
+					printSmall(false, 240, 160, (unHide ? STR_Y_UNHIDE : STR_Y_HIDE) + "  " + STR_B_NO, Alignment::right, FontPalette::dialog);
 				} else {
-					printSmall(false, 240, 160, (unHide ? STR_Y_UNHIDE : STR_Y_HIDE) + "  " + STR_A_DEL + "  " + STR_B_NO, Alignment::right);
+					printSmall(false, 240, 160, (unHide ? STR_Y_UNHIDE : STR_Y_HIDE) + "  " + STR_A_DEL + "  " + STR_B_NO, Alignment::right, FontPalette::dialog);
 				}
 				updateText(false);
 				while (1) {

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
@@ -273,7 +273,7 @@ int FontGraphic::calcWidth(std::u16string_view text) {
 	return x;
 }
 
-ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view text, Alignment align, bool rtl) {
+ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view text, Alignment align, bool rtl, FontPalette palette) {
 	// If RTL isn't forced, check for RTL text
 	if(!rtl) {
 		for(const auto c : text) {
@@ -292,7 +292,7 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 		} case Alignment::center: {
 			size_t newline = text.find('\n');
 			while(newline != text.npos) {
-				print(x, y, top, text.substr(0, newline), align, rtl);
+				print(x, y, top, text.substr(0, newline), align, rtl, palette);
 				text = text.substr(newline + 1);
 				newline = text.find('\n');
 				y += tileHeight;
@@ -303,7 +303,7 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 		} case Alignment::right: {
 			size_t newline = text.find('\n');
 			while(newline != text.npos) {
-				print(x - calcWidth(text.substr(0, newline)), y, top, text.substr(0, newline), Alignment::left, rtl);
+				print(x - calcWidth(text.substr(0, newline)), y, top, text.substr(0, newline), Alignment::left, rtl, palette);
 				text = text.substr(newline + 1);
 				newline = text.find('\n');
 				y += tileHeight;
@@ -437,7 +437,7 @@ ITCM_CODE void FontGraphic::print(int x, int y, bool top, std::u16string_view te
 				for(int j = 0; j < tileWidth; j++) {
 					u8 px = fontTiles[(index * tileSize) + (i * tileWidth + j) / 4] >> ((3 - ((i * tileWidth + j) % 4)) * 2) & 3;
 					if(px)
-						dst[(y + i) * 256 + j] = px;
+						dst[(y + i) * 256 + j] = 4*((int)palette) + px;
 				}
 			}
 		}

--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
@@ -12,6 +12,12 @@ enum class Alignment {
 	center,
 	right,
 };
+enum class FontPalette {
+	regular = 0,
+	titlebox = 1,
+	dialog = 2,
+	overlay = 3
+};
 
 class FontGraphic {
 private:
@@ -51,7 +57,7 @@ public:
 	int calcWidth(std::string_view text) { return calcWidth(utf8to16(text)); }
 	int calcWidth(std::u16string_view text);
 
-	void print(int x, int y, bool top, int value, Alignment align, bool rtl = false) { print(x, y, top, std::to_string(value), align, rtl); }
-	void print(int x, int y, bool top, std::string_view text, Alignment align, bool rtl = false) { print(x, y, top, utf8to16(text), align, rtl); }
-	void print(int x, int y, bool top, std::u16string_view text, Alignment align, bool rtl = false);
+	void print(int x, int y, bool top, int value, Alignment align, bool rtl = false, FontPalette palette = FontPalette::regular) { print(x, y, top, std::to_string(value), align, rtl, palette); }
+	void print(int x, int y, bool top, std::string_view text, Alignment align, bool rtl = false, FontPalette palette = FontPalette::regular) { print(x, y, top, utf8to16(text), align, rtl, palette); }
+	void print(int x, int y, bool top, std::u16string_view text, Alignment align, bool rtl = false, FontPalette palette = FontPalette::regular);
 };

--- a/romsel_dsimenutheme/arm9/source/graphics/TextEntry.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/TextEntry.cpp
@@ -1,7 +1,7 @@
 #include "TextEntry.h"
 
-TextEntry::TextEntry(bool large, int x, int y, std::string_view message, Alignment align)
-	: large(large), x(x), y(y), message(FontGraphic::utf8to16(message)), align(align) {};
+TextEntry::TextEntry(bool large, int x, int y, std::string_view message, Alignment align, FontPalette palette)
+	: large(large), x(x), y(y), message(FontGraphic::utf8to16(message)), align(align), palette(palette) {};
 
-TextEntry::TextEntry(bool large, int x, int y, std::u16string_view message, Alignment align)
-	: large(large), x(x), y(y), message(message), align(align) {};
+TextEntry::TextEntry(bool large, int x, int y, std::u16string_view message, Alignment align, FontPalette palette)
+	: large(large), x(x), y(y), message(message), align(align), palette(palette) {};

--- a/romsel_dsimenutheme/arm9/source/graphics/TextEntry.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/TextEntry.h
@@ -8,7 +8,8 @@ public:
 	int x, y;
 	std::u16string message;
 	Alignment align;
+	FontPalette palette;
 
-	TextEntry(bool large, int x, int y, std::string_view message, Alignment align);
-	TextEntry(bool large, int x, int y, std::u16string_view message, Alignment align);
+	TextEntry(bool large, int x, int y, std::string_view message, Alignment align, FontPalette palette);
+	TextEntry(bool large, int x, int y, std::u16string_view message, Alignment align, FontPalette palette);
 };

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
@@ -21,7 +21,10 @@ ThemeConfig::ThemeConfig(bool _3dsDefaults)
 	_startTextUserPalette(true), _startBorderUserPalette(true), _buttonArrowUserPalette(true),
 	_movingArrowUserPalette(true), _launchDotsUserPalette(true), _dialogBoxUserPalette(true), _purpleBatteryAvailable(false),
 	_renderPhoto(true), _playStartupJingle(false), _startupJingleDelayAdjust(0),
-	_fontPalette1(0x0000), _fontPalette2(0xDEF7), _fontPalette3(0xC631), _fontPalette4(0xA108)
+	_fontPalette1(0x0000), _fontPalette2(0xDEF7), _fontPalette3(0xC631), _fontPalette4(0xA108),
+	_fontPaletteTitlebox1(0x0000), _fontPaletteTitlebox2(0xDEF7), _fontPaletteTitlebox3(0xC631), _fontPaletteTitlebox4(0xA108),
+	_fontPaletteDialog1(0x0000), _fontPaletteDialog2(0xDEF7), _fontPaletteDialog3(0xC631), _fontPaletteDialog4(0xA108),
+	_fontPaletteOverlay1(0x0000), _fontPaletteOverlay2(0xDEF7), _fontPaletteOverlay3(0xC631), _fontPaletteOverlay4(0xA108)
 {
 	// hack to reassign 3ds defaults
 	if (_3dsDefaults) {
@@ -102,4 +105,16 @@ void ThemeConfig::loadConfig() {
 	_fontPalette2 = themeConfig.GetInt("THEME", "FontPalette2", _fontPalette2);
 	_fontPalette3 = themeConfig.GetInt("THEME", "FontPalette3", _fontPalette3);
 	_fontPalette4 = themeConfig.GetInt("THEME", "FontPalette4", _fontPalette4);
+	_fontPaletteTitlebox1 = themeConfig.GetInt("THEME", "FontPaletteTitlebox1", _fontPalette1);
+	_fontPaletteTitlebox2 = themeConfig.GetInt("THEME", "FontPaletteTitlebox2", _fontPalette2);
+	_fontPaletteTitlebox3 = themeConfig.GetInt("THEME", "FontPaletteTitlebox3", _fontPalette3);
+	_fontPaletteTitlebox4 = themeConfig.GetInt("THEME", "FontPaletteTitlebox4", _fontPalette4);
+	_fontPaletteDialog1 = themeConfig.GetInt("THEME", "FontPaletteDialog1", _fontPalette1);
+	_fontPaletteDialog2 = themeConfig.GetInt("THEME", "FontPaletteDialog2", _fontPalette2);
+	_fontPaletteDialog3 = themeConfig.GetInt("THEME", "FontPaletteDialog3", _fontPalette3);
+	_fontPaletteDialog4 = themeConfig.GetInt("THEME", "FontPaletteDialog4", _fontPalette4);
+	_fontPaletteOverlay1 = themeConfig.GetInt("THEME", "FontPaletteOverlay1", _fontPalette1);
+	_fontPaletteOverlay2 = themeConfig.GetInt("THEME", "FontPaletteOverlay2", _fontPalette2);
+	_fontPaletteOverlay3 = themeConfig.GetInt("THEME", "FontPaletteOverlay3", _fontPalette3);
+	_fontPaletteOverlay4 = themeConfig.GetInt("THEME", "FontPaletteOverlay4", _fontPalette4);
 }

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
@@ -57,6 +57,18 @@ private:
 	u16 _fontPalette2;
 	u16 _fontPalette3;
 	u16 _fontPalette4;
+	u16 _fontPaletteTitlebox1;
+	u16 _fontPaletteTitlebox2;
+	u16 _fontPaletteTitlebox3;
+	u16 _fontPaletteTitlebox4;
+	u16 _fontPaletteDialog1;
+	u16 _fontPaletteDialog2;
+	u16 _fontPaletteDialog3;
+	u16 _fontPaletteDialog4;
+	u16 _fontPaletteOverlay1;
+	u16 _fontPaletteOverlay2;
+	u16 _fontPaletteOverlay3;
+	u16 _fontPaletteOverlay4;
 
 public:
 	ThemeConfig();
@@ -115,6 +127,18 @@ public:
 	u16 fontPalette2() const { return _fontPalette2; }
 	u16 fontPalette3() const { return _fontPalette3; }
 	u16 fontPalette4() const { return _fontPalette4; }
+	u16 fontPaletteTitlebox1() const { return _fontPaletteTitlebox1; }
+	u16 fontPaletteTitlebox2() const { return _fontPaletteTitlebox2; }
+	u16 fontPaletteTitlebox3() const { return _fontPaletteTitlebox3; }
+	u16 fontPaletteTitlebox4() const { return _fontPaletteTitlebox4; }
+	u16 fontPaletteDialog1() const { return _fontPaletteDialog1; }
+	u16 fontPaletteDialog2() const { return _fontPaletteDialog2; }
+	u16 fontPaletteDialog3() const { return _fontPaletteDialog3; }
+	u16 fontPaletteDialog4() const { return _fontPaletteDialog4; }
+	u16 fontPaletteOverlay1() const { return _fontPaletteOverlay1; }
+	u16 fontPaletteOverlay2() const { return _fontPaletteOverlay2; }
+	u16 fontPaletteOverlay3() const { return _fontPaletteOverlay3; }
+	u16 fontPaletteOverlay4() const { return _fontPaletteOverlay4; }
 };
 
 typedef singleton<ThemeConfig> themeConfig_s;

--- a/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
@@ -57,6 +57,18 @@ void fontInit() {
 		tc().fontPalette2(),
 		tc().fontPalette3(),
 		tc().fontPalette4(),
+		tc().fontPaletteTitlebox1(),
+		tc().fontPaletteTitlebox2(),
+		tc().fontPaletteTitlebox3(),
+		tc().fontPaletteTitlebox4(),
+		tc().fontPaletteDialog1(),
+		tc().fontPaletteDialog2(),
+		tc().fontPaletteDialog3(),
+		tc().fontPaletteDialog4(),
+		tc().fontPaletteOverlay1(),
+		tc().fontPaletteOverlay2(),
+		tc().fontPaletteOverlay3(),
+		tc().fontPaletteOverlay4(),
 	};
 	tonccpy(BG_PALETTE, palette, sizeof(palette));
 	tonccpy(BG_PALETTE_SUB, palette, sizeof(palette));
@@ -107,7 +119,7 @@ void updateText(bool top) {
 	for(auto it = text.begin(); it != text.end(); ++it) {
 		FontGraphic *font = getFont(it->large);
 		if(font)
-			font->print(it->x, it->y, top, it->message, it->align);
+			font->print(it->x, it->y, top, it->message, it->align, false, it->palette);
 	}
 	text.clear();
 
@@ -157,18 +169,18 @@ void clearText() {
 	clearText(false);
 }
 
-void printSmall(bool top, int x, int y, std::string_view message, Alignment align) {
-	getTextQueue(top).emplace_back(false, x, y, message, align);
+void printSmall(bool top, int x, int y, std::string_view message, Alignment align, FontPalette palette) {
+	getTextQueue(top).emplace_back(false, x, y, message, align, palette);
 }
-void printSmall(bool top, int x, int y, std::u16string_view message, Alignment align) {
-	getTextQueue(top).emplace_back(false, x, y, message, align);
+void printSmall(bool top, int x, int y, std::u16string_view message, Alignment align, FontPalette palette) {
+	getTextQueue(top).emplace_back(false, x, y, message, align, palette);
 }
 
-void printLarge(bool top, int x, int y, std::string_view message, Alignment align) {
-	getTextQueue(top).emplace_back(true, x, y, message, align);
+void printLarge(bool top, int x, int y, std::string_view message, Alignment align, FontPalette palette) {
+	getTextQueue(top).emplace_back(true, x, y, message, align, palette);
 }
-void printLarge(bool top, int x, int y, std::u16string_view message, Alignment align) {
-	getTextQueue(top).emplace_back(true, x, y, message, align);
+void printLarge(bool top, int x, int y, std::u16string_view message, Alignment align, FontPalette palette) {
+	getTextQueue(top).emplace_back(true, x, y, message, align, palette);
 }
 
 int calcSmallFontWidth(std::string_view text) {

--- a/romsel_dsimenutheme/arm9/source/graphics/fontHandler.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/fontHandler.h
@@ -12,10 +12,10 @@ void updateTextImg(u16* img, bool top);
 void clearText(bool top);
 void clearText();
 
-void printSmall(bool top, int x, int y, std::string_view message, Alignment align = Alignment::left);
-void printSmall(bool top, int x, int y, std::u16string_view message, Alignment align = Alignment::left);
-void printLarge(bool top, int x, int y, std::string_view message, Alignment align = Alignment::left);
-void printLarge(bool top, int x, int y, std::u16string_view message, Alignment align = Alignment::left);
+void printSmall(bool top, int x, int y, std::string_view message, Alignment align = Alignment::left, FontPalette palette = FontPalette::regular);
+void printSmall(bool top, int x, int y, std::u16string_view message, Alignment align = Alignment::left, FontPalette palette = FontPalette::regular);
+void printLarge(bool top, int x, int y, std::string_view message, Alignment align = Alignment::left, FontPalette palette = FontPalette::regular);
+void printLarge(bool top, int x, int y, std::u16string_view message, Alignment align = Alignment::left, FontPalette palette = FontPalette::regular);
 
 int calcSmallFontWidth(std::string_view text);
 int calcSmallFontWidth(std::u16string_view text);

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -734,9 +734,9 @@ void writeBannerText(std::u16string text) {
 		out += line + u'\n';
 	}
 	if (tc().titleboxTextLarge() && !ms().macroMode) {
-		printLarge(false, 0, tc().titleboxTextY() - (((lines.size() - 1) * largeFontHeight()) / 2), out, Alignment::center);
+		printLarge(false, 0, tc().titleboxTextY() - (((lines.size() - 1) * largeFontHeight()) / 2), out, Alignment::center, FontPalette::titlebox);
 	} else {
-		printSmall(false, 0, tc().titleboxTextY() - (((lines.size() - 1) * smallFontHeight()) / 2), out, Alignment::center);
+		printSmall(false, 0, tc().titleboxTextY() - (((lines.size() - 1) * smallFontHeight()) / 2), out, Alignment::center, FontPalette::titlebox);
 	}
 }
 
@@ -748,7 +748,17 @@ static inline void writeDialogTitle(std::u16string text) {
 		}
 	}
 
-	printLarge(false, ms().rtl() ? 256 - 70 : 70, 31 - (lines * largeFontHeight() / 2), text, ms().rtl() ? Alignment::right : Alignment::left);
+	printLarge(false, ms().rtl() ? 256 - 70 : 70, 31 - (lines * largeFontHeight() / 2), text, ms().rtl() ? Alignment::right : Alignment::left, FontPalette::dialog);
+}
+static inline void writeDialogTitleFolder(std::u16string text) {
+	int lines = 0;
+	for(auto c : text) {
+		if(c == '\n') {
+			lines++;
+		}
+	}
+
+	printLarge(false, 0, tc().titleboxTextY() - (lines * largeFontHeight() / 2), text, Alignment::center, FontPalette::dialog);
 }
 
 static inline std::u16string splitLongDialogTitle(std::string_view text) {
@@ -792,17 +802,17 @@ static inline std::u16string splitLongDialogTitle(std::string_view text) {
 }
 
 void titleUpdate(bool isDir, std::string_view name, int num) {
+	bool theme_showdialogbox = (showdialogbox || (ms().theme == TWLSettings::EThemeSaturn && currentBg == 1) || (ms().theme == TWLSettings::EThemeHBL && dbox_showIcon));
 	if (isDir) {
-		if (name == "..") {
-			writeBannerText(STR_BACK);
-		} else {
-			writeBannerText(name);
+		if (theme_showdialogbox) {
+			writeDialogTitleFolder(splitLongDialogTitle(name == ".." ? STR_BACK : name));
+		}
+		else {
+			writeBannerText(name == ".." ? STR_BACK : name);
 		}
 	} else if (infoFound[num] || extension(name, {".nds", ".dsi", ".ids", ".srl", ".app"})) {
 		// this is an nds/app file!
 		// or a file with custom banner text
-
-		bool theme_showdialogbox = (showdialogbox || (ms().theme == TWLSettings::EThemeSaturn && currentBg == 1) || (ms().theme == TWLSettings::EThemeHBL && dbox_showIcon));
 		if (theme_showdialogbox) {
 			writeDialogTitle(cachedTitle[num]);
 		} else if (infoFound[num]) {
@@ -811,7 +821,6 @@ void titleUpdate(bool isDir, std::string_view name, int num) {
 			writeBannerText(name);
 		}
 	} else {
-		bool theme_showdialogbox = (showdialogbox || (ms().theme == TWLSettings::EThemeSaturn && currentBg == 1) || (ms().theme == TWLSettings::EThemeHBL && dbox_showIcon));
 		if (theme_showdialogbox) {
 			writeDialogTitle(splitLongDialogTitle(name.substr(0, name.rfind('.'))));
 		} else {

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -693,52 +693,52 @@ void perGameSettings (std::string filename) {
 		int perGameOpEndXpos = ms().rtl() ? 24 : 256 - 24;
 		bool flashcardKernelOnly = (!(perGameSettings_useBootstrap == -1 ? ms().useBootstrap : perGameSettings_useBootstrap) && ms().secondaryDevice && !isHomebrew[CURPOS] && unitCode[CURPOS] == 2 && (perGameSettings_dsiMode==-1 ? !DEFAULT_DSI_MODE : perGameSettings_dsiMode==0));
 
-		printSmall(false, ms().rtl() ? 256 - 16 : 16, row1Y, dirContName, startAlign);
+		printSmall(false, ms().rtl() ? 256 - 16 : 16, row1Y, dirContName, startAlign, FontPalette::dialog);
 		//if (showSDKVersion) printSmall(false, 16, row2Y, (useTwlCfg ? "TwlCfg found!" : SDKnumbertext));
-		if (showSDKVersion) printSmall(false, 16, row2Y, SDKnumbertext);
-		printSmall(false, 256 - 16, row2Y, gameTIDText, Alignment::right);
-		printSmall(false, 16, botRowY, fileCounter);
+		if (showSDKVersion) printSmall(false, 16, row2Y, SDKnumbertext, Alignment::left, FontPalette::dialog);
+		printSmall(false, 256 - 16, row2Y, gameTIDText, Alignment::right, FontPalette::dialog);
+		printSmall(false, 16, botRowY, fileCounter, Alignment::left, FontPalette::dialog);
 
 		if (showPerGameSettings) {
-			printSmall(false, ms().rtl() ? 256 - 16 : 16, perGameOpYpos+(perGameSettings_cursorPosition*14)-(firstPerGameOpShown*14), ms().rtl() ? "<" : ">", startAlign);
+			printSmall(false, ms().rtl() ? 256 - 16 : 16, perGameOpYpos+(perGameSettings_cursorPosition*14)-(firstPerGameOpShown*14), ms().rtl() ? "<" : ">", startAlign, FontPalette::dialog);
 		}
 		for (int i = firstPerGameOpShown; i < firstPerGameOpShown+4; i++) {
 		if (!showPerGameSettings || perGameOp[i] == -1) break;
 		switch (perGameOp[i]) {
 			case 0:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_LANGUAGE + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_LANGUAGE + ":", startAlign, FontPalette::dialog);
 				if (perGameSettings_language == -1 || flashcardKernelOnly) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_SYSTEM, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_SYSTEM, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == -2) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == 0) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_JAPANESE, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_JAPANESE, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_ENGLISH, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_ENGLISH, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == 2) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_FRENCH, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_FRENCH, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == 3) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_GERMAN, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_GERMAN, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == 4) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_ITALIAN, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_ITALIAN, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == 5) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_SPANISH, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_SPANISH, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == 6) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_CHINESE, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_CHINESE, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_language == 7) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_KOREAN, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_KOREAN, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 1:
 				if (isHomebrew[CURPOS]) {
-					printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_RAM_DISK + ":", startAlign);
+					printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_RAM_DISK + ":", startAlign, FontPalette::dialog);
 					std::string path("ramdisks/" + filenameForInfo.substr(0, filenameForInfo.find_last_of('.')) + getImgExtension(perGameSettings_ramDiskNo));
 					if(perGameSettings_ramDiskNo > 0)
 						path += std::to_string(perGameSettings_ramDiskNo);
 					bool exists = access(path.c_str(), F_OK) == 0;
 					snprintf (saveNoDisplay, sizeof(saveNoDisplay), "%i%s", perGameSettings_ramDiskNo, exists ? "*" : "");
 				} else {
-					printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_SAVE_NO + ":", startAlign);
+					printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_SAVE_NO + ":", startAlign, FontPalette::dialog);
 					bool exists;
 					if(isDSiWare[CURPOS]) {
 						std::string path("saves/" + filenameForInfo.substr(0, filenameForInfo.find_last_of('.')));
@@ -750,165 +750,165 @@ void perGameSettings (std::string filename) {
 					snprintf (saveNoDisplay, sizeof(saveNoDisplay), "%i%s", perGameSettings_saveNo, exists ? "*" : "");
 				}
 				if (isHomebrew[CURPOS] && perGameSettings_ramDiskNo == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NONE, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NONE, endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, saveNoDisplay, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, saveNoDisplay, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 2:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_RUN_IN + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_RUN_IN + ":", startAlign, FontPalette::dialog);
 				if (perGameSettings_dsiMode == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_dsiMode > 0) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DSI_MODE, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DSI_MODE, endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DS_MODE, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DS_MODE, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 3:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_ARM9_CPU_SPEED + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_ARM9_CPU_SPEED + ":", startAlign, FontPalette::dialog);
 				if ((perGameSettings_dsiMode==-1 ? (DEFAULT_DSI_MODE && unitCode[CURPOS] > 0) : perGameSettings_dsiMode > 0) && runInShown) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "133mhz (TWL)", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, "133mhz (TWL)", endAlign, FontPalette::dialog);
 				} else {
 					if (perGameSettings_boostCpu == -1) {
-						printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+						printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 					} else if (perGameSettings_boostCpu == 1) {
-						printSmall(false, perGameOpEndXpos, perGameOpYpos, "133mhz (TWL)", endAlign);
+						printSmall(false, perGameOpEndXpos, perGameOpYpos, "133mhz (TWL)", endAlign, FontPalette::dialog);
 					} else {
-						printSmall(false, perGameOpEndXpos, perGameOpYpos, "67mhz (NTR)", endAlign);
+						printSmall(false, perGameOpEndXpos, perGameOpYpos, "67mhz (NTR)", endAlign, FontPalette::dialog);
 					}
 				}
 				break;
 			case 4:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_VRAM_BOOST + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_VRAM_BOOST + ":", startAlign, FontPalette::dialog);
 				if ((perGameSettings_dsiMode==-1 ? (DEFAULT_DSI_MODE && unitCode[CURPOS] > 0) : perGameSettings_dsiMode > 0) && runInShown) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, unitCode[CURPOS] == 0 ? STR_DSI_MODE : STR_AUTO, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, unitCode[CURPOS] == 0 ? STR_DSI_MODE : STR_AUTO, endAlign, FontPalette::dialog);
 				} else {
 					if (perGameSettings_boostVram == -1) {
-						printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+						printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 					} else if (perGameSettings_boostVram == 1) {
-						printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DSI_MODE, endAlign);
+						printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DSI_MODE, endAlign, FontPalette::dialog);
 					} else {
-						printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DS_MODE, endAlign);
+						printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DS_MODE, endAlign, FontPalette::dialog);
 					}
 				}
 				break;
 			case 5:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_CARD_READ_DMA + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_CARD_READ_DMA + ":", startAlign, FontPalette::dialog);
 				if (perGameSettings_cardReadDMA == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_cardReadDMA == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_ON, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_ON, endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_OFF, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_OFF, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 6:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_DIRECT_BOOT + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_DIRECT_BOOT + ":", startAlign, FontPalette::dialog);
 				if (perGameSettings_directBoot) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_YES, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_YES, endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NO, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NO, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 7:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, ms().rtl() ? ":Bootstrap" : "Bootstrap:", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, ms().rtl() ? ":Bootstrap" : "Bootstrap:", startAlign, FontPalette::dialog);
 				if (flashcardKernelOnly) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NOT_USED, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NOT_USED, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_bootstrapFile == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_bootstrapFile == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NIGHTLY, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NIGHTLY, endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_RELEASE, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_RELEASE, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 8:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_SCREEN_ASPECT_RATIO + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_SCREEN_ASPECT_RATIO + ":", startAlign, FontPalette::dialog);
 				if (flashcardKernelOnly) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NOT_USED, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NOT_USED, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_wideScreen == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_wideScreen == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "16:10", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, "16:10", endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "4:3", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, "4:3", endAlign, FontPalette::dialog);
 				}
 				break;
 			case 9:
-				printSmall(false, 0, perGameOpYpos, setAsDonorRom, Alignment::center);
+				printSmall(false, 0, perGameOpYpos, setAsDonorRom, Alignment::center, FontPalette::dialog);
 				break;
 			case 10:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_EXPAND_ROM_SPACE + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_EXPAND_ROM_SPACE + ":", startAlign, FontPalette::dialog);
 				if (flashcardKernelOnly) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NOT_USED, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NOT_USED, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_expandRomSpace == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_expandRomSpace == 2) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_Y_512KB, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_Y_512KB, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_expandRomSpace == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_YES, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_YES, endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NO, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NO, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 11:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_REGION + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_REGION + ":", startAlign, FontPalette::dialog);
 				if (perGameSettings_region == -2) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_region == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_SYSTEM, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_SYSTEM, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_region == 0) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_JAPAN, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_JAPAN, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_region == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_USA, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_USA, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_region == 2) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_EUROPE, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_EUROPE, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_region == 3) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_AUSTRALIA, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_AUSTRALIA, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_region == 4) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_CHINA, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_CHINA, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_region == 5) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_KOREA, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_KOREA, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 12:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_ASYNCH_CARD_READ + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_ASYNCH_CARD_READ + ":", startAlign, FontPalette::dialog);
 				if (perGameSettings_asyncCardRead == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_asyncCardRead == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_ON, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_ON, endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_OFF, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_OFF, endAlign, FontPalette::dialog);
 				}
 				break;
 			case 13:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_DSIWAREBOOTER + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_DSIWAREBOOTER + ":", startAlign, FontPalette::dialog);
 				if (perGameSettings_dsiwareBooter == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_dsiwareBooter == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "nds-bootstrap", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, "nds-bootstrap", endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, "Unlaunch", endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, "Unlaunch", endAlign, FontPalette::dialog);
 				}
 				break;
 			case 14:
-				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_USEBOOTSTRAP + ":", startAlign);
+				printSmall(false, perGameOpStartXpos, perGameOpYpos, STR_USEBOOTSTRAP + ":", startAlign, FontPalette::dialog);
 				if (perGameSettings_useBootstrap == -1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_DEFAULT, endAlign, FontPalette::dialog);
 				} else if (perGameSettings_useBootstrap == 1) {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_YES, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_YES, endAlign, FontPalette::dialog);
 				} else {
-					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NO, endAlign);
+					printSmall(false, perGameOpEndXpos, perGameOpYpos, STR_NO, endAlign, FontPalette::dialog);
 				}
 				break;
 		}
 		perGameOpYpos += 14;
 		}
 		if (!showPerGameSettings && !showCheats) {
-			printSmall(false, 240, botRowY, STR_A_OK, Alignment::right);
+			printSmall(false, 240, botRowY, STR_A_OK, Alignment::right, FontPalette::dialog);
 		} else {
-			printSmall(false, 240, botRowY, showCheats ? STR_X_CHEATS_B_BACK : STR_B_BACK, Alignment::right);
+			printSmall(false, 240, botRowY, showCheats ? STR_X_CHEATS_B_BACK : STR_B_BACK, Alignment::right, FontPalette::dialog);
 		}
 		updateText(false);
 		do {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Added 3 additional font palettes for use in the DSi based themes.
FontPaletteTitlebox applies to the game title in the menu.
FontPaletteDialog applies to all pop-up dialog messages (per-game settings, SELECT Menu, etc.).
FontPaletteOverlay is for anything that renders overlaid against the theme's background (the macro mode shoulder buttons, and HBL's "^" pointer.

Anything that doesn't meet the above categories (white loading screens, certain errors, etc.) uses the regular FontPalette.
The original FontPalette also serves as the default for the other palettes if they are not specified in the config file.

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
