### PR TITLE
Add ESRB Ratings for Multiple Titles

### DIFF
--- a/romsel_dsimenutheme/nitrofiles/ESRB.ini
+++ b/romsel_dsimenutheme/nitrofiles/ESRB.ini
@@ -1,3 +1,8 @@
+[C32]
+Game Title = Ace Attorney Investigations: Miles Edgeworth
+Rating = T
+Descriptors en = Blood, Mild Language, Mild Suggestive Themes, Mild Violence
+
 [YW2]
 Game Title = Advance Wars: Days of Ruin
 Rating = E10
@@ -48,6 +53,11 @@ Descriptors en = Violence
 [BBY]
 Game Title = The Backyardigans
 Rating = E
+
+[BGH]
+Game Title = Band Hero
+Rating = E10
+Descriptors en = Lyrics
 
 [AY6]
 Game Title = Bangai-O Spirits
@@ -285,6 +295,11 @@ Game Title = Coraline
 Rating = E
 Descriptors en = Mild Cartoon Violence, Mild Suggestive Themes
 
+[YIH]
+Game Title = Cory in the House
+Rating = E
+Descriptors en = Comic Mischief
+
 [BQ8]
 Game Title = Crafting Mama
 Rating = E
@@ -342,9 +357,33 @@ Game Title = Diddy Kong Racing DS
 Rating = E
 Descriptors en = Mild Cartoon Violence
 
+[A3E]
+Game Title = Diner Dash: Sizzle and Serve
+Rating = E
+
+[VAL]
+Game Title = Disney Alice in Wonderland
+Rating = E10
+Descriptors en = Mild Cartoon Violence
+
 [CY9]
 Game Title = Disney Club Penguin: Elite Penguin Force: Herbert's Revenge
 Rating = E
+
+[B5V]
+Game Title = Disney Phineas and Ferb: Across the 2nd Dimension
+Rating = E
+Descriptors en = Mild Cartoon Violence
+
+[VPF]
+Game Title = Disney Phineas and Ferb: Ride Again
+Rating = E
+Descriptors en = Mild Cartoon Violence
+
+[BW4]
+Game Title = Disney Wizards of Waverly Place: Spellbound
+Rating = E
+Descriptors en = Comic Mischief
 
 [AK6]
 Game Title = Disney's Kim Possible: Global Gemini
@@ -540,6 +579,11 @@ Descriptors en = Comic Mischief
 Game Title = Geometry Wars: Galaxies
 Rating = E
 
+[BGT]
+Game Title = GHOST TRICK: Phantom Detective
+Rating = T
+Descriptors en = Mild Language, Mild Violence
+
 [BZI]
 Game Title = Giana Sisters DS
 Rating = E
@@ -569,6 +613,21 @@ Descriptors en = Blood and Gore, Drug Reference, Sexual Content, Strong Language
 Game Title = Grease DS
 Rating = E10
 Descriptors en = Language, Mild Lyrics
+
+[YGH]
+Game Title = Guitar Hero: On Tour
+Rating = E10
+Descriptors en = Lyrics
+
+[CGS]
+Game Title = Guitar Hero On Tour: Decades
+Rating = E10
+Descriptors en = Lyrics
+
+[C6Q]
+Game Title = Guitar Hero On Tour: Modern Hits
+Rating = E10
+Descriptors en = Lyrics
 
 [ABC]
 Game Title = Harvest Moon DS
@@ -833,6 +892,11 @@ Game Title = LEGO The Lord of the Rings
 Rating = E10
 Descriptors en = Cartoon Violence
 
+[CLR]
+Game Title = Line Rider 2: Unbound
+Rating = E
+Descriptors en = Comic Mischief
+
 [YK6]
 Game Title = LOL
 Rating = E
@@ -1035,6 +1099,16 @@ Game Title = Monster Rancher DS
 Rating = E
 Descriptors en = Mild Fantasy Violence, Mild Suggestive Themes
 
+[AQI]
+Game Title = MySims
+Rating = E
+Descriptors en = Simulated Gambling
+
+[CMS]
+Game Title = MySims Party
+Rating = E
+Descriptors en = Cartoon Violence
+
 [ADR]
 Game Title = Mr. Driller Drill Spirits
 Rating = E
@@ -1143,6 +1217,10 @@ Rating = E
 Game Title = Pac-Pix
 Rating = E
 
+[C7P]
+Game Title = Peggle Dual Shot
+Rating = E
+
 [CNV]
 Game Title = Personal Trainer: Cooking
 Rating = E
@@ -1156,6 +1234,11 @@ Rating = E
 Game Title = Phantasy Star Zero
 Rating = E10
 Descriptors en = Fantasy Violence, Mild Suggestive Themes
+
+[CFP]
+Game Title = Phineas and Ferb
+Rating = E
+Descriptors en = Comic Mischief
 
 [AGY]
 Game Title = Phoenix Wright: Ace Attorney
@@ -1818,6 +1901,11 @@ Descriptors en = Cartoon Violence, Crude Humor
 Game Title = The Wizard of Oz: Beyond the Yellow Brick Road
 Rating = E
 Descriptors en = Mild Fantasy Violence
+
+[CY7]
+Game Title = Wizards of Waverly Place
+Rating = E
+Descriptors en = Comic Mischief
 
 [AWL]
 Game Title = The World Ends with You


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
<!-- Describe what you've changed. -->
I have edited the `ESRB.ini` file to include more ratings for multiple titles. The list of titles are as follows:
- Ace Attorney Investigations: Miles Edgeworth
- Band Hero
- Cory in the House
- Diner Dash: Sizzle and Serve
- Disney Alice in Wonderland
- Disney Phineas and Ferb: Across the 2nd Dimension
- Disney Phineas and Ferb: Ride Again
- Disney Wizards of Waverly Place: Spellbound
- GHOST TRICK: Phantom Detective
- Guitar Hero: On Tour
- Guitar Hero On Tour: Decades
- Guitar Hero On Tour: Modern Hits
- Line Rider 2: Unbound
- MySims
- MySims Party
- Peggle Dual Shot
- Phineas and Ferb
- Wizards of Waverly Place

All titles, except for the following, reflect their names on the ESRB's online game ratings search:
- Band Hero (as "Band Hero DS" is not reflected on the box art, nor in-game)
- Line Rider 2: Unbound (as "Line Rider 2.0: Unbound" is not reflected on the box art, nor in-game)
#### Where have you tested it?
<!-- Specify where you've tested it. -->
TWLMenu v25.11.0 (nightly 6ff57ce6b33b1fa4fcb31bb9c3d61118397c08d4), nds-bootstrap v0.72.1, DSLite on an Acekard2i.
***

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
