### PR TITLE
Add ESRB Ratings for more DS games

### DIFF
--- a/romsel_dsimenutheme/nitrofiles/ESRB.ini
+++ b/romsel_dsimenutheme/nitrofiles/ESRB.ini
@@ -41,6 +41,10 @@ Game Title = Assassin's Creed II: Discovery
 Rating = T
 Descriptors en = Violence
 
+[BBY]
+Game Title = The Backyardigans
+Rating = E
+
 [AY6]
 Game Title = Bangai-O Spirits
 Rating = E10
@@ -289,6 +293,10 @@ Descriptors en = Blood, Drug Reference, Mild Language, Mild Sexual Themes, Viole
 Game Title = Diary Girl
 Rating = E
 
+[ADD]
+Game Title = Dig Dug: Digging Strike
+Rating = E
+
 [YDI]
 Game Title = Digimon World Championship
 Rating = E
@@ -490,6 +498,10 @@ Game Title = Foto Showdown
 Rating = E
 Descriptors en = Mild Fantasy Violence
 
+[CF3]
+Game Title = Freddi Fish: ABC Under the Sea
+Rating = EC
+
 [TFB]
 Game Title = Frozen: Olaf's Quest
 Rating = E
@@ -593,6 +605,22 @@ Rating = E
 Game Title = Hotel Dusk: Room 215
 Rating = T
 Descriptors en = Mild Language, Mild Violence, Use of Alcohol
+
+[B7E]
+Game Title = I SPY Castle
+Rating = E
+
+[YP5]
+Game Title = I SPY Fun House
+Rating = E
+
+[TGS]
+Game Title = I SPY Game Pack
+Rating = E
+
+[BIU]
+Game Title = I SPY Universe
+Rating = E
 
 [AIA]
 Game Title = Ice Age 2 The Meltdown Video Game
@@ -960,6 +988,10 @@ Rating = E
 Game Title = Miss Spider's Sunny Patch Friends - Harvest Time Hop and Fly
 Rating = E
 
+[ADR]
+Game Title = Mr. Driller Drill Spirits
+Rating = E
+
 [YNM]
 Game Title = Namco Museum DS
 Rating = E
@@ -1045,6 +1077,15 @@ Descriptors en = Mild Cartoon Violence
 [APN]
 Game Title = Pac'N Roll
 Rating = E
+
+[APC]
+Game Title = Pac-Pix
+Rating = E
+
+[CNV]
+Game Title = Personal Trainer: Cooking
+Rating = E
+Descriptors en = Alcohol Reference
 
 [C24]
 Game Title = Phantasy Star Zero
@@ -1383,6 +1424,7 @@ Descriptors en = Mild Cartoon Violence
 [VSO]
 Game Title = Sonic Classic Collection
 Rating = E
+Descriptors en = Comic Mischief
 
 [BXS]
 Game Title = Sonic Colors
@@ -1451,6 +1493,16 @@ Game Title = Spider-Man: Web of Shadows
 Rating = E10
 Descriptors en = Mild Cartoon Violence
 
+[AL3]
+Game Title = SpongeBob's Atlantis SquarePantis
+Rating = E
+Descriptors en = Mild Cartoon Violence
+
+[BSO]
+Game Title = SpongeBob's Truth or Square
+Rating = E
+Descriptors en = Mild Cartoon Violence
+
 [ASF]
 Game Title = Starfox Command
 Rating = E10
@@ -1493,6 +1545,10 @@ Descriptors en = Comic Mischief
 Game Title = System Flaw
 Rating = E
 Descriptors en = Fantasy Violence
+
+[B55]
+Game Title = Team Umizoomi
+Rating = EC
 
 [ACU]
 Game Title = Tenchu: Dark Secret
@@ -1580,6 +1636,11 @@ Game Title = The Urbz: Sims in the City
 Rating = E
 Descriptors en = Crude Humor, Mild Violence, Suggestive Themes
 
+[CP3]
+Game Title = Viva Piñata: Pocket Paradise
+Rating = E
+Descriptors en = Comic Mischief
+
 [CBK]
 Game Title = Walt Disney Pictures Bolt
 Rating = E
