### PR TITLE
Save DS Lite backlight information verbatim to 0x02003000

### DIFF
--- a/quickmenu/arm7/source/main.c
+++ b/quickmenu/arm7/source/main.c
@@ -254,7 +254,7 @@ int main() {
 
 	if (SNDEXCNT == 0) {
 		if(pmBacklight & 0xF0) // DS Lite
-			backlightLevel = ((pmBacklight & 3) + ((readPowerManagement(PM_CONTROL_REG) & 0xC) != 0)) << 8; // Brightness
+			backlightLevel = pmBacklight & 3; // Brightness
 	}
 
 	if (isDSiMode()) {

--- a/romsel_dsimenutheme/arm7/source/main.c
+++ b/romsel_dsimenutheme/arm7/source/main.c
@@ -169,7 +169,7 @@ int main() {
 
 	if (SNDEXCNT == 0) {
 		if(pmBacklight & 0xF0) { // DS Lite
-			int backlightLevel = ((pmBacklight & 3) + ((readPowerManagement(PM_CONTROL_REG) & 0xC) != 0)) << 8; // Brightness
+			int backlightLevel = pmBacklight & 3; // Brightness
 			*(int*)0x02003000 = backlightLevel;
 		}
 	}

--- a/romsel_r4theme/arm7/source/main.c
+++ b/romsel_r4theme/arm7/source/main.c
@@ -169,7 +169,7 @@ int main() {
 
 	if (SNDEXCNT == 0) {
 		if(pmBacklight & 0xF0) { // DS Lite
-			int backlightLevel = ((pmBacklight & 3) + ((readPowerManagement(PM_CONTROL_REG) & 0xC) != 0)) << 8; // Brightness
+			int backlightLevel = pmBacklight & 3; // Brightness
 			*(int*)0x02003000 = backlightLevel;
 		}
 	}

--- a/title/arm7/source/main.c
+++ b/title/arm7/source/main.c
@@ -233,7 +233,7 @@ int main() {
 
 	if (SNDEXCNT == 0) {
 		if(pmBacklight & 0xF0) { // DS Lite
-			int backlightLevel = ((pmBacklight & 3) + ((readPowerManagement(PM_CONTROL_REG) & 0xC) != 0)) << 8; // Brightness
+			int backlightLevel = pmBacklight & 3; // Brightness
 			*(int*)0x02003000 = backlightLevel;
 		}
 	}


### PR DESCRIPTION
#### What's changed?

- This variable is only used for the DS Lite, as seen by all the functions that use it having a if check for it.

- For whatever reason, we are doing bit ops on it, causing Wood to go crazy trying to parse the value that is now shifted left by 8, and defaults to 0. So just remove any other unneeded ops.

- This fixes #1968.

#### Where have you tested it?

DS Lite, R4iTT

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
