### PR TITLE
Re-order credits and add Secondary Developers credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
 - [lifehackerhansol](https://github.com/lifehackerhansol): Improving support for flashcard autobooting and kernel loading
 - [NightScript](https://github.com/NightScript370): Code cleanup, defining code standards, added flashcard functionality for Wood UI theme, manual pages
 ## App Launchers
-- [ahezard](https://github.com/ahezard), [shutterbug2000](https://github.com/shutterbug2000), and [Rocket Robz](https://github.com/RocketRobz): [nds-bootstrap](https://github.com/ahezard/nds-bootstrap) (used for launching Nintendo DS(i) ROMs off the SD card)
+- [ahezard](https://github.com/ahezard), [shutterbug2000](https://github.com/shutterbug2000) and [Rocket Robz](https://github.com/RocketRobz): [nds-bootstrap](https://github.com/ahezard/nds-bootstrap) (used for launching Nintendo DS(i) ROMs off the SD card)
 - [Alekmaul](https://github.com/alekmaul): [AmeDS](https://www.gamebrew.org/wiki/AmeDS) (used for launching Amstrad CPC ROMs)
 - [Alekmaul](https://github.com/alekmaul) & [wavemotion](https://github.com/wavemotion-dave): [StellaDS](https://github.com/wavemotion-dave/StellaDS), [A5200DS](https://github.com/wavemotion-dave/A5200DS), [A7800DS](https://github.com/wavemotion-dave/A7800DS), [XEGS-DS](https://github.com/wavemotion-dave/XEGS-DS) (used for launching Atari 2600/5200/7800/XEGS ROMs), and [ColecoDS](https://github.com/wavemotion-dave/ColecoDS) (used for launching ColecoVision, Sord M5, and Sega SG-1000 ROMs)
 - archiede: [SNEmulDS](https://www.gamebrew.org/wiki/SNEmulDS) (used for launching SNES ROMs)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
 ## Secondary Developers
 - [DieGo](https://github.com/DieGo367): Adding support for custom ROM/folder icons and improvements for custom skins
 - [lifehackerhansol](https://github.com/lifehackerhansol): Improving support for flashcard autobooting and kernel loading
-- [NightScript](https://github.com/NightScript370): Code cleanup, added functionality for Acekard theme in regards to flashcards
+- [NightScript](https://github.com/NightScript370): Code cleanup, defining code standards, added flashcard functionality for Wood UI theme, manual pages
 ## App Launchers
 - [ahezard](https://github.com/ahezard), [shutterbug2000](https://github.com/shutterbug2000), and [Rocket Robz](https://github.com/RocketRobz): [nds-bootstrap](https://github.com/ahezard/nds-bootstrap) (used for launching Nintendo DS(i) ROMs off the SD card)
 - [Alekmaul](https://github.com/alekmaul): [AmeDS](https://www.gamebrew.org/wiki/AmeDS) (used for launching Amstrad CPC ROMs)
@@ -83,7 +83,6 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
 - [fail0verflow](https://github.com/fail0verflow/), Fluto, and Arkhandar: Homebrew Channel/Launcher graphics
 - [FlameKat53](https://github.com/FlameKat53): Manual icon for DSi theme's `SELECT` menu
 - [Mr. Start](https://github.com/Arthur-Start): Super Nintendo DS splash screen
-- [NightScript](https://github.com/NightScript370/): Reworked Manual pages
 - [spinal_cord](https://gbatemp.net/members/spinal_cord.90607/): [DSi4DS](https://gbatemp.net/threads/dsi4ds.173617/) and [DSision2](https://gbatemp.net/threads/dsision2.92740/) graphics
 - [StarvingArtist](https://www.deviantart.com/starvingartist/): Game Console icons
 ## Music

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
 - [lifehackerhansol](https://github.com/lifehackerhansol): Improving support for flashcard autobooting and kernel loading
 - [NightScript](https://github.com/NightScript370): Code cleanup, added functionality for Acekard theme in regards to flashcards
 ## App Launchers
-- [ahezard](https://github.com/ahezard) & [shutterbug2000](https://github.com/shutterbug2000): [nds-bootstrap](https://github.com/ahezard/nds-bootstrap) (used for launching Nintendo DS(i) ROMs off the SD card)
+- [ahezard](https://github.com/ahezard), [shutterbug2000](https://github.com/shutterbug2000), and [Rocket Robz](https://github.com/RocketRobz): [nds-bootstrap](https://github.com/ahezard/nds-bootstrap) (used for launching Nintendo DS(i) ROMs off the SD card)
 - [Alekmaul](https://github.com/alekmaul): [AmeDS](https://www.gamebrew.org/wiki/AmeDS) (used for launching Amstrad CPC ROMs)
 - [Alekmaul](https://github.com/alekmaul) & [wavemotion](https://github.com/wavemotion-dave): [StellaDS](https://github.com/wavemotion-dave/StellaDS), [A5200DS](https://github.com/wavemotion-dave/A5200DS), [A7800DS](https://github.com/wavemotion-dave/A7800DS), [XEGS-DS](https://github.com/wavemotion-dave/XEGS-DS) (used for launching Atari 2600/5200/7800/XEGS ROMs), and [ColecoDS](https://github.com/wavemotion-dave/ColecoDS) (used for launching ColecoVision, Sord M5, and Sega SG-1000 ROMs)
 - archiede: [SNEmulDS](https://www.gamebrew.org/wiki/SNEmulDS) (used for launching SNES ROMs)

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
    <img src="https://img.shields.io/badge/GBAtemp-Thread-blue.svg" alt="GBAtemp Thread">
   </a>
   <a href="https://discord.gg/yD3spjv">
-   <img src="https://img.shields.io/badge/Discord%20Server-%23twilight--menu-dev-green.svg" alt="Discord Server">
+   <img src="https://img.shields.io/badge/Discord%20Server-%23twilight--menu--dev-green.svg" alt="Discord Server">
   </a>
   <a href="https://github.com/DS-Homebrew/TWiLightMenu/actions?query=workflow%3A%22Build+TWiLight+Menu%2B%2B%22">
-   <img src="https://github.com/DS-Homebrew/TWiLightMenu/workflows/Build%20TWiLight%20Menu++/badge.svg" height="20" alt="Build status on GitHub Actions">
+   <img src="https://github.com/DS-Homebrew/TWiLightMenu/actions/workflows/nightly.yml/badge.svg" height="20" alt="Build status on GitHub Actions">
   </a>
   <a href="https://crowdin.com/project/TwilightMenu">
     <img src="https://badges.crowdin.net/TwilightMenu/localized.svg" alt="Localized on Crowdin">

--- a/README.md
+++ b/README.md
@@ -54,53 +54,58 @@ You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.
 - [Rocket Robz](https://github.com/RocketRobz): Lead Developer
 - [chyyran](https://github.com/chyyran): Porting the akMenu/Wood UI to TWiLight Menu++ & adding the ability to load sub-themes off the SD card for DSi/3DS themes
 - [Pk11](https://github.com/Epicpkmn11): Adding the ability to load skins off the SD card for the R4 theme, implemented sorting & made manuals use PNG, improved font rendering, providing a custom background for Unlaunch, managing translations, and various bug fixes
+## Secondary Developers
+- [DieGo](https://github.com/DieGo367): Adding support for custom ROM/folder icons and improvements for custom skins
+- [lifehackerhansol](https://github.com/lifehackerhansol): Improving support for flashcard autobooting and kernel loading
+- [NightScript](https://github.com/NightScript370): Code cleanup, added functionality for Acekard theme in regards to flashcards
 ## App Launchers
-- [ahezard](https://github.com/ahezard) & [shutterbug2000](https://github.com/shutterbug2000): [nds-bootstrap](https://github.com/ahezard/nds-bootstrap) (used to launch Nintendo DS ROMs off the SD card)
-- [Drenn](https://github.com/Drenn1): [GameYob](https://github.com/Drenn1/GameYob) (used to launch Gameboy ROMs)
-- [Coto](https://coto88.bitbucket.io/): Working on [SNEmulDS](https://www.gamebrew.org/wiki/SNEmulDS) with acheid/Loopy (used to launch SNES ROMs) & [nesDS](https://github.com/RocketRobz/NesDS) ([TWL Edition](https://github.com/ApacheThunder/NesDS) by [Apache Thunder](https://github.com/ApacheThunder)) (used to launch NES ROMs)
-- Lordus: [jEnesisDS](https://gamebrew.org/wiki/JEnesisDS) (used to launch Sega Mega Drive/Genesis ROMs)
-- Ryan FB & [xonn83](https://github.com/xonn83): [PicoDriveDS](https://github.com/xonn83/PicodriveDS_GBMacro) (used to launch large Sega Mega Drive/Genesis ROMs)
-- [Gericom](https://github.com/Gericom): [GBARunner2](https://github.com/Gericom/GBARunner2) (used to launch GameBoy Advance ROMs outside of the DS Phat/Lite's GBA mode)
-     - [therealteamplayer](https://github.com/therealteamplayer): [Hicode+DSP](https://github.com/therealteamplayer/GBARunner2) merged builds included for DSi/3DS
-     - [unresolvedsymbol](https://github.com/unresolvedsymbol): [rom3M+master "DSL-Enhanced"](https://github.com/unresolvedsymbol/GBARunner2-DSL-Enhanced) builds included for flashcards
-- [FluBBaOfWard](https://github.com/FluBBaOfWard): [S8DS](https://github.com/FluBBaOfWard/S8DS) (used to launch Sega Master System, Game Gear, SG-1000, and ColecoVision ROMs), [NitroGrafx](https://github.com/FluBBaOfWard/NitroGrafx) (used to launch PC Engine/TurboGrafx-16 ROMs), [NitroSwan](https://github.com/FluBBaOfWard/NitroSwan) (used to launch WonderSwan ROMs), and [NGPDS](https://github.com/FluBBaOfWard/NGPDS) (used to launch Neo Geo Pocket ROMs)
-- [Alekmaul](https://github.com/alekmaul) & [wavemotion](https://github.com/wavemotion-dave): [StellaDS](https://github.com/wavemotion-dave/StellaDS), [A5200DS](https://github.com/wavemotion-dave/A5200DS), [A7800DS](https://github.com/wavemotion-dave/A7800DS), [XEGS-DS](https://github.com/wavemotion-dave/XEGS-DS) (used to launch Atari 2600/5200/7800/XEGS ROMs), and [ColecoDS](https://github.com/wavemotion-dave/ColecoDS) (used to launch ColecoVision, Sord M5, and Sega SG-1000 ROMs)
-- [wavemotion](https://github.com/wavemotion-dave): [Nintellivision/NINTV-DS](https://github.com/wavemotion-dave/NINTV-DS) (used to launch Intellivision ROMs)
-- [xonn83](https://github.com/xonn83): GBMacro version of [jEnesisDS](https://github.com/xonn83/jEnesisDS_macro).
+- [ahezard](https://github.com/ahezard) & [shutterbug2000](https://github.com/shutterbug2000): [nds-bootstrap](https://github.com/ahezard/nds-bootstrap) (used for launching Nintendo DS(i) ROMs off the SD card)
+- [Alekmaul](https://github.com/alekmaul): [AmeDS](https://www.gamebrew.org/wiki/AmeDS) (used for launching Amstrad CPC ROMs)
+- [Alekmaul](https://github.com/alekmaul) & [wavemotion](https://github.com/wavemotion-dave): [StellaDS](https://github.com/wavemotion-dave/StellaDS), [A5200DS](https://github.com/wavemotion-dave/A5200DS), [A7800DS](https://github.com/wavemotion-dave/A7800DS), [XEGS-DS](https://github.com/wavemotion-dave/XEGS-DS) (used for launching Atari 2600/5200/7800/XEGS ROMs), and [ColecoDS](https://github.com/wavemotion-dave/ColecoDS) (used for launching ColecoVision, Sord M5, and Sega SG-1000 ROMs)
+- archiede: [SNEmulDS](https://www.gamebrew.org/wiki/SNEmulDS) (used for launching SNES ROMs)
+     - [Coto](https://coto88.bitbucket.io/): [SNEmulDS Revival](https://bitbucket.org/Coto88/snemulds)
+- [chishm](https://github.com/chishm): [tuna-viDS](https://github.com/chishm/tuna-vids) (used for playing Xvid videos)
+- [Drenn](https://github.com/Drenn1): [GameYob](https://github.com/Drenn1/GameYob) (used for launching Gameboy ROMs)
+- [FluBBaOfWard](https://github.com/FluBBaOfWard): [S8DS](https://github.com/FluBBaOfWard/S8DS) (used for launching Sega Master System, Game Gear, SG-1000, and ColecoVision ROMs), [NitroGrafx](https://github.com/FluBBaOfWard/NitroGrafx) (used for launching PC Engine/TurboGrafx-16 ROMs), [NitroSwan](https://github.com/FluBBaOfWard/NitroSwan) (used for launching WonderSwan ROMs), and [NGPDS](https://github.com/FluBBaOfWard/NGPDS) (used for launching Neo Geo Pocket ROMs)
+- [FluBBaOfWard](https://github.com/FluBBaOfWard), [Coto](https://coto88.bitbucket.io/), and Loopy: [nesDS](https://github.com/DS-Homebrew/NesDS) (used for launching NES ROMs)
+     - [Apache Thunder](https://github.com/ApacheThunder): [TWL Edition](https://github.com/ApacheThunder/NesDS) of nesDS
+- [Gericom](https://github.com/Gericom): [FastVideoDSPlayer](https://github.com/Gericom/FastVideoDSPlayer) (used for launching FastVideoDS videos) & [GBARunner2](https://github.com/Gericom/GBARunner2) (used for launching GameBoy Advance ROMs outside of the DS Phat/Lite's GBA mode)
+     - [therealteamplayer](https://github.com/therealteamplayer): [Hicode+DSP](https://github.com/therealteamplayer/GBARunner2) merged builds of GBARunner2 included for DSi/3DS
+     - [unresolvedsymbol](https://github.com/unresolvedsymbol): [rom3M+master "DSL-Enhanced"](https://github.com/unresolvedsymbol/GBARunner2-DSL-Enhanced) builds of GBARunner2 included for flashcards
+- Lordus: [jEnesisDS](https://gamebrew.org/wiki/JEnesisDS) (used for launching Sega Mega Drive/Genesis ROMs)
+     - [xonn83](https://github.com/xonn83): GBMacro version of [jEnesisDS](https://github.com/xonn83/jEnesisDS_macro)
+- [redbug26](https://github.com/redbug26): [CrocoDS](https://github.com/redbug26/crocods-nds) (used for launching Amstrad CPC ROMs)
+- Ryan FB, [Rocket Robz](https://github.com/RocketRobz), and [xonn83](https://github.com/xonn83): [PicoDriveTWL](https://github.com/DS-Homebrew/PicoDriveTWL) (used for launching large Sega Mega Drive/Genesis ROMs)
+- [wavemotion](https://github.com/wavemotion-dave): [Nintellivision/NINTV-DS](https://github.com/wavemotion-dave/NINTV-DS) (used for launching Intellivision ROMs)
 ## Graphics & Themes
+- [Absent-Reality](http://pixeljoint.com/p/19283.htm): Intellivision icon
+- davi: Border for GBC theme (originally for GameYob)
+- [fail0verflow](https://github.com/fail0verflow/), Fluto, and Arkhandar: Homebrew Channel/Launcher graphics
+- [FlameKat53](https://github.com/FlameKat53): Manual icon for DSi theme's `SELECT` menu
+- [Mr. Start](https://github.com/Arthur-Start): Super Nintendo DS splash screen
+- [NightScript](https://github.com/NightScript370/): Reworked Manual pages
 - [spinal_cord](https://gbatemp.net/members/spinal_cord.90607/): [DSi4DS](https://gbatemp.net/threads/dsi4ds.173617/) and [DSision2](https://gbatemp.net/threads/dsision2.92740/) graphics
 - [StarvingArtist](https://www.deviantart.com/starvingartist/): Game Console icons
-- [Mr. Start](https://github.com/Arthur-Start): Super Nintendo DS splash screen
-- [Absent-Reality](http://pixeljoint.com/p/19283.htm): Intellivision icon
-- [FlameKat53](https://github.com/FlameKat53): Manual icon for DSi theme's `SELECT` menu
-- [fail0verflow](https://github.com/fail0verflow/), Fluto, and Arkhandar: Homebrew Channel/Launcher graphics
-- davi: Border for GBC theme (originally for GameYob)
-- [NightScript](https://github.com/NightScript370/): Reworked Manual pages
 ## Music
-- IkaMusumeYiyaRoxie: General N64 MIDI Soundfont, used for the title splash fanfare
 - [BlastoiseVeteran](https://soundcloud.com/blastyveteran): Remastered version of Nintendo DSi Shop music
+- IkaMusumeYiyaRoxie: General N64 MIDI Soundfont, used for the title splash fanfare
 ## Sound
-- [Firexploit](https://github.com/Firexploit): 3DS UI sounds for the 3DS theme, which some are also used in the DSi theme.
 - [dbry](https://github.com/dbry): Xtreme Quality IMA-ADPCM decoder code from [adpcm-xq](https://github.com/dbry/adpcm-xq).
+- [Firexploit](https://github.com/Firexploit): 3DS UI sounds for the 3DS theme, which some are also used in the DSi theme.
 ## Others
-- [Arisotura](https://github.com/Arisotura): ROM list from melonDS, and BIOS dumper code from [dsibiosdumper](https://github.com/Arisotura/dsibiosdumper)
-- [profi200](https://github.com/profi200): Improved SD code from fastboot3DS
 - [ahezard](https://github.com/ahezard): NDMA code from nds-bootstrap
+- Another World & Yellow Wood Goblin: The original akMenu/Wood UI
+- [Arisotura](https://github.com/Arisotura): ROM list from melonDS, and BIOS dumper code from [dsibiosdumper](https://github.com/Arisotura/dsibiosdumper)
+- [devkitPro](https://github.com/devkitPro): Code used in nds-hb-menu, and the use of the bootloader, devkitARM, libnds, and libfat
 - [Gericom](https://github.com/Gericom), TrolleyDave, and FAST6191: GBA SRAM-patching code, used in gbapatcher ([SRAM patching thread at GBAtemp](https://gbatemp.net/threads/reverse-engineering-gba-patching.60168/))
 - Nikokaro: Found no-tilt patches for *WarioWare: Twisted!*, and *Yoshi Topsy-Turvy*. ([GBAtemp thread](https://gbatemp.net/threads/gba-no-tilt-patches-for-ds-users.584128/))
-- [devkitPro](https://github.com/devkitPro): Code used in nds-hb-menu, and the use of the bootloader, devkitARM, libnds, and libfat
-- Another World & Yellow Wood Goblin: The original akMenu/Wood UI
-- [NightScript](https://github.com/NightScript370): Code cleanup, added functionality for Acekard theme in regards to flashcards
-- [SNBeast](https://github.com/SNBeast): Unlaunch patches
+- [profi200](https://github.com/profi200): Improved SD code from fastboot3DS
+- RadDude McCoolguy, fintogive, KazoWAR, Vague Rant, [gamemasterplc](https://github.com/gamemasterplc), [Rocket Robz](https://github.com/RocketRobz), [ChampionLeake](https://github.com/ChampionLeake), [DeadSkullzJr](https://github.com/DeadSkullzJr), [spellboundtriangle](https://github.com/spellboundtriangle), [LedyBacer](https://github.com/LedyBacer): Widescreen cheats
 - retrogamefan & Rudolph: Included AP-patches for nds-bootstrap
    - [enler](https://github.com/enler): Fixing AP-patch for Pokemon Black 2 (Japan) for DS⁽ⁱ⁾ mode compatibility
    - [Rocket Robz](https://github.com/RocketRobz): Fixing some DS⁽ⁱ⁾-Enhanced game AP-patches for DS⁽ⁱ⁾ mode compatibility
-- fintogive, RadDude McCoolguy, KazoWAR, Vague Rant, [gamemasterplc](https://github.com/gamemasterplc), [Rocket Robz](https://github.com/RocketRobz), [ChampionLeake](https://github.com/ChampionLeake), [DeadSkullzJr](https://github.com/DeadSkullzJr), [spellboundtriangle](https://github.com/spellboundtriangle), [LedyBacer](https://github.com/LedyBacer): Widescreen Cheats
-- [Gericom](https://github.com/Gericom): [FastVideoDSPlayer](https://github.com/Gericom/FastVideoDSPlayer) for FastVideoDS video playback
-- [chishm](https://github.com/chishm): [tuna-viDS](https://github.com/chishm/tuna-vids) for Xvid video playback
+- [SNBeast](https://github.com/SNBeast): Unlaunch patches
 - Taiju Yamada: Code used to bypass R4i-SDHC boot file protection
-- [lifehackerhansol](https://github.com/lifehackerhansol): Improving support for flashcard autobooting and kernel loading
-- [DieGo](https://github.com/DieGo367): Adding support for custom ROM/folder icons and improvements for custom skins
 ## Translators
 - Arabic: [Ken Brown](https://crowdin.com/profile/kenkenkenneth), [SLG3](https://crowdin.com/profile/slg3)
 - Bulgarian: [Peter0x44](https://github.com/Peter0x44), [Tescu](https://crowdin.com/profile/tescu48)


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- This attempts to order all of the credits in alphabetical order, with some exceptions:
  - Rocket Robz is displayed first in Main Developers
  - Multiple people in a single credit is left more or less arbitrary, I moved some things around but it probably doesn't matter much?
  - Translations are left alone as they're ordered alphabetically by the language themselves already
- Also moves some things around and corrected some details, honestly can't remember everything & the diff doesn't help much since everything was reordered
- Moves @DieGo367, @lifehackerhansol, and @NightScript370's "Other" contributions to a new credits category, Secondary Developers
- Adds CrocoDS and AmeDS credits
- Other minor edits

#### Where have you tested it?

No changes to the code have been made.

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