@@ -1594,6 +1655,11 @@ Descriptors en = Cartoon Violence
 Game Title = Wario: Master of Disguise
 Rating = E10
 Descriptors en = Crude Humor, Mild Cartoon Violence
+
+[UOR]
+Game Title = WarioWare: D.I.Y.
+Rating = E
+Descriptors en = Comic Mischief, Mild Cartoon Violence
 
 [AZW]
 Game Title = WarioWare: Touched!

--- a/romsel_dsimenutheme/nitrofiles/ESRB.ini
+++ b/romsel_dsimenutheme/nitrofiles/ESRB.ini
@@ -873,6 +873,10 @@ Game Title = The Magic School Bus: Oceans
 Rating = E
 Descriptors en = Comic Mischief
 
+[APL]
+Game Title = Magnetica
+Rating = E
+
 [CLJ]
 Game Title = Mario and Luigi: Bowser's Inside Story
 Rating = E
@@ -1013,6 +1017,11 @@ Rating = E
 Game Title = Miss Spider's Sunny Patch Friends - Harvest Time Hop and Fly
 Rating = E
 
+[CFM]
+Game Title = Monster Rancher DS
+Rating = E
+Descriptors en = Mild Fantasy Violence, Mild Suggestive Themes
+
 [ADR]
 Game Title = Mr. Driller Drill Spirits
 Rating = E
@@ -1147,6 +1156,10 @@ Rating = E
 
 [A8N]
 Game Title = Planet Puzzle League
+Rating = E
+
+[ASN]
+Game Title = Polarium
 Rating = E
 
 [IRB]
@@ -1328,6 +1341,26 @@ Game Title = Rainbow Islands Revolution
 Rating = E
 Descriptors en = Comic Mischief
 
+[ARY]
+Game Title = Rayman DS
+Rating = E
+Descriptors en = Mild Violence
+
+[AR5]
+Game Title = Rayman Raving Rabbids
+Rating = E
+Descriptors en = Mild Cartoon Violence
+
+[YRR]
+Game Title = Rayman Raving Rabbids 2
+Rating = E10
+Descriptors en = Crude Humor, Mild Cartoon Violence
+
+[CRI]
+Game Title = Rayman Raving Rabbids TV Party
+Rating = E10
+Descriptors en = Comic Mischief
+
 [ABH]
 Game Title = Resident Evil Deadly Silence
 Rating = M
@@ -1385,6 +1418,22 @@ Rating = E
 Game Title = SEGA Superstars Tennis™
 Rating = E
 Descriptors en = Mild Cartoon Violence
+
+[BSR]
+Game Title = Sesame Street: Cookie's Counting Carnival
+Rating = EC
+
+[BER]
+Game Title = Sesame Street: Elmo's A-to-Zoo Adventure
+Rating = EC
+
+[B6L]
+Game Title = Sesame Street: Elmo's Musical Monsterpiece
+Rating = EC
+
+[BYT]
+Game Title = Sesame Street: Ready, Set, Grover! With Elmo
+Rating = EC
 
 [CVI]
 Game Title = Shin Megami Tensei: Devil Survivor
@@ -1533,10 +1582,43 @@ Game Title = SpongeBob's Atlantis SquarePantis
 Rating = E
 Descriptors en = Mild Cartoon Violence
 
+[VBV]
+Game Title = SpongeBob's Boating Bash
+Rating = E
+Descriptors en = Comic Mischief
+
+[B6B]
+Game Title = SpongeBob's Surf & Skate Roadtrip
+Rating = E
+
 [BSO]
 Game Title = SpongeBob's Truth or Square
 Rating = E
 Descriptors en = Mild Cartoon Violence
