### PR TITLE
Allow skins to set username/date/time X/Y and override settings for macro mode

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -130,9 +130,6 @@ extern void SetWidescreen(const char *filename);
 
 extern bool rocketVideo_playVideo;
 
-extern char usernameRendered[11];
-extern bool usernameRenderedDone;
-
 extern void bgOperations(bool waitFrame);
 
 std::string gameOrderIniPath, recentlyPlayedIniPath, timesPlayedIniPath;

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
@@ -3,7 +3,6 @@
 #include "themefilenames.h"
 #include "common/twlmenusettings.h"
 #include "common/singleton.h"
-#include "common/inifile.h"
 
 #include <nds.h>
 #include <string>
@@ -49,6 +48,12 @@ ThemeConfig::ThemeConfig(bool _3dsDefaults)
 	}
 }
 
+int ThemeConfig::getInt(CIniFile &ini, const std::string &item, int defaultVal) {
+	if(ms().macroMode)
+		return ini.GetInt("MACRO", item, ini.GetInt("THEME", item, defaultVal));
+
+	return ini.GetInt("THEME", item, defaultVal);
+}
 
 void ThemeConfig::loadConfig() {
 	//iprintf("tc().loadConfig()\n");
@@ -56,73 +61,73 @@ void ThemeConfig::loadConfig() {
 	int macroW = 0;
 
 	CIniFile themeConfig(TFN_THEME_SETTINGS);
-	_startBorderRenderY = themeConfig.GetInt("THEME", "StartBorderRenderY", _startBorderRenderY);
-	_startBorderSpriteW = themeConfig.GetInt("THEME", "StartBorderSpriteW", _startBorderSpriteW);
-	_startBorderSpriteH = themeConfig.GetInt("THEME", "StartBorderSpriteH", _startBorderSpriteH);
-	_startTextRenderY = themeConfig.GetInt("THEME", "StartTextRenderY", _startTextRenderY);
+	_startBorderRenderY = getInt(themeConfig, "StartBorderRenderY", _startBorderRenderY);
+	_startBorderSpriteW = getInt(themeConfig, "StartBorderSpriteW", _startBorderSpriteW);
+	_startBorderSpriteH = getInt(themeConfig, "StartBorderSpriteH", _startBorderSpriteH);
+	_startTextRenderY = getInt(themeConfig, "StartTextRenderY", _startTextRenderY);
 
-	_bubbleTipRenderY = themeConfig.GetInt("THEME", "BubbleTipRenderY", _bubbleTipRenderY);
-	_bubbleTipRenderX = themeConfig.GetInt("THEME", "BubbleTipRenderX", _bubbleTipRenderX);
-	_bubbleTipSpriteW = themeConfig.GetInt("THEME", "BubbleTipSpriteW", _bubbleTipSpriteW);
-	_bubbleTipSpriteH = themeConfig.GetInt("THEME", "BubbleTipSpriteH", _bubbleTipSpriteH);
+	_bubbleTipRenderY = getInt(themeConfig, "BubbleTipRenderY", _bubbleTipRenderY);
+	_bubbleTipRenderX = getInt(themeConfig, "BubbleTipRenderX", _bubbleTipRenderX);
+	_bubbleTipSpriteW = getInt(themeConfig, "BubbleTipSpriteW", _bubbleTipSpriteW);
+	_bubbleTipSpriteH = getInt(themeConfig, "BubbleTipSpriteH", _bubbleTipSpriteH);
 
-	_titleboxRenderY = themeConfig.GetInt("THEME", "TitleboxRenderY", _titleboxRenderY);
-	_titleboxMaxLines = themeConfig.GetInt("THEME", "TitleboxMaxLines", _titleboxMaxLines);
-	macroY = themeConfig.GetInt("THEME", "MacroTitleboxTextY", -1);
-	macroW = themeConfig.GetInt("THEME", "MacroTitleboxTextW", -1);
-	_titleboxTextY = themeConfig.GetInt("THEME", "TitleboxTextY", _titleboxTextY);
-	_titleboxTextW = themeConfig.GetInt("THEME", "TitleboxTextW", _titleboxTextW);
+	_titleboxRenderY = getInt(themeConfig, "TitleboxRenderY", _titleboxRenderY);
+	_titleboxMaxLines = getInt(themeConfig, "TitleboxMaxLines", _titleboxMaxLines);
+	macroY = getInt(themeConfig, "MacroTitleboxTextY", -1);
+	macroW = getInt(themeConfig, "MacroTitleboxTextW", -1);
+	_titleboxTextY = getInt(themeConfig, "TitleboxTextY", _titleboxTextY);
+	_titleboxTextW = getInt(themeConfig, "TitleboxTextW", _titleboxTextW);
 	if (ms().macroMode) {
 		if (macroY != -1) _titleboxTextY = macroY;
 		if (macroW != -1) _titleboxTextW = macroW;
 	}
-	_titleboxTextLarge = themeConfig.GetInt("THEME", "TitleboxTextLarge", _titleboxTextLarge);
+	_titleboxTextLarge = getInt(themeConfig, "TitleboxTextLarge", _titleboxTextLarge);
 
-	_volumeRenderX = themeConfig.GetInt("THEME", "VolumeRenderX", _volumeRenderX);
-	_volumeRenderY = themeConfig.GetInt("THEME", "VolumeRenderY", _volumeRenderY);
-	// _photoRenderX = themeConfig.GetInt("THEME", "PhotoRenderX", _photoRenderX);
-	// _photoRenderY = themeConfig.GetInt("THEME", "PhotoRenderY", _photoRenderY);
-	_shoulderLRenderY = themeConfig.GetInt("THEME", "ShoulderLRenderY", _shoulderLRenderY);
-	_shoulderLRenderX = themeConfig.GetInt("THEME", "ShoulderLRenderX", _shoulderLRenderX);
-	_shoulderRRenderY = themeConfig.GetInt("THEME", "ShoulderRRenderY", _shoulderRRenderY);
-	_shoulderRRenderX = themeConfig.GetInt("THEME", "ShoulderRRenderX", _shoulderRRenderX);
-	_batteryRenderY = themeConfig.GetInt("THEME", "BatteryRenderY", _batteryRenderY);
-	_batteryRenderX = themeConfig.GetInt("THEME", "BatteryRenderX", _batteryRenderX);
-	_usernameRenderY = themeConfig.GetInt("THEME", "UsernameRenderY", _usernameRenderY);
-	_usernameRenderX = themeConfig.GetInt("THEME", "UsernameRenderX", _usernameRenderX);
-	_usernameRenderXDS = themeConfig.GetInt("THEME", "UsernameRenderXDS", _usernameRenderXDS);
-	_dateRenderY = themeConfig.GetInt("THEME", "DateRenderY", _dateRenderY);
-	_dateRenderX = themeConfig.GetInt("THEME", "DateRenderX", _dateRenderX);
-	_timeRenderY = themeConfig.GetInt("THEME", "TimeRenderY", _timeRenderY);
-	_timeRenderX = themeConfig.GetInt("THEME", "TimeRenderX", _timeRenderX);
+	_volumeRenderX = getInt(themeConfig, "VolumeRenderX", _volumeRenderX);
+	_volumeRenderY = getInt(themeConfig, "VolumeRenderY", _volumeRenderY);
+	// _photoRenderX = getInt(themeConfig, "PhotoRenderX", _photoRenderX);
+	// _photoRenderY = getInt(themeConfig, "PhotoRenderY", _photoRenderY);
+	_shoulderLRenderY = getInt(themeConfig, "ShoulderLRenderY", _shoulderLRenderY);
+	_shoulderLRenderX = getInt(themeConfig, "ShoulderLRenderX", _shoulderLRenderX);
+	_shoulderRRenderY = getInt(themeConfig, "ShoulderRRenderY", _shoulderRRenderY);
+	_shoulderRRenderX = getInt(themeConfig, "ShoulderRRenderX", _shoulderRRenderX);
+	_batteryRenderY = getInt(themeConfig, "BatteryRenderY", _batteryRenderY);
+	_batteryRenderX = getInt(themeConfig, "BatteryRenderX", _batteryRenderX);
+	_usernameRenderY = getInt(themeConfig, "UsernameRenderY", _usernameRenderY);
+	_usernameRenderX = getInt(themeConfig, "UsernameRenderX", _usernameRenderX);
+	_usernameRenderXDS = getInt(themeConfig, "UsernameRenderXDS", _usernameRenderXDS);
+	_dateRenderY = getInt(themeConfig, "DateRenderY", _dateRenderY);
+	_dateRenderX = getInt(themeConfig, "DateRenderX", _dateRenderX);
+	_timeRenderY = getInt(themeConfig, "TimeRenderY", _timeRenderY);
+	_timeRenderX = getInt(themeConfig, "TimeRenderX", _timeRenderX);
 
-	_startTextUserPalette = themeConfig.GetInt("THEME", "StartTextUserPalette", _startTextUserPalette);
-	_startBorderUserPalette = themeConfig.GetInt("THEME", "StartBorderUserPalette", _startBorderUserPalette);
-	_buttonArrowUserPalette = themeConfig.GetInt("THEME", "ButtonArrowUserPalette", _buttonArrowUserPalette);
-	_movingArrowUserPalette = themeConfig.GetInt("THEME", "MovingArrowUserPalette", _movingArrowUserPalette);
-	_launchDotsUserPalette = themeConfig.GetInt("THEME", "LaunchDotsUserPalette", _launchDotsUserPalette);
-	_dialogBoxUserPalette = themeConfig.GetInt("THEME", "DialogBoxUserPalette", _dialogBoxUserPalette);
-	_purpleBatteryAvailable = themeConfig.GetInt("THEME", "PurpleBatteryAvailable", _purpleBatteryAvailable);
-	_rotatingCubesRenderY = themeConfig.GetInt("THEME", "RotatingCubesRenderY", _rotatingCubesRenderY);
-	_renderPhoto = themeConfig.GetInt("THEME", "RenderPhoto", _renderPhoto);
+	_startTextUserPalette = getInt(themeConfig, "StartTextUserPalette", _startTextUserPalette);
+	_startBorderUserPalette = getInt(themeConfig, "StartBorderUserPalette", _startBorderUserPalette);
+	_buttonArrowUserPalette = getInt(themeConfig, "ButtonArrowUserPalette", _buttonArrowUserPalette);
+	_movingArrowUserPalette = getInt(themeConfig, "MovingArrowUserPalette", _movingArrowUserPalette);
+	_launchDotsUserPalette = getInt(themeConfig, "LaunchDotsUserPalette", _launchDotsUserPalette);
+	_dialogBoxUserPalette = getInt(themeConfig, "DialogBoxUserPalette", _dialogBoxUserPalette);
+	_purpleBatteryAvailable = getInt(themeConfig, "PurpleBatteryAvailable", _purpleBatteryAvailable);
+	_rotatingCubesRenderY = getInt(themeConfig, "RotatingCubesRenderY", _rotatingCubesRenderY);
+	_renderPhoto = getInt(themeConfig, "RenderPhoto", _renderPhoto);
 
-	_playStartupJingle = themeConfig.GetInt("THEME", "PlayStartupJingle", _playStartupJingle);
-	_startupJingleDelayAdjust = themeConfig.GetInt("THEME", "StartupJingleDelayAdjust", _startupJingleDelayAdjust);
+	_playStartupJingle = getInt(themeConfig, "PlayStartupJingle", _playStartupJingle);
+	_startupJingleDelayAdjust = getInt(themeConfig, "StartupJingleDelayAdjust", _startupJingleDelayAdjust);
 
-	_fontPalette1 = themeConfig.GetInt("THEME", "FontPalette1", _fontPalette1);
-	_fontPalette2 = themeConfig.GetInt("THEME", "FontPalette2", _fontPalette2);
-	_fontPalette3 = themeConfig.GetInt("THEME", "FontPalette3", _fontPalette3);
-	_fontPalette4 = themeConfig.GetInt("THEME", "FontPalette4", _fontPalette4);
-	_fontPaletteTitlebox1 = themeConfig.GetInt("THEME", "FontPaletteTitlebox1", _fontPalette1);
-	_fontPaletteTitlebox2 = themeConfig.GetInt("THEME", "FontPaletteTitlebox2", _fontPalette2);
-	_fontPaletteTitlebox3 = themeConfig.GetInt("THEME", "FontPaletteTitlebox3", _fontPalette3);
-	_fontPaletteTitlebox4 = themeConfig.GetInt("THEME", "FontPaletteTitlebox4", _fontPalette4);
-	_fontPaletteDialog1 = themeConfig.GetInt("THEME", "FontPaletteDialog1", _fontPalette1);
-	_fontPaletteDialog2 = themeConfig.GetInt("THEME", "FontPaletteDialog2", _fontPalette2);
-	_fontPaletteDialog3 = themeConfig.GetInt("THEME", "FontPaletteDialog3", _fontPalette3);
-	_fontPaletteDialog4 = themeConfig.GetInt("THEME", "FontPaletteDialog4", _fontPalette4);
-	_fontPaletteOverlay1 = themeConfig.GetInt("THEME", "FontPaletteOverlay1", _fontPalette1);
-	_fontPaletteOverlay2 = themeConfig.GetInt("THEME", "FontPaletteOverlay2", _fontPalette2);
-	_fontPaletteOverlay3 = themeConfig.GetInt("THEME", "FontPaletteOverlay3", _fontPalette3);
-	_fontPaletteOverlay4 = themeConfig.GetInt("THEME", "FontPaletteOverlay4", _fontPalette4);
+	_fontPalette1 = getInt(themeConfig, "FontPalette1", _fontPalette1);
+	_fontPalette2 = getInt(themeConfig, "FontPalette2", _fontPalette2);
+	_fontPalette3 = getInt(themeConfig, "FontPalette3", _fontPalette3);
+	_fontPalette4 = getInt(themeConfig, "FontPalette4", _fontPalette4);
+	_fontPaletteTitlebox1 = getInt(themeConfig, "FontPaletteTitlebox1", _fontPalette1);
+	_fontPaletteTitlebox2 = getInt(themeConfig, "FontPaletteTitlebox2", _fontPalette2);
+	_fontPaletteTitlebox3 = getInt(themeConfig, "FontPaletteTitlebox3", _fontPalette3);
+	_fontPaletteTitlebox4 = getInt(themeConfig, "FontPaletteTitlebox4", _fontPalette4);
+	_fontPaletteDialog1 = getInt(themeConfig, "FontPaletteDialog1", _fontPalette1);
+	_fontPaletteDialog2 = getInt(themeConfig, "FontPaletteDialog2", _fontPalette2);
+	_fontPaletteDialog3 = getInt(themeConfig, "FontPaletteDialog3", _fontPalette3);
+	_fontPaletteDialog4 = getInt(themeConfig, "FontPaletteDialog4", _fontPalette4);
+	_fontPaletteOverlay1 = getInt(themeConfig, "FontPaletteOverlay1", _fontPalette1);
+	_fontPaletteOverlay2 = getInt(themeConfig, "FontPaletteOverlay2", _fontPalette2);
+	_fontPaletteOverlay3 = getInt(themeConfig, "FontPaletteOverlay3", _fontPalette3);
+	_fontPaletteOverlay4 = getInt(themeConfig, "FontPaletteOverlay4", _fontPalette4);
 }

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
@@ -16,7 +16,8 @@ ThemeConfig::ThemeConfig(bool _3dsDefaults)
 	_titleboxRenderY(85), _titleboxMaxLines(4), _titleboxTextY(30), _titleboxTextW(240), _titleboxTextLarge(true),
 	_bubbleTipRenderY(80), _bubbleTipRenderX(122), _bubbleTipSpriteH(8), _bubbleTipSpriteW(11),
 	_rotatingCubesRenderY(78), _shoulderLRenderY(172), _shoulderLRenderX(0), _shoulderRRenderY(172), _shoulderRRenderX(178),
-	_volumeRenderY(4), _volumeRenderX(16),  _batteryRenderY(5), _batteryRenderX(235),
+	_volumeRenderY(4), _volumeRenderX(16), _batteryRenderY(5), _batteryRenderX(235), _usernameRenderY(15), _usernameRenderX(28),
+	_usernameRenderXDS(4), _dateRenderY(7), _dateRenderX(162), _timeRenderY(7), _timeRenderX(200),
 	// _photoRenderY(24), _photoRenderX(179),
 	_startTextUserPalette(true), _startBorderUserPalette(true), _buttonArrowUserPalette(true),
 	_movingArrowUserPalette(true), _launchDotsUserPalette(true), _dialogBoxUserPalette(true), _purpleBatteryAvailable(false),
@@ -87,6 +88,13 @@ void ThemeConfig::loadConfig() {
 	_shoulderRRenderX = themeConfig.GetInt("THEME", "ShoulderRRenderX", _shoulderRRenderX);
 	_batteryRenderY = themeConfig.GetInt("THEME", "BatteryRenderY", _batteryRenderY);
 	_batteryRenderX = themeConfig.GetInt("THEME", "BatteryRenderX", _batteryRenderX);
+	_usernameRenderY = themeConfig.GetInt("THEME", "UsernameRenderY", _usernameRenderY);
+	_usernameRenderX = themeConfig.GetInt("THEME", "UsernameRenderX", _usernameRenderX);
+	_usernameRenderXDS = themeConfig.GetInt("THEME", "UsernameRenderXDS", _usernameRenderXDS);
+	_dateRenderY = themeConfig.GetInt("THEME", "DateRenderY", _dateRenderY);
+	_dateRenderX = themeConfig.GetInt("THEME", "DateRenderX", _dateRenderX);
+	_timeRenderY = themeConfig.GetInt("THEME", "TimeRenderY", _timeRenderY);
+	_timeRenderX = themeConfig.GetInt("THEME", "TimeRenderX", _timeRenderX);
 
 	_startTextUserPalette = themeConfig.GetInt("THEME", "StartTextUserPalette", _startTextUserPalette);
 	_startBorderUserPalette = themeConfig.GetInt("THEME", "StartBorderUserPalette", _startBorderUserPalette);

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
@@ -38,6 +38,15 @@ private:
 	int _batteryRenderY;
 	int _batteryRenderX;
 
+	int _usernameRenderY;
+	int _usernameRenderX;
+	int _usernameRenderXDS;
+
+	int _dateRenderY;
+	int _dateRenderX;
+	int _timeRenderY;
+	int _timeRenderX;
+
 	// int _photoRenderY;
 	// int _photoRenderX;
 
@@ -106,6 +115,15 @@ public:
 	
 	int batteryRenderY() const { return _batteryRenderY; }
 	int batteryRenderX() const { return _batteryRenderX; }
+
+	int usernameRenderY() const { return _usernameRenderY; }
+	int usernameRenderX() const { return _usernameRenderX; }
+	int usernameRenderXDS() const { return _usernameRenderXDS; }
+
+	int dateRenderY() const { return _dateRenderY; }
+	int dateRenderX() const { return _dateRenderX; }
+	int timeRenderY() const { return _timeRenderY; }
+	int timeRenderX() const { return _timeRenderX; }
 
 	// int photoRenderY() const { return _photoRenderY; }
 	// int photoRenderX() const { return _photoRenderX; }

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
@@ -1,5 +1,6 @@
 #include <nds.h>
 #include <string>
+#include "common/inifile.h"
 #include "common/singleton.h"
 
 #pragma once
@@ -8,6 +9,8 @@
 
 class ThemeConfig {
 private:
+	int getInt(CIniFile &ini, const std::string &item, int defaultVal);
+
 	int _startBorderRenderY;
 	int _startBorderSpriteW;
 	int _startBorderSpriteH;

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -36,7 +36,6 @@ extern u8 *rotatingCubesLocation;
 
 // #include <nds/arm9/decompress.h>
 // extern u16 bmpImageBuffer[256*192];
-extern s16 usernameRendered[11];
 extern bool showColon;
 
 static u16 _bmpImageBuffer[256 * 192] = {0};
@@ -694,10 +693,11 @@ void ThemeTextures::drawProfileName() {
 	// Load username
 	char fontPath[64] = {0};
 	FILE *file;
-	int x = (dsiFeatures() ? 28 : 4);
+	int x = (dsiFeatures() ? tc().usernameRenderX() : tc().usernameRenderXDS());
+	s16 *username = useTwlCfg ? (s16 *)0x02000448 : PersonalData->name;
 
 	for (int c = 0; c < 10; c++) {
-		unsigned int charIndex = getTopFontSpriteIndex(usernameRendered[c]);
+		unsigned int charIndex = getTopFontSpriteIndex(username[c]);
 		// 42 characters per line.
 		unsigned int texIndex = charIndex / 42;
 		sprintf(fontPath, "nitro:/graphics/top_font/small_font_%u.bmp", texIndex);
@@ -710,7 +710,7 @@ void ThemeTextures::drawProfileName() {
 			fseek(file, 0xe, SEEK_SET);
 			u8 pixelStart = (u8)fgetc(file) + 0xe;
 			fseek(file, pixelStart, SEEK_SET);
-			for (int y = 15; y >= 0; y--) {
+			for (int y = tc().usernameRenderY(); y >= 0; y--) {
 				fread(_bmpImageBuffer, 2, 0x200, file);
 				u16 *src = _bmpImageBuffer + (top_font_texcoords[0 + (4 * charIndex)]);
 

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -66,8 +66,6 @@ static int frontBubblesYpos_def[3] = {256, 256+64, 256+32};
 static int backBubblesYpos[4] = {256, 256+56, 256+32, 256+16};
 static int frontBubblesYpos[3] = {256, 256+64, 256+32};
 
-extern u16 usernameRendered[11];
-
 extern bool whiteScreen;
 extern bool fadeType;
 extern bool fadeSpeed;
@@ -1343,19 +1341,13 @@ static std::string loadedDate;
 
 ITCM_CODE void drawCurrentDate() {
 	// Load date
-	int x = (ms().theme >= 4 ? 122 : 162);
-	if (ms().theme == TWLSettings::EThemeHBL) {
-		x -= 28;
-	}
-	int y = (ms().theme == TWLSettings::EThemeSaturn ? 12 : 7);
-
 	std::string currentDate = getDate();
 	if (currentDate == loadedDate && !reloadDate)
 		return;
 
 	loadedDate = currentDate;
 
-	ms().macroMode ? tex().drawDateTimeMacro(loadedDate.c_str(), x, y) : tex().drawDateTime(loadedDate.c_str(), x, y);
+	ms().macroMode ? tex().drawDateTimeMacro(loadedDate.c_str(), tc().dateRenderX(), tc().dateRenderY()) : tex().drawDateTime(loadedDate.c_str(), tc().dateRenderX(), tc().dateRenderY());
 
 	reloadDate = false;
 }
@@ -1364,12 +1356,6 @@ static std::string loadedTime;
 
 ITCM_CODE void drawCurrentTime() {
 	// Load time
-	int x = (ms().theme >= 4 ? 162 : 200);
-	if (ms().theme == TWLSettings::EThemeHBL) {
-		x -= 28;
-	}
-	int y = (ms().theme == TWLSettings::EThemeSaturn ? 12 : 7);
-
 	std::string currentTime = retTime();
 	if (currentTime[0] == ' ')
 		currentTime[0] = '0';
@@ -1380,7 +1366,7 @@ ITCM_CODE void drawCurrentTime() {
 
 	loadedTime = currentTime;
 
-	ms().macroMode ? tex().drawDateTimeMacro(currentTime.c_str(), x, y) : tex().drawDateTime(currentTime.c_str(), x, y);
+	ms().macroMode ? tex().drawDateTimeMacro(currentTime.c_str(), tc().timeRenderX(), tc().timeRenderY()) : tex().drawDateTime(currentTime.c_str(), tc().timeRenderX(), tc().timeRenderY());
 
 	reloadTime = false;
 }

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -130,9 +130,6 @@ bool applaunchprep = false;
 
 int spawnedtitleboxes = 0;
 
-s16 usernameRendered[11] = {0};
-bool usernameRenderedDone = false;
-
 bool showColon = true;
 
 struct statvfs st[2];
@@ -938,13 +935,6 @@ int main(int argc, char **argv) {
 		tex().load3DSTheme();
 	} else {
 		tex().loadDSiTheme();
-	}
-
-	//printf("Username copied\n");
-	if(useTwlCfg) {
-		tonccpy(usernameRendered, (s16*)0x02000448, sizeof(s16) * 10);
-	} else {
-		tonccpy(usernameRendered, PersonalData->name, sizeof(s16) * PersonalData->nameLen);
 	}
 
 	if (sdFound()) statvfs("sd:/", &st[0]);

--- a/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
+++ b/romsel_dsimenutheme/arm9/source/perGameSettings.cpp
@@ -94,9 +94,6 @@ extern mm_sound_effect snd_wrong;
 extern mm_sound_effect snd_back;
 extern mm_sound_effect snd_switch;
 
-extern char usernameRendered[11];
-extern bool usernameRenderedDone;
-
 extern void bgOperations(bool waitFrame);
 
 char fileCounter[8];

--- a/romsel_dsimenutheme/nitrofiles/themes/dsi/dark/theme.ini
+++ b/romsel_dsimenutheme/nitrofiles/themes/dsi/dark/theme.ini
@@ -13,8 +13,6 @@ TitleboxRenderY		= 85
 TitleboxMaxLines	= 4
 TitleboxTextY		= 30
 TitleboxTextW		= 240
-MacroTitleboxTextY	= 40
-MacroTitleboxTextW	= 224
 TitleboxTextLarge	= 1
 
 VolumeRenderX		= 4
@@ -42,3 +40,7 @@ LaunchDotsUserPalette	= 1
 DialogBoxUserPalette	= 1
 PurpleBatteryAvailable  = 1
 RenderPhoto				= 1
+
+[MACRO]
+TitleboxTextY	= 38
+TitleboxTextW	= 224

--- a/romsel_dsimenutheme/nitrofiles/themes/hbLauncher/default/theme.ini
+++ b/romsel_dsimenutheme/nitrofiles/themes/hbLauncher/default/theme.ini
@@ -28,6 +28,9 @@ ShoulderRRenderX	= 178
 BatteryRenderY		= 5
 BatteryRenderX		= 235
 
+DateRenderX			= 94
+TimeRenderX			= 134
+
 FontPalette1		= 0x0000
 FontPalette2		= 0xB9CE
 FontPalette3		= 0xD6B5

--- a/romsel_dsimenutheme/nitrofiles/themes/hbLauncher/default/theme.ini
+++ b/romsel_dsimenutheme/nitrofiles/themes/hbLauncher/default/theme.ini
@@ -13,7 +13,6 @@ TitleboxRenderY		= 85
 TitleboxMaxLines	= 4
 TitleboxTextY		= 30
 TitleboxTextW		= 240
-MacroTitleboxTextY	= 38
 TitleboxTextLarge	= 1
 
 VolumeRenderX		= 4
@@ -43,3 +42,6 @@ MovingArrowUserPalette	= 1
 LaunchDotsUserPalette	= 1
 DialogBoxUserPalette	= 1
 RenderPhoto				= 0
+
+[MACRO]
+TitleboxTextY	= 38

--- a/romsel_dsimenutheme/nitrofiles/themes/saturn/default/theme.ini
+++ b/romsel_dsimenutheme/nitrofiles/themes/saturn/default/theme.ini
@@ -13,7 +13,6 @@ TitleboxRenderY		= 94
 TitleboxMaxLines	= 4
 TitleboxTextY		= 30
 TitleboxTextW		= 240
-MacroTitleboxTextY	= 38
 TitleboxTextLarge	= 1
 
 VolumeRenderX		= 40
@@ -45,3 +44,6 @@ MovingArrowUserPalette	= 1
 LaunchDotsUserPalette	= 1
 DialogBoxUserPalette	= 1
 RenderPhoto				= 0
+
+[MACRO]
+TitleboxTextY	= 38

--- a/romsel_dsimenutheme/nitrofiles/themes/saturn/default/theme.ini
+++ b/romsel_dsimenutheme/nitrofiles/themes/saturn/default/theme.ini
@@ -28,6 +28,11 @@ ShoulderRRenderX	= 178
 BatteryRenderY 		= 10
 BatteryRenderX		= 198
 
+DateRenderY			= 12
+DateRenderX			= 122
+TimeRenderY			= 12
+TimeRenderX			= 162
+
 FontPalette1		= 0x0000
 FontPalette2		= 0xB9CE
 FontPalette3		= 0xD6B5


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Username, date, and time positions now come from the skin config, their default (DSi/3DS theme) settings are:
   ```ini
   UsernameRenderY=15
   UsernameRenderX=28
   UsernameRenderXDS=4
   DateRenderY=7
   DateRenderX=162
   TimeRenderY=7
   TimeRenderX=200
   ```
  (I'll update the examples in a bit)
   - Closes #1903 
- Any setting can now be overridden for macro mode by putting it in a `[MACRO]` section of the ini with the same name
   - `MacroTitleboxTextY` and `MacroTitleboxTextW` parsing is kept for compatibility, however all the internal skins have been switched to the new method for those
   - Closes #1904 

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
