### PR TITLE
Fix always using Grayscale for the transparent parts of battary, volu…

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -1129,9 +1129,11 @@ ITCM_CODE void ThemeTextures::drawVolumeImageCached() {
 		_cachedVolumeLevel = volumeLevel;
 		if (!topBorderBufferLoaded) {
 			_backgroundTextures[ms().macroMode].copy(_topBorderBuffer, false);
-			for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
-				_topBorderBuffer[i] =
-					convertVramColorToGrayscale(_topBorderBuffer[i]);
+			if (ms().colorMode == 1) {
+				for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
+					_topBorderBuffer[i] =
+						convertVramColorToGrayscale(_topBorderBuffer[i]);
+				}
 			}
 			topBorderBufferLoaded = true;
 		}
@@ -1223,9 +1225,11 @@ ITCM_CODE void ThemeTextures::drawBatteryImageCached() {
 		_cachedBatteryLevel = batteryLevel;
 		if (!topBorderBufferLoaded) {
 			_backgroundTextures[ms().macroMode].copy(_topBorderBuffer, false);
-			for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
-				_topBorderBuffer[i] =
-					convertVramColorToGrayscale(_topBorderBuffer[i]);
+			if (ms().colorMode == 1) {
+				for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
+					_topBorderBuffer[i] =
+						convertVramColorToGrayscale(_topBorderBuffer[i]);
+				}
 			}
 			topBorderBufferLoaded = true;
 		}
@@ -1345,9 +1349,11 @@ ITCM_CODE unsigned int ThemeTextures::getDateTimeFontSpriteIndex(const u16 lette
 ITCM_CODE void ThemeTextures::drawDateTime(const char *str, int posX, int posY) {
 	if (!topBorderBufferLoaded) {
 		_backgroundTextures[0].copy(_topBorderBuffer, false);
-		for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
-			_topBorderBuffer[i] =
-				convertVramColorToGrayscale(_topBorderBuffer[i]);
+		if (ms().colorMode == 1) {
+			for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
+				_topBorderBuffer[i] =
+					convertVramColorToGrayscale(_topBorderBuffer[i]);
+			}
 		}
 		topBorderBufferLoaded = true;
 	}
@@ -1383,9 +1389,11 @@ ITCM_CODE void ThemeTextures::drawDateTimeMacro(const char *str, int posX, int p
 
 	if (!topBorderBufferLoaded) {
 		_backgroundTextures[1].copy(_topBorderBuffer, false);
-		for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
-			_topBorderBuffer[i] =
-				convertVramColorToGrayscale(_topBorderBuffer[i]);
+		if (ms().colorMode == 1) {
+			for (u16 i = 0; i < BG_BUFFER_PIXELCOUNT; i++) {
+				_topBorderBuffer[i] =
+					convertVramColorToGrayscale(_topBorderBuffer[i]);
+			}
 		}
 		topBorderBufferLoaded = true;
 	}


### PR DESCRIPTION
…me, and date/time

<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Only convert the _topBorderBuffer to grayscale when the color mode is set to Grayscale.

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
