### PR TITLE
Improve in-game menu hotkey setting menu

### DIFF
--- a/settings/arm9/source/graphics/FontGraphic.cpp
+++ b/settings/arm9/source/graphics/FontGraphic.cpp
@@ -256,6 +256,7 @@ std::u16string FontGraphic::utf8to16(std::string_view text) {
 			c |=  text[i++] & 0x3F;
 		} else {
 			i++; // out of range or something (This only does up to 0xFFFF since it goes to a U16 anyways)
+			continue;
 		}
 		out += c;
 	}

--- a/settings/arm9/source/language.inl
+++ b/settings/arm9/source/language.inl
@@ -367,8 +367,10 @@ STRING(AB_SETBG, "\\A / \\B: Set background")
 STRING(AB_SETFONT, "\\A / \\B: Set font")
 
 STRING(HOLD_1S_SET, "Hold keys to set hotkey")
+STRING(HOLD_1S_DETAILS, "Hold at least two keys for 1 second.\nThe default is \\L \\DD SELECT.\nHold \\B to cancel.")
 STRING(TOUCH, "Touch")
 STRING(HOTKEY_SET, "Hotkey set!")
+STRING(HOTKEY_SETTING_CANCELLED, "Hotkey setting cancelled!")
 
 // STRING(SNES_EMULATOR, "Choose a SNES emulator")
 // STRING(DESCRIPTION_SNES_EMULATOR, "Choose whether you would rather use SNEmulDS or lolSNES.")

--- a/settings/nitrofiles/languages/en/language.ini
+++ b/settings/nitrofiles/languages/en/language.ini
@@ -350,5 +350,7 @@ AB_SETBG=\A / \B: Set background
 AB_SETFONT=\A / \B: Set font
 
 HOLD_1S_SET=Hold keys to set hotkey
+HOLD_1S_DETAILS=Hold at least two keys for 1 second.\nThe default is \L \DD SELECT.\nHold \B to cancel.
 TOUCH=Touch
 HOTKEY_SET=Hotkey set!
+HOTKEY_SETTING_CANCELLED=Hotkey setting cancelled!


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes hotkeys require at least two buttons (single button hotkeys could still be set manually in the INI if really wanted)
- Allows holding <kbd>B</kbd> to cancel and retain the previous hotkey
- Adds text stating as such
- Oh also fixed a couple unrelated warnings, should maybe have committed that separately whoops

#### Where have you tested it?

- no$gba

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
