### PR TITLE
Font crash fix: check next location != 0

### DIFF
--- a/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/FontGraphic.cpp
@@ -163,7 +163,7 @@ FontGraphic::FontGraphic(const char* path, bool useExpansionPak) : useExpansionP
 		u32 locPAMC, mapType;
 		fread(&locPAMC, 4, 1, file);
 
-		while (locPAMC < fileSize) {
+		while (locPAMC && locPAMC < fileSize) {
 			u16 firstChar, lastChar;
 			fseek(file, locPAMC, SEEK_SET);
 			fread(&firstChar, 2, 1, file);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Fixes a possible crash that occurs because of the way font loading checks for the next character map.

Details since I found it kind of interesting:
When loading the location of the next character map, a value of 0 is supposed to indicate no further maps exist. The previous code ignores this and just checks if the location given is within the file size. This causes it to jump to the start of the file and treat it like a character map. The "map type" it finds doesn't match any of the 3 existing types, so no additional characters are mapped. Then it checks for the next map location again, and where it reads this from the second time coincidentally lines up with where an NFTR font usually stores its resource size. For most fonts, this value will fail the loop condition and stop, so this bug has gone unnoticed. But if a font reports an incorrect file size that was lower than in actuality, then the code just jumps randomly and endlessly looking for character maps.

#### Where have you tested it?

melonDS 0.9.5

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
