### PR TITLE
Remove unnecessary files from nightly 7Zs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -65,9 +65,13 @@ jobs:
           # Make artifacts directory
           mkdir -p ~/artifacts
 
-          # Don't include fonts or debug files in nightlies
+          # Don't include unnecessary files in nightlies
           rm -rf 7zfile/_nds/TWiLightMenu/extras/fonts
           rm -rf 7zfile/debug
+          rm -rf 7zfile/roms
+          rm "7zfile/3DS - CFW users/Games supported with widescreen.txt"
+          rm "7zfile/AP-patched games.txt"
+          rm 7zfile/snemul.cfg
 
           cp -r 7zfile/ TWiLightMenu/
           7z a TWiLightMenu.7z TWiLightMenu/


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Removes the following from nightly `.7z` files as they're not really that important for nightlies:
- `roms`
- 3DS - CFW users/Games supported with widescreen.txt
- AP-patched games.txt
- snemul.cfg

None of these use that much space, but this allows Universal-Updater to keep its simple 'extract everything' script for nightlies. imo if it's not worth extracting it's not worth downloading.

#### Where have you tested it?

- Untested, Actions will run on the PR

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
