### PR TITLE
Add missed INI setting for RTS-compatible flashcart loaders

### DIFF
--- a/7zfile/Flashcard users/Flashcart Loader/R4i Gold 1.64/_wfwd/globalsettings.ini
+++ b/7zfile/Flashcard users/Flashcart Loader/R4i Gold 1.64/_wfwd/globalsettings.ini
@@ -3,3 +3,4 @@ uiName = void
 langDirectory = English
 saveext = .sav
 autorunWithLastRom  = 1
+rts = 1

--- a/7zfile/Flashcard users/Flashcart Loader/R4iDSN/_wfwd/globalsettings.ini
+++ b/7zfile/Flashcard users/Flashcart Loader/R4iDSN/_wfwd/globalsettings.ini
@@ -3,3 +3,4 @@ uiName = void
 langDirectory = English
 saveext = .sav
 autorunWithLastRom  = 1
+rts = 1


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Set `rts=1` on flashcarts that need it for RTS. It was missed, so kernel assumed 0.
- Closes #2147 

#### Where have you tested it?

- R4iDSN

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
    - no source code changes