### PR TITLE
Allow making the loading screen dark

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
@@ -20,7 +20,7 @@ ThemeConfig::ThemeConfig(bool _3dsDefaults)
 	// _photoRenderY(24), _photoRenderX(179),
 	_startTextUserPalette(true), _startBorderUserPalette(true), _buttonArrowUserPalette(true), _movingArrowUserPalette(true),
 	_launchDotsUserPalette(true), _dialogBoxUserPalette(true), _usernameUserPalette(true),
-	_purpleBatteryAvailable(false), _renderPhoto(true), _playStartupJingle(false), _startupJingleDelayAdjust(0),
+	_purpleBatteryAvailable(false), _renderPhoto(true), _darkLoading(false), _playStartupJingle(false), _startupJingleDelayAdjust(0),
 	_fontPalette1(0x0000), _fontPalette2(0xDEF7), _fontPalette3(0xC631), _fontPalette4(0xA108),
 	_fontPaletteTitlebox1(0x0000), _fontPaletteTitlebox2(0xDEF7), _fontPaletteTitlebox3(0xC631), _fontPaletteTitlebox4(0xA108),
 	_fontPaletteDialog1(0x0000), _fontPaletteDialog2(0xDEF7), _fontPaletteDialog3(0xC631), _fontPaletteDialog4(0xA108),
@@ -47,6 +47,7 @@ ThemeConfig::ThemeConfig(bool _3dsDefaults)
 
 	if (ms().theme == TWLSettings::EThemeSaturn || ms().theme == TWLSettings::EThemeHBL) {
 		_renderPhoto = false;
+		_darkLoading = true;
 	}
 }
 
@@ -113,6 +114,7 @@ void ThemeConfig::loadConfig() {
 	_purpleBatteryAvailable = getInt(themeConfig, "PurpleBatteryAvailable", _purpleBatteryAvailable);
 	_rotatingCubesRenderY = getInt(themeConfig, "RotatingCubesRenderY", _rotatingCubesRenderY);
 	_renderPhoto = getInt(themeConfig, "RenderPhoto", _renderPhoto);
+	_darkLoading = getInt(themeConfig, "DarkLoading", _darkLoading);
 
 	_playStartupJingle = getInt(themeConfig, "PlayStartupJingle", _playStartupJingle);
 	_startupJingleDelayAdjust = getInt(themeConfig, "StartupJingleDelayAdjust", _startupJingleDelayAdjust);

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
@@ -63,6 +63,7 @@ private:
 	bool _purpleBatteryAvailable;
 
 	bool _renderPhoto;
+	bool _darkLoading;
 	bool _playStartupJingle;
 	int _startupJingleDelayAdjust;
 
@@ -150,6 +151,7 @@ public:
 	bool purpleBatteryAvailable() const { return _purpleBatteryAvailable; }
 
 	bool renderPhoto() const { return _renderPhoto; }
+	bool darkLoading() const { return _darkLoading; }
 
 	bool playStartupJingle() const { return _playStartupJingle; }
 	int startupJingleDelayAdjust() const { return _startupJingleDelayAdjust; }

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -68,7 +68,6 @@ extern bool whiteScreen;
 extern bool fadeType;
 extern bool fadeSpeed;
 extern bool fadeSleep;
-extern bool fadeColor;
 extern bool controlTopBright;
 extern bool controlBottomBright;
 int fadeDelay = 0;
@@ -455,9 +454,9 @@ void vBlankHandler() {
 	}
 
 	if (controlBottomBright && renderFrame)
-		SetBrightness(0, fadeColor ? screenBrightness : -screenBrightness);
+		SetBrightness(0, tc().darkLoading() ? -screenBrightness : screenBrightness);
 	if (controlTopBright && !ms().macroMode && renderFrame)
-		SetBrightness(1, fadeColor ? screenBrightness : -screenBrightness);
+		SetBrightness(1, tc().darkLoading() ? -screenBrightness : screenBrightness);
 
 	if (showdialogbox) {
 		// Dialogbox moving into view...
@@ -989,7 +988,7 @@ void vBlankHandler() {
 				}
 			}*/
 		if (whiteScreen) {
-			glBoxFilled(0, 0, 256, 192, RGB15(31, 31, 31));
+			glBoxFilled(0, 0, 256, 192, tc().darkLoading() ? RGB15(0, 0, 0) : RGB15(31, 31, 31));
 		}
 		if (showProgressIcon && ms().theme != TWLSettings::EThemeSaturn) {
 			glSprite(ms().rtl() ? 16 : 224, 152, GL_FLIP_NONE, &tex().progressImage()[progressAnimNum]);
@@ -1003,12 +1002,12 @@ void vBlankHandler() {
 			}
 			int fillColor = ms().colorMode == 1 ? convertVramColorToGrayscale(RGB15(0, 0, 31)) : RGB15(0, 0, 31);
 			if (ms().rtl()) {
-				glBoxFilled(barXpos, barYpos, barXpos-192, barYpos+5, RGB15(23, 23, 23));
+				glBoxFilled(barXpos, barYpos, barXpos-192, barYpos+5, tc().darkLoading() ? RGB15(6, 6, 6) : RGB15(23, 23, 23));
 				if (progressBarLength > 0) {
 					glBoxFilled(barXpos, barYpos, barXpos-progressBarLength, barYpos+5, fillColor);
 				}
 			} else {
-				glBoxFilled(barXpos, barYpos, barXpos+192, barYpos+5, RGB15(23, 23, 23));
+				glBoxFilled(barXpos, barYpos, barXpos+192, barYpos+5, tc().darkLoading() ? RGB15(6, 6, 6) : RGB15(23, 23, 23));
 				if (progressBarLength > 0) {
 					glBoxFilled(barXpos, barYpos, barXpos+progressBarLength, barYpos+5, fillColor);
 				}

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -71,7 +71,6 @@ bool whiteScreen = true;
 bool fadeType = false; // false = out, true = in
 bool fadeSpeed = true; // false = slow (for DSi launch effect), true = fast
 bool fadeSleep = false;
-bool fadeColor = true; // false = black, true = white
 bool controlTopBright = true;
 bool controlBottomBright = true;
 bool widescreenFound = false;
@@ -968,7 +967,6 @@ int main(int argc, char **argv) {
 
 	if (ms().theme == TWLSettings::EThemeSaturn || ms().theme == TWLSettings::EThemeHBL) {
 		whiteScreen = false;
-		fadeColor = false;
 	}
 
 	langInit();

--- a/romsel_dsimenutheme/nitrofiles/themes/hbLauncher/default/theme.ini
+++ b/romsel_dsimenutheme/nitrofiles/themes/hbLauncher/default/theme.ini
@@ -47,6 +47,7 @@ MovingArrowUserPalette	= 1
 LaunchDotsUserPalette	= 1
 DialogBoxUserPalette	= 1
 RenderPhoto				= 0
+DarkLoading				= 1
 
 [MACRO]
 TitleboxTextY	= 38

--- a/romsel_dsimenutheme/nitrofiles/themes/saturn/default/theme.ini
+++ b/romsel_dsimenutheme/nitrofiles/themes/saturn/default/theme.ini
@@ -49,6 +49,7 @@ MovingArrowUserPalette	= 1
 LaunchDotsUserPalette	= 1
 DialogBoxUserPalette	= 1
 RenderPhoto				= 0
+DarkLoading				= 1
 
 [MACRO]
 TitleboxTextY	= 38


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Makes it so you can make the loading screen dark, like the HBL and Saturn themes, in any skin

#### Where have you tested it?

- DSi (K) from Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
