### PR TITLE
Fix toncset (byte version) not working correctly

### DIFF
--- a/universal/include/common/tonccpy.h
+++ b/universal/include/common/tonccpy.h
@@ -12,7 +12,7 @@ extern "C" {
 
 typedef unsigned int uint;
 #define BIT_MASK(len)       ( (1<<(len))-1 )
-static inline u32 quad8(u8 x)   {   x |= x<<8; return x | x<<16;    }
+static inline u32 quad8(u16 x)   {   x |= x<<8; return x | x<<16;    }
 
 
 //# Declarations and inlines.


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- quad8() was bugged for anything besides `0`, since the input was a u8 an input of say `1` would end up with `0x00010001` instead of `0x01010101`

#### Where have you tested it?

- My Advent of Code 2022 day 14 program, and several other things I've fixed this on in the past but apparently TWiLight's still bugged

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
