### PR TITLE
Make Skin's the default music option for DSi themes

### DIFF
--- a/universal/source/common/twlmenusettings.cpp
+++ b/universal/source/common/twlmenusettings.cpp
@@ -47,7 +47,7 @@ TWLSettings::TWLSettings()
 	showSelectMenu = false;
 	theme = EThemeDSi;
 	settingsMusic = ESMusicTheme;
-	dsiMusic = EMusicRegular;
+	dsiMusic = EMusicTheme;
 	boxArtColorDeband = false;
 
 	gbaBooter = isDSiMode() ? EGbaGbar2 : EGbaNativeGbar2;


### PR DESCRIPTION
Closes #2072

<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Changes the enum so that skins are the default music option.

#### What were the results of the test?

According to tests by others, it actually breaks #2071. As such, that should get fixed before this gets merged, so this will be a draft PR until then

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
