### PR TITLE
Scroll cheat names in R4 theme

### DIFF
--- a/romsel_r4theme/arm9/source/cheat.h
+++ b/romsel_r4theme/arm9/source/cheat.h
@@ -70,7 +70,7 @@ private:
 
   std::string nextToken (FILE* fp, TOKEN_TYPE& tokenType);
 
-  void drawCheatList(std::vector<CheatCodelist::cParsedItem *>& list, uint curPos, uint screenPos);
+  void drawCheatList(std::vector<CheatCodelist::cParsedItem *>& list, uint curPos, uint screenPos, uint scrollPos);
 };
 
 #endif // CHEAT_H


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes the cheat names scroll in the R4 theme, same as the DSi theme
- Names are not truncated to fit in the box due to limitations in the printing, will fix if/when I redo that
- Fixes #1919

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
