### PR TITLE
Add extension blocking INI-only setting

### DIFF
--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1063,6 +1063,13 @@ int main(int argc, char **argv) {
 		extensionList.emplace_back(".plg"); // DSTWO Plugin
 	}
 
+	if(ms().blockedExtensions.size() > 0) {
+		auto toErase = std::remove_if(extensionList.begin(), extensionList.end(), [](std::string_view str) {
+			return std::find(ms().blockedExtensions.begin(), ms().blockedExtensions.end(), str) != ms().blockedExtensions.end();
+		});
+		extensionList.erase(toErase, extensionList.end());
+	}
+
 	srand(time(NULL));
 
 	char path[256] = {0};

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -11,6 +11,7 @@
 #include <sys/stat.h>
 #include <limits.h>
 
+#include <algorithm>
 #include <string.h>
 #include <unistd.h>
 #include <gl2d.h>

--- a/romsel_r4theme/arm9/source/main.cpp
+++ b/romsel_r4theme/arm9/source/main.cpp
@@ -1171,6 +1171,13 @@ int main(int argc, char **argv) {
 		extensionList.emplace_back(".plg"); // DSTWO Plugin
 	}
 
+	if(ms().blockedExtensions.size() > 0) {
+		auto toErase = std::remove_if(extensionList.begin(), extensionList.end(), [](std::string_view str) {
+			return std::find(ms().blockedExtensions.begin(), ms().blockedExtensions.end(), str) != ms().blockedExtensions.end();
+		});
+		extensionList.erase(toErase, extensionList.end());
+	}
+
 	srand(time(NULL));
 	
 	bool copyDSiWareSavBack =

--- a/universal/include/common/twlmenusettings.h
+++ b/universal/include/common/twlmenusettings.h
@@ -1,6 +1,7 @@
 
 #include <nds.h>
 #include <string>
+#include <vector>
 #include "common/bootstrappaths.h"
 #include "common/singleton.h"
 
@@ -305,6 +306,7 @@ public:
 	bool previousUsedDevice;
 	bool secondaryDevice;
 	bool fcSaveOnSd;
+	std::vector<std::string> blockedExtensions;
 
 	int flashcard;
 	TSlot1LaunchMethod slot1LaunchMethod;

--- a/universal/source/common/twlmenusettings.cpp
+++ b/universal/source/common/twlmenusettings.cpp
@@ -237,6 +237,7 @@ void TWLSettings::loadSettings()
 	previousUsedDevice = settingsini.GetInt("SRLOADER", "PREVIOUS_USED_DEVICE", previousUsedDevice);
 	secondaryDevice = bothSDandFlashcard() ? settingsini.GetInt("SRLOADER", "SECONDARY_DEVICE", secondaryDevice) : flashcardFound();
 	fcSaveOnSd = settingsini.GetInt("SRLOADER", "FC_SAVE_ON_SD", fcSaveOnSd);
+	settingsini.GetStringVector("SRLOADER", "BLOCKED_EXTENSIONS", blockedExtensions, ':');
 
 	flashcard = settingsini.GetInt("SRLOADER", "FLASHCARD", flashcard);
 	slot1LaunchMethod = (TSlot1LaunchMethod)settingsini.GetInt("SRLOADER", "SLOT1_LAUNCHMETHOD", slot1LaunchMethod);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Adds `BLOCKED_EXTENSIONS` INI-only setting which is a `:` separated list of all extensions to block, ex:
```ini
BLOCKED_EXTENSIONS = .bmp:.png
```

#### Where have you tested it?

- no$gba

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