+
+[AQ4]
+Game Title = SpongeBob SquarePants: Creature from the Krusty Krab
+Rating = E
+Descriptors en = Comic Mischief
+
+[CS9]
+Game Title = SpongeBob SquarePants featuring Nicktoons: Globs of Doom
+Rating = E
+Descriptors en = Mild Cartoon Violence
+
+[TLU]
+Game Title = SpongeBob SquarePants: Plankton's Robotic Revenge
+Rating = E
+Descriptors en = Cartoon Violence
+
+[AS9]
+Game Title = SpongeBob SquarePants: The Yellow Avenger
+Rating = E
+Descriptors en = Comic Mischief, Mild Cartoon Violence
+
+[CCK]
+Game Title = SpongeBob vs. The Big One: Beach Party Cook-Off
+Rating = E
 
 [ASF]
 Game Title = Starfox Command

--- a/romsel_dsimenutheme/nitrofiles/ESRB.ini
+++ b/romsel_dsimenutheme/nitrofiles/ESRB.ini
@@ -133,6 +133,10 @@ Game Title = Big Bang Mini
 Rating = E
 Descriptors en = Mild Fantasy Violence
 
+[AYA]
+Game Title = Big Brain Academy
+Rating = E
+
 [TB6]
 Game Title = Big Hero 6: Battle in the Bay
 Rating = E10
@@ -156,6 +160,14 @@ Descriptors en = Comic Mischief
 Game Title = Bomberman Land Touch! 2
 Rating = E
 Descriptors en = Comic Mischief
+
+[AND]
+Game Title = Brain Age: Train Your Brain in Minutes a Day!
+Rating = E
+
+[ANM]
+Game Title = Brain Age 2: More Training in Minutes a Day!
+Rating = E
 
 [TBG]
 Game Title = Bubble Guppies
@@ -274,6 +286,10 @@ Game Title = Crafting Mama
 Rating = E
 Descriptors en = Comic Mischief
 
+[YCU]
+Game Title = Crosswords DS
+Rating = E
+
 [VC6]
 Game Title = CSI: Crime Scene Investigation: Unsolved!
 Rating = T
@@ -348,6 +364,11 @@ Rating = E
 Game Title = Disney Two Pack - Frozen: Olaf's Quest + Big Hero 6: Battle in the Bay
 Rating = E10
 Descriptors en = Cartoon Violence, Comic Mischief
+
+[ABU]
+Game Title = DK: Jungle Climber
+Rating = E
+Descriptors en = Comic Mischief
 
 [ADB]
 Game Title = Dragon Ball Z: Supersonic Warriors 2
@@ -482,6 +503,10 @@ Descriptors en = Alcohol Reference, Fantasy Violence, Mild Suggestive Themes
 Game Title = Fire Emblem: Shadow Dragon
 Rating = E10
 Descriptors en = Mild Fantasy Violence, Mild Language
+
+[AG3]
+Game Title = Flash Focus: Vision Training in Minutes a Day
+Rating = E
 
 [YKH]
 Game Title = Fossil Fighters
@@ -1254,6 +1279,11 @@ Game Title = Professor Layton and the Unwound Future
 Rating = E10
 Descriptors en = Mild Violence
 
+[BKQ]
+Game Title = Pucca Power Up
+Rating = E
+Descriptors en = Mild Cartoon Violence
+
 [YPH]
 Game Title = Puzzle de Harvest Moon
 Rating = E
@@ -1277,6 +1307,11 @@ Descriptors en = Mild Fantasy Violence, Mild Language, Mild Suggestive Themes
 Game Title = Puyo Pop Fever
 Rating = E
 Descriptors en = Mild Language
+
+[AM7]
+Game Title = QuickSpot
+Rating = E10
+Descriptors en = Comic Mischief, Mild Suggestive Themes, Use of Tobacco
 
 [VRG]
 Game Title = Rabbids Go Home


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

I edited the `ESRB.ini` file to include more entries. (There might be some games added to the list that already have ESRB ratings embedded within the ROM, so let me or Rocket Robz know so they can be removed from the list. We might need to display the ESRB rating no more than just one time.)

#### Where have you tested it?

I've tested it on my North American New Nintendo 2DS XL running TWiLightMenu++ v25.8.1 (latest release build) via Luma3DS CFW, verifying games I own to show ESRB ratings, some with content descriptors.

***

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
