### PR TITLE
Fix residual text when printing small characters with the date time/username fonts

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.h
@@ -55,6 +55,7 @@ public:
 	~FontGraphic(void);
 
 	u8 height(void) { return tileHeight; }
+	u8 width(void) { return tileWidth + 1; }
 
 	int calcWidth(std::string_view text) { return calcWidth(utf8to16(text)); }
 	int calcWidth(std::u16string_view text);

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -762,7 +762,7 @@ void ThemeTextures::drawProfileName() {
 
 	toncset16(FontGraphic::textBuf[1], 0, 256 * usernameFont()->height());
 	usernameFont()->print(0, 0, true, username, Alignment::left, FontPalette::name);
-	int width = usernameFont()->calcWidth(username);
+	int width = usernameFont()->width() * 10;
 
 	// Copy to background
 	for (int y = 0; y < usernameFont()->height(); y++) {
@@ -1297,7 +1297,7 @@ ITCM_CODE void ThemeTextures::drawDateTime(const char *str, int posX, int posY) 
 
 	toncset16(FontGraphic::textBuf[1], 0, 256 * dateTimeFont()->height());
 	dateTimeFont()->print(0, 0, true, str, Alignment::left, FontPalette::dateTime);
-	int width = dateTimeFont()->calcWidth(str);
+	int width = dateTimeFont()->width() * strlen(str);
 
 	// Copy to background
 	for (int y = 0; y < dateTimeFont()->height(); y++) {
@@ -1331,7 +1331,7 @@ ITCM_CODE void ThemeTextures::drawDateTimeMacro(const char *str, int posX, int p
 
 	toncset16(FontGraphic::textBuf[1], 0, 256 * dateTimeFont()->height());
 	dateTimeFont()->print(0, 0, true, str, Alignment::left, FontPalette::dateTime);
-	int width = dateTimeFont()->calcWidth(str);
+	int width = dateTimeFont()->width() * strlen(str);
 
 	// Copy to background
 	for (int y = 0; y < dateTimeFont()->height(); y++) {


### PR DESCRIPTION


<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Clears the maximum width for the given string instead of just the actual length, fixing leftover pixels when printing smaller characters like `1`
- Fixes #2011 

#### Where have you tested it?

- no$gba

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
