### PR TITLE
Remember preferred display screen after macro mode switch

### DIFF
--- a/settings/arm9/source/gbarunner2settings.cpp
+++ b/settings/arm9/source/gbarunner2settings.cpp
@@ -8,6 +8,7 @@
 GBAR2Settings::GBAR2Settings()
 {
     useBottomScreen = false;
+    bottomScreenPrefered = false;
     frame = true;
     centerMask = true;
     gbaColors = false;
@@ -22,6 +23,9 @@ void GBAR2Settings::loadSettings()
 
     // UI settings.
     useBottomScreen = (gbarunner2ini.GetString("emulation", "useBottomScreen", "false")=="false" ? false : true);
+    bottomScreenPrefered = (gbarunner2ini.GetString("emulation", "bottomScreenPrefered", "unset")=="unset" ? useBottomScreen :
+        gbarunner2ini.GetString("emulation", "bottomScreenPrefered", "false")=="false" ? false : true
+    );
     frame = (gbarunner2ini.GetString("emulation", "frame", "true")=="true" ? true : false);
     centerMask = (gbarunner2ini.GetString("emulation", "centerMask", "true")=="true" ? true : false);
     gbaColors = (gbarunner2ini.GetString("emulation", "gbaColors", "false")=="false" ? false : true);
@@ -36,7 +40,8 @@ void GBAR2Settings::saveSettings()
     gbar2Fix = true;
     CIniFile gbarunner2ini(GBARUNNER2_INI);
 
-    gbarunner2ini.SetString("emulation", "useBottomScreen", (useBottomScreen || ms().macroMode) ? "true" : "false");
+    gbarunner2ini.SetString("emulation", "useBottomScreen", (bottomScreenPrefered || ms().macroMode) ? "true" : "false");
+    gbarunner2ini.SetString("emulation", "bottomScreenPrefered", bottomScreenPrefered ? "true" : "false");
     gbarunner2ini.SetString("emulation", "frame", frame ? "true" : "false");
     gbarunner2ini.SetString("emulation", "centerMask", centerMask ? "true" : "false");
     gbarunner2ini.SetString("emulation", "gbaColors", gbaColors ? "true" : "false");

--- a/settings/arm9/source/gbarunner2settings.h
+++ b/settings/arm9/source/gbarunner2settings.h
@@ -22,6 +22,7 @@ class GBAR2Settings
 
   public:
     bool useBottomScreen;
+    bool bottomScreenPrefered;
     bool frame;
     bool centerMask;
     bool gbaColors;

--- a/settings/arm9/source/main.cpp
+++ b/settings/arm9/source/main.cpp
@@ -1171,7 +1171,7 @@ int main(int argc, char **argv)
 		.option(STR_WRAM_I_CACHE, STR_DESCRIPTION_GBAR2_WRAMICACHE, Option::Bool(&gs().wramICache), {STR_ON, STR_OFF}, {true, false})
 		.option(STR_BIOS_INTRO, STR_DESCRIPTION_BIOSINTRO, Option::Bool(&gs().skipIntro), {STR_OFF, STR_ON}, {true, false});
 	if (!ms().macroMode) {
-		gbar2Page.option(STR_DISPLAY_SCREEN, STR_DESCRIPTION_DISPLAY_SCREEN, Option::Bool(&gs().useBottomScreen), {STR_BOTTOM, STR_TOP}, {true, false});
+		gbar2Page.option(STR_DISPLAY_SCREEN, STR_DESCRIPTION_DISPLAY_SCREEN, Option::Bool(&gs().bottomScreenPrefered), {STR_BOTTOM, STR_TOP}, {true, false});
 	}
 	gbar2Page
 		.option(STR_BORDER_FRAME, STR_DESCRIPTION_BORDER_FRAME, Option::Bool(&gs().frame), {STR_ON, STR_OFF}, {true, false})


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Remember the user's preferred display screen for GBARunner2 so that it can be restored after disabling macro mode.

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
