### PR TITLE
Various grayscale color mode fixes

### DIFF
--- a/quickmenu/arm9/source/graphics/graphics.cpp
+++ b/quickmenu/arm9/source/graphics/graphics.cpp
@@ -268,6 +268,9 @@ void bottomBgLoad(void) {
 
 	for(uint i=0;i<image.size()/4;i++) {
 		bmpImageBuffer[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
+		if (ms().colorMode == 1) {
+			bmpImageBuffer[i] = convertVramColorToGrayscale(bmpImageBuffer[i]);
+		}
 	}
 
 	// Start loading
@@ -582,6 +585,9 @@ void topBgLoad(void) {
 
 	for(uint i=0;i<image.size()/4;i++) {
 		topImageBuffer[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
+		if (ms().colorMode == 1) {
+			topImageBuffer[i] = convertVramColorToGrayscale(topImageBuffer[i]);
+		}
 	}
 
 	// Start loading

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -961,7 +961,7 @@ void ThemeTextures::drawBoxArt(const char *filename) {
 			}
 			_bmpImageBuffer2[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
 			if (ms().colorMode == 1) {
-				_bmpImageBuffer2[i] = convertVramColorToGrayscale(tex().photoBuffer()[i]);
+				_bmpImageBuffer2[i] = convertVramColorToGrayscale(_bmpImageBuffer[i]);
 			}
 			if ((i % imageWidth) == imageWidth-1) alternatePixel = !alternatePixel;
 			alternatePixel = !alternatePixel;
@@ -1046,7 +1046,7 @@ void ThemeTextures::drawBoxArtFromMem(int num) {
 			}
 			_bmpImageBuffer2[i] = image[i*4]>>3 | (image[(i*4)+1]>>3)<<5 | (image[(i*4)+2]>>3)<<10 | BIT(15);
 			if (ms().colorMode == 1) {
-				_bmpImageBuffer2[i] = convertVramColorToGrayscale(tex().photoBuffer()[i]);
+				_bmpImageBuffer2[i] = convertVramColorToGrayscale(_bmpImageBuffer[i]);
 			}
 			if ((i % imageWidth) == imageWidth-1) alternatePixel = !alternatePixel;
 			alternatePixel = !alternatePixel;
@@ -1233,6 +1233,8 @@ void ThemeTextures::drawTopBgAvoidingShoulders() {
 		for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
 			_bgSubBuffer[i] =
 			    convertVramColorToGrayscale(_bgSubBuffer[i]);
+			if (boxArtColorDeband)
+				_bgSubBuffer2[i] = _bgSubBuffer[i];
 		}
 	}
 

--- a/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
@@ -11,6 +11,7 @@
 #include "TextEntry.h"
 #include "ThemeConfig.h"
 #include "themefilenames.h"
+#include "tool/colortool.h"
 
 FontGraphic *smallFont;
 FontGraphic *largeFont;
@@ -73,6 +74,11 @@ void fontInit() {
 		tc().fontPaletteOverlay3(),
 		tc().fontPaletteOverlay4(),
 	};
+	if (ms().colorMode == 1) {
+		for (int i = 0; i < 4*4; i++) {
+			palette[i] = convertVramColorToGrayscale(palette[i]);
+		}
+	}
 	tonccpy(BG_PALETTE, palette, sizeof(palette));
 	tonccpy(BG_PALETTE_SUB, palette, sizeof(palette));
 }

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -976,15 +976,16 @@ void vBlankHandler() {
 				barXpos += ms().rtl() ? -12 : 12;
 				barYpos += 12;
 			}
+			int fillColor = ms().colorMode == 1 ? convertVramColorToGrayscale(RGB15(0, 0, 31)) : RGB15(0, 0, 31);
 			if(ms().rtl()) {
 				glBoxFilled(barXpos, barYpos, barXpos-192, barYpos+5, RGB15(23, 23, 23));
 				if (progressBarLength > 0) {
-					glBoxFilled(barXpos, barYpos, barXpos-progressBarLength, barYpos+5, RGB15(0, 0, 31));
+					glBoxFilled(barXpos, barYpos, barXpos-progressBarLength, barYpos+5, fillColor);
 				}
 			} else {
 				glBoxFilled(barXpos, barYpos, barXpos+192, barYpos+5, RGB15(23, 23, 23));
 				if (progressBarLength > 0) {
-					glBoxFilled(barXpos, barYpos, barXpos+progressBarLength, barYpos+5, RGB15(0, 0, 31));
+					glBoxFilled(barXpos, barYpos, barXpos+progressBarLength, barYpos+5, fillColor);
 				}
 			}
 		}
@@ -1291,6 +1292,8 @@ void loadBootstrapScreenshot(FILE *file) {
 
 			// RGB 565 -> BGR 5551
 			val = ((val >> 11) & 0x1F) | ((val & (0x1F << 6)) >> 1) | ((val & 0x1F) << 10) | BIT(15);
+			if (ms().colorMode == 1)
+				val = convertVramColorToGrayscale(val);
 
 			u8 y = photoHeight - row - 1;
 			bgSubBuffer[(24 + y) * 256 + 24 + col] = val;

--- a/romsel_dsimenutheme/arm9/source/graphics/iconHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/iconHandler.cpp
@@ -368,9 +368,16 @@ void glReloadIconPalette(int num) {
 		cachedPalette = _paletteCache[num];
 		break;
 	}
+	
+	u16 *newPalette = (u16*) cachedPalette;
+	if (ms().colorMode == 1) {
+		for (int i = 0; i < 16; i++) {
+			*(newPalette + i) = convertVramColorToGrayscale(*(newPalette + i));
+		}
+	}
 
 	glBindTexture(0, textureID);
-	glColorTableEXT(0, 0, 16, 0, 0, cachedPalette);
+	glColorTableEXT(0, 0, 16, 0, 0, newPalette);
 }
 
 /**

--- a/title/arm9/source/bootsplash.cpp
+++ b/title/arm9/source/bootsplash.cpp
@@ -113,7 +113,7 @@ void bootSplashDSi(void) {
 			}
 			u16 color = image[i * 4] >> 3 | (image[(i * 4) + 1] >> 3) << 5 | (image[(i * 4) + 2] >> 3) << 10 | (image[(i * 4) + 3] > 0) << 15;
 			if (ms().colorMode == 1) {
-				color = convertVramColorToGrayscale(color);
+				color = (color & 0x8000) | (convertVramColorToGrayscale(color) & 0x7FFF);
 			}
 
 			if(x >= width) {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Applies grayscale effect to various places in DSi-based themes where it was previously missing:
- Font palette colors
    - Fixes a crash that is seemingly caused by certain font colors being used.
- Loading screen progress bar
- nds-bootstrap screenshots
- When reloading icon palettes
    - Fixes animated icons that use multiple palettes (i.e. WordleDS) appearing in color.

Additionally:
- Applies grayscale to background graphics for DS Classic Menu
- Fix flickering and corruption on boxart and background in DSi-based themes when both grayscale mode and boxart debanding are enabled.
- Fix transparency on boot splash Nintendo logo when grayscale is enabled.

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
