### PR TITLE
DSi Theme: Macro-specific backgrounds

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -212,6 +212,13 @@ void ThemeTextures::reloadPalDialogBox() {
 	}
 }
 
+inline bool textureExists(std::string textureName) {
+	return (access((textureName + ".grf").c_str(), F_OK) == 0
+	 || access((textureName + ".png").c_str(), F_OK) == 0
+	 || access((textureName + ".bmp").c_str(), F_OK) == 0
+	);
+}
+
 void ThemeTextures::loadBackgrounds() {
 	// 0: Top, 1: Bottom, 2: Bottom Bubble, 3: Moving, 4: MovingLeft, 5: MovingRight
 
@@ -231,16 +238,32 @@ void ThemeTextures::loadBackgrounds() {
 		return;
 	}
 	// DSi Theme
-	_backgroundTextures.emplace_back(TFN_BG_BOTTOMBG, TFN_FALLBACK_BG_BOTTOMBG);
-	if (ms().macroMode
-	&& (access(((std::string)TFN_BG_BOTTOMBUBBLEBG_MACRO).c_str(), F_OK) == 0
-	 || access(((std::string)TFN_FALLBACK_BG_BOTTOMBUBBLEBG_MACRO).c_str(), F_OK) == 0)
-	) {
-		_backgroundTextures.emplace_back(TFN_BG_BOTTOMBUBBLEBG_MACRO, TFN_FALLBACK_BG_BOTTOMBUBBLEBG_MACRO);
-	} else {
-		_backgroundTextures.emplace_back(TFN_BG_BOTTOMBUBBLEBG, TFN_FALLBACK_BG_BOTTOMBUBBLEBG);
+	if (ms().macroMode) {
+		if (textureExists((std::string) TFN_BG_BOTTOMBG_MACRO)) {
+			_backgroundTextures.emplace_back(TFN_BG_BOTTOMBG_MACRO, TFN_FALLBACK_BG_BOTTOMBG);
+		} else {
+			_backgroundTextures.emplace_back(TFN_BG_BOTTOMBG, TFN_FALLBACK_BG_BOTTOMBG);
+		}
+
+		if (textureExists((std::string)TFN_BG_BOTTOMBUBBLEBG_MACRO)
+		 || textureExists((std::string)TFN_FALLBACK_BG_BOTTOMBUBBLEBG_MACRO)
+		) {
+			_backgroundTextures.emplace_back(TFN_BG_BOTTOMBUBBLEBG_MACRO, TFN_FALLBACK_BG_BOTTOMBUBBLEBG_MACRO);
+		} else {
+			_backgroundTextures.emplace_back(TFN_BG_BOTTOMBUBBLEBG, TFN_FALLBACK_BG_BOTTOMBUBBLEBG);
+		}
+
+		if (ms().theme == TWLSettings::EThemeDSi && textureExists((std::string)TFN_BG_BOTTOMMOVINGBG_MACRO)) {
+			_backgroundTextures.emplace_back(TFN_BG_BOTTOMMOVINGBG_MACRO, TFN_FALLBACK_BG_BOTTOMMOVINGBG);
+		} else {
+			_backgroundTextures.emplace_back(TFN_BG_BOTTOMMOVINGBG, TFN_FALLBACK_BG_BOTTOMMOVINGBG);
+		}
 	}
-	if (ms().theme == TWLSettings::EThemeDSi) _backgroundTextures.emplace_back(TFN_BG_BOTTOMMOVINGBG, TFN_FALLBACK_BG_BOTTOMMOVINGBG);
+	else {
+		_backgroundTextures.emplace_back(TFN_BG_BOTTOMBG, TFN_FALLBACK_BG_BOTTOMBG);
+		_backgroundTextures.emplace_back(TFN_BG_BOTTOMBUBBLEBG, TFN_FALLBACK_BG_BOTTOMBUBBLEBG);
+		if (ms().theme == TWLSettings::EThemeDSi) _backgroundTextures.emplace_back(TFN_BG_BOTTOMMOVINGBG, TFN_FALLBACK_BG_BOTTOMMOVINGBG);
+	}
 	
 }
 

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -268,6 +268,11 @@ void bottomBgLoad(int drawBubble, bool init = false) {
 		tex().resetCachedVolumeLevel();
 		tex().resetCachedBatteryLevel();
 		tex().resetProfileName();
+		drawCurrentDate();
+		drawCurrentTime();
+		tex().drawVolumeImageCached();
+		tex().drawBatteryImageCached();
+		tex().drawProfileName();
 		prevBottomBgState = bottomBgState;
 	}
 }

--- a/romsel_dsimenutheme/arm9/source/graphics/themefilenames.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/themefilenames.h
@@ -45,11 +45,13 @@
 
 #define TFN_BG_TOPBG                TFN_UI_DIRECTORY"/background/top"
 #define TFN_BG_BOTTOMBG             TFN_UI_DIRECTORY"/background/bottom"
+#define TFN_BG_BOTTOMBG_MACRO       TFN_UI_DIRECTORY"/background/bottom_macro"
 #define TFN_BG_BOTTOMBUBBLEBG       TFN_UI_DIRECTORY"/background/bottom_bubble"
 #define TFN_BG_BOTTOMBUBBLEBG_MACRO TFN_UI_DIRECTORY"/background/bottom_bubble_macro"
 #define TFN_BG_BOTTOMBG_DS          TFN_UI_DIRECTORY"/background/bottom_ds"
 #define TFN_BG_BOTTOMBUBBLEBG_DS    TFN_UI_DIRECTORY"/background/bottom_bubble_ds"
 #define TFN_BG_BOTTOMMOVINGBG       TFN_UI_DIRECTORY"/background/bottom_moving"
+#define TFN_BG_BOTTOMMOVINGBG_MACRO TFN_UI_DIRECTORY"/background/bottom_moving_macro"
 #define TFN_BG_BOTTOMMOVING_LBG     TFN_UI_DIRECTORY"/background/bottom_moving_l"
 #define TFN_BG_BOTTOMMOVING_RBG     TFN_UI_DIRECTORY"/background/bottom_moving_r"
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Added two optional macro-mode-specific backgrounds: `bottom_macro` and `bottom_moving_macro`.
- Immediately redraw background UI after the background changes in macro mode.

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
