### PR TITLE
Allow themes to bundle a font

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
@@ -10,6 +10,7 @@
 #include "myDSiMode.h"
 #include "TextEntry.h"
 #include "ThemeConfig.h"
+#include "themefilenames.h"
 
 FontGraphic *smallFont;
 FontGraphic *largeFont;
@@ -43,6 +44,8 @@ void fontInit() {
 	// Load font graphics
 	std::string fontPath = std::string(sdFound() ? "sd:" : "fat:") + "/_nds/TWiLightMenu/extras/fonts/" + ms().font;
 	std::string defaultPath = std::string(sdFound() ? "sd:" : "fat:") + "/_nds/TWiLightMenu/extras/fonts/Default";
+	if (ms().font == "Default")
+		fontPath = TFN_FONT_DIRECTORY; // load custom theme's font when font is set to Default
 	bool dsiFont = (dsiFeatures() && !sys().arm7SCFGLocked()) || sys().dsDebugRam() || useExpansionPak;
 	smallFont = new FontGraphic({fontPath + (dsiFont ? "/small-dsi.nftr" : "/small-ds.nftr"), fontPath + "/small.nftr", defaultPath + (dsiFont ? "/small-dsi.nftr" : "/small-ds.nftr"), "nitro:/graphics/font/small.nftr"}, useExpansionPak);
 	// If custom small font but no custom large font, use small font as large font

--- a/romsel_dsimenutheme/arm9/source/graphics/themefilenames.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/themefilenames.h
@@ -127,6 +127,8 @@
 #define TFN_LZ77_RVID_CUBES         TFN_UI_DIRECTORY"/video/3dsRotatingCubes.lz77.rvid"
 #define TFN_LZ77_RVID_CUBES_BW      TFN_UI_DIRECTORY"/video/3dsRotatingCubes_bw.lz77.rvid"
 
+#define TFN_FONT_DIRECTORY          TFN_UI_DIRECTORY"/font"
+
 #define TFN_SOUND_EFFECTBANK        TFN_UI_DIRECTORY"/sound/sfx.bin"
 #define TFN_SOUND_BG                TFN_UI_DIRECTORY"/sound/bgm.wav"
 #define TFN_SOUND_BG_CACHE          TFN_UI_DIRECTORY"/sound/bgm.pcm.raw"


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

DSi-based themes can bundle a font in the `font` directory. This includes the usual small and large fonts and the ds or dsi specific versions. Theme fonts are only used if the user has their font set to "Default".

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
