### PR TITLE
Some top-screen text printing fixes

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.cpp
@@ -757,12 +757,12 @@ void ThemeTextures::drawProfileName() {
 	// Load username
 	int xPos = (dsiFeatures() ? tc().usernameRenderX() : tc().usernameRenderXDS());
 	int yPos = tc().usernameRenderY();
-	char16_t username[10];
+	char16_t username[11] = {0};
 	tonccpy(username, useTwlCfg ? (s16 *)0x02000448 : PersonalData->name, 10 * sizeof(char16_t));
 
 	toncset16(FontGraphic::textBuf[1], 0, 256 * usernameFont()->height());
 	usernameFont()->print(0, 0, true, username, Alignment::left, FontPalette::name);
-	int width = usernameFont()->width() * 10;
+	int width = usernameFont()->calcWidth(username);
 
 	// Copy to background
 	for (int y = 0; y < usernameFont()->height(); y++) {
@@ -1283,7 +1283,7 @@ void ThemeTextures::drawShoulders(bool LShoulderActive, bool RShoulderActive) {
 	commitBgSubModify();
 }
 
-ITCM_CODE void ThemeTextures::drawDateTime(const char *str, int posX, int posY) {
+ITCM_CODE void ThemeTextures::drawDateTime(const char *str, int posX, int posY, bool isDate) {
 	if (!topBorderBufferLoaded) {
 		_backgroundTextures[0].copy(_topBorderBuffer, false);
 		if (ms().colorMode == 1) {
@@ -1297,7 +1297,7 @@ ITCM_CODE void ThemeTextures::drawDateTime(const char *str, int posX, int posY) 
 
 	toncset16(FontGraphic::textBuf[1], 0, 256 * dateTimeFont()->height());
 	dateTimeFont()->print(0, 0, true, str, Alignment::left, FontPalette::dateTime);
-	int width = dateTimeFont()->width() * strlen(str);
+	int width = max(dateTimeFont()->calcWidth(str), isDate ? _previousDateWidth : _previousTimeWidth);
 
 	// Copy to background
 	for (int y = 0; y < dateTimeFont()->height(); y++) {
@@ -1313,9 +1313,15 @@ ITCM_CODE void ThemeTextures::drawDateTime(const char *str, int posX, int posY) 
 			}
 		}
 	}
+
+	if (isDate) {
+		_previousDateWidth = dateTimeFont()->calcWidth(str);
+	} else {
+		_previousTimeWidth = dateTimeFont()->calcWidth(str);
+	}
 }
 
-ITCM_CODE void ThemeTextures::drawDateTimeMacro(const char *str, int posX, int posY) {
+ITCM_CODE void ThemeTextures::drawDateTimeMacro(const char *str, int posX, int posY, bool isDate) {
 	if (ms().theme == TWLSettings::EThemeSaturn) return;
 
 	if (!topBorderBufferLoaded) {
@@ -1331,7 +1337,7 @@ ITCM_CODE void ThemeTextures::drawDateTimeMacro(const char *str, int posX, int p
 
 	toncset16(FontGraphic::textBuf[1], 0, 256 * dateTimeFont()->height());
 	dateTimeFont()->print(0, 0, true, str, Alignment::left, FontPalette::dateTime);
-	int width = dateTimeFont()->width() * strlen(str);
+	int width = max(dateTimeFont()->calcWidth(str), isDate ? _previousDateWidth : _previousTimeWidth);
 
 	// Copy to background
 	for (int y = 0; y < dateTimeFont()->height(); y++) {
@@ -1342,6 +1348,12 @@ ITCM_CODE void ThemeTextures::drawDateTimeMacro(const char *str, int posX, int p
 
 			BG_GFX[(posY + y) * 256 + (posX + x)] = val;
 		}
+	}
+
+	if (isDate) {
+		_previousDateWidth = dateTimeFont()->calcWidth(str);
+	} else {
+		_previousTimeWidth = dateTimeFont()->calcWidth(str);
 	}
 }
 

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeTextures.h
@@ -72,8 +72,8 @@ public:
 	void resetCachedBatteryLevel();
 
 	void drawShoulders(bool LShoulderActive, bool RShoulderActive);
-	void drawDateTime(const char* date, int posX, int posY);
-	void drawDateTimeMacro(const char* date, int posX, int posY);
+	void drawDateTime(const char* date, int posX, int posY, bool isDate);
+	void drawDateTimeMacro(const char* date, int posX, int posY, bool isDate);
 
 	void clearTopScreen();
 	static void videoSetup();
@@ -350,6 +350,8 @@ private:
 	int _cachedVolumeLevel;
 	int _cachedBatteryLevel;
 	bool _profileNameLoaded;
+	int _previousDateWidth = 0;
+	int _previousTimeWidth = 0;
 };
 
 

--- a/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/fontHandler.cpp
@@ -87,7 +87,7 @@ void fontInit() {
 		tc().fontPaletteDateTime4(),
 	};
 	if (ms().colorMode == 1) {
-		for (int i = 0; i < 4*4; i++) {
+		for (int i = 0; i < sizeof(palette); i++) {
 			palette[i] = convertVramColorToGrayscale(palette[i]);
 		}
 	}

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -1372,7 +1372,7 @@ ITCM_CODE void drawCurrentDate() {
 
 	loadedDate = currentDate;
 
-	ms().macroMode ? tex().drawDateTimeMacro(loadedDate.c_str(), tc().dateRenderX(), tc().dateRenderY()) : tex().drawDateTime(loadedDate.c_str(), tc().dateRenderX(), tc().dateRenderY());
+	ms().macroMode ? tex().drawDateTimeMacro(loadedDate.c_str(), tc().dateRenderX(), tc().dateRenderY(), true) : tex().drawDateTime(loadedDate.c_str(), tc().dateRenderX(), tc().dateRenderY(), true);
 
 	reloadDate = false;
 }
@@ -1391,7 +1391,7 @@ ITCM_CODE void drawCurrentTime() {
 
 	loadedTime = currentTime;
 
-	ms().macroMode ? tex().drawDateTimeMacro(currentTime.c_str(), tc().timeRenderX(), tc().timeRenderY()) : tex().drawDateTime(currentTime.c_str(), tc().timeRenderX(), tc().timeRenderY());
+	ms().macroMode ? tex().drawDateTimeMacro(currentTime.c_str(), tc().timeRenderX(), tc().timeRenderY(), false) : tex().drawDateTime(currentTime.c_str(), tc().timeRenderX(), tc().timeRenderY(), false);
 
 	reloadTime = false;
 }

--- a/romsel_dsimenutheme/arm9/source/tool/colortool.cpp
+++ b/romsel_dsimenutheme/arm9/source/tool/colortool.cpp
@@ -14,5 +14,5 @@ unsigned short convertVramColorToGrayscale(unsigned short val) {
 	min = (min < r) ? min : r;
 	max = (max + min) / 2;
 
-	return 32768|(max<<10)|(max<<5)|(max);
+	return (val & 32768)|(max<<10)|(max<<5)|(max);
 }


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fix printing garbage data because of unterminated string when the username is 10 characters long.
- Fix FontPaletteUsername/DateTime not being converted when in grayscale mode (my bad, I left a magic number there before).
- Fix transparent text background becoming pure black/solid in grayscale mode (colortool now preserves bit 15).
- Tighten the screen space that is cleared when printing top-screen text.

For that last one, calcWidth() is used again. The width of the previously printed date/time string is stored so that upon next print we can clear only exactly what needs to be cleared. This isn't a full fix for #2015 but it should help alleviate the issue.

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
