### PR TITLE
treewide: replace SNDEXCNT define with libnds REG_SNDEXTCNT define

### DIFF
--- a/3dssplash/arm7/source/main.c
+++ b/3dssplash/arm7/source/main.c
@@ -36,7 +36,6 @@ void my_installSystemFIFO(void);
 
 #define BIT_SET(c, n) ((c) << (n))
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int status = 0;
@@ -116,7 +115,7 @@ int main() {
 
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 	
 
 	// 03: Status: Init/Volume/Battery/SD
@@ -124,9 +123,9 @@ int main() {
 	// Battery is 7 bits -- bits 0-7
 	// Volume is 00h to 1Fh = 5 bits -- bits 8-12
 	// SD status -- bits 13-14
-	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): sndExcnt)
+	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): REG_SNDEXTCNT)
 
-	u8 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT) 
+	u8 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT) 
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT) 
 									| BIT_SET(!!(readCommand & BIT(4) || readCommand & BIT(5) || readCommand & BIT(6) || readCommand & BIT(7)), DSLITE_BIT));
 

--- a/booter_fc/arm7/source/main.c
+++ b/booter_fc/arm7/source/main.c
@@ -31,8 +31,6 @@
 
 void my_installSystemFIFO(void);
 
-#define SNDEXCNT (*(vu16*)0x4004700)
-
 //---------------------------------------------------------------------------------
 void ReturntoDSiMenu() {
 //---------------------------------------------------------------------------------
@@ -106,7 +104,7 @@ int main() {
 	setPowerButtonCB(powerButtonCB);
 
 	bool isRegularDS = true; 
-	if (SNDEXCNT != 0) isRegularDS = false; // If sound frequency setting is found, then the console is not a DS Phat/Lite
+	if (REG_SNDEXTCNT != 0) isRegularDS = false; // If sound frequency setting is found, then the console is not a DS Phat/Lite
 	fifoSendValue32(FIFO_USER_07, isRegularDS);
 	// Keep the ARM7 mostly idle
 	while (!exitflag) {

--- a/imageview/arm7/source/main.c
+++ b/imageview/arm7/source/main.c
@@ -36,7 +36,6 @@ void my_installSystemFIFO(void);
 
 #define BIT_SET(c, n) ((c) << (n))
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int status = 0;
@@ -119,7 +118,7 @@ int main() {
 
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 	
 
 	// 03: Status: Init/Volume/Battery/SD
@@ -127,9 +126,9 @@ int main() {
 	// Battery is 7 bits -- bits 0-7
 	// Volume is 00h to 1Fh = 5 bits -- bits 8-12
 	// SD status -- bits 13-14
-	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): sndExcnt)
+	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): REG_SNDEXTCNT)
 
-	u8 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT) 
+	u8 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT) 
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT) 
 									| BIT_SET(!!(readCommand & BIT(4) || readCommand & BIT(5) || readCommand & BIT(6) || readCommand & BIT(7)), DSLITE_BIT));
 

--- a/manual/arm7/source/main.c
+++ b/manual/arm7/source/main.c
@@ -36,7 +36,6 @@ void my_installSystemFIFO(void);
 
 #define BIT_SET(c, n) ((c) << (n))
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int status = 0;
@@ -119,7 +118,7 @@ int main() {
 
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 	
 
 	// 03: Status: Init/Volume/Battery/SD
@@ -127,9 +126,9 @@ int main() {
 	// Battery is 7 bits -- bits 0-7
 	// Volume is 00h to 1Fh = 5 bits -- bits 8-12
 	// SD status -- bits 13-14
-	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): sndExcnt)
+	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): REG_SNDEXTCNT)
 
-	u8 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT) 
+	u8 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT) 
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT) 
 									| BIT_SET(!!(readCommand & BIT(4) || readCommand & BIT(5) || readCommand & BIT(6) || readCommand & BIT(7)), DSLITE_BIT));
 

--- a/quickmenu/arm7/source/main.c
+++ b/quickmenu/arm7/source/main.c
@@ -42,7 +42,6 @@ u8 my_i2cWriteRegister(u8 device, u8 reg, u8 data);
 
 #define BIT_SET(c, n) ((c) << (n))
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int timeTilVolumeLevelRefresh = 0;
@@ -80,7 +79,7 @@ void ReturntoDSiMenu() {
 //---------------------------------------------------------------------------------
 void changeBacklightLevel() {
 //---------------------------------------------------------------------------------
-	if (SNDEXCNT == 0) {
+	if (REG_SNDEXTCNT == 0) {
 		backlightLevel++;
 		if (backlightLevel > 3) {
 			backlightLevel = 0;
@@ -235,7 +234,7 @@ int main() {
 
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 
 
 	// 03: Status: Init/Volume/Battery/SD
@@ -243,16 +242,16 @@ int main() {
 	// Battery is 7 bits -- bits 0-7
 	// Volume is 00h to 1Fh = 5 bits -- bits 8-12
 	// SD status -- bits 13-14
-	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): sndExcnt)
+	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): REG_SNDEXTCNT)
 
-	u8 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT)
+	u8 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT)
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT)
 									| BIT_SET(!!(pmBacklight & BIT(4) || pmBacklight & BIT(5) || pmBacklight & BIT(6) || pmBacklight & BIT(7)), DSLITE_BIT));
 
 	status = (status & ~INIT_MASK) | ((initStatus << INIT_OFF) & INIT_MASK);
 	fifoSendValue32(FIFO_USER_03, status);
 
-	if (SNDEXCNT == 0) {
+	if (REG_SNDEXTCNT == 0) {
 		if (pmBacklight & 0xF0) // DS Lite
 			backlightLevel = pmBacklight & 3; // Brightness
 	}
@@ -267,7 +266,7 @@ int main() {
 		if ((REG_KEYINPUT & (KEY_SELECT | KEY_START | KEY_L | KEY_R)) == 0) {
 			exitflag = true;
 		}
-		if (SNDEXCNT == 0) {
+		if (REG_SNDEXTCNT == 0) {
 			*(int*)0x02003000 = backlightLevel;
 		}
 		if (isDSiMode() && *(u8*)(0x02FFFD00) != 0xFF) {

--- a/romsel_aktheme/arm7/source/arm7status.h
+++ b/romsel_aktheme/arm7/source/arm7status.h
@@ -2,7 +2,7 @@
 #ifndef A7STAT_H
 #define A7STAT_H
 
-#define SNDEXCNT_BIT 2
+#define SNDEXTCNT_BIT 2
 #define REGSCFG_BIT 1
 #define DSLITE_BIT 0
 

--- a/romsel_aktheme/arm7/source/main.c
+++ b/romsel_aktheme/arm7/source/main.c
@@ -37,7 +37,6 @@
 void my_touchInit();
 void my_installSystemFIFO(void);
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int soundVolume = 127;
@@ -136,7 +135,7 @@ int main() {
 	
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 	
 
 	// 05: Volume/Battery/SD
@@ -147,7 +146,7 @@ int main() {
 
 	u8 readCommand = readPowerManagement(4);
 
-	u32 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT) 
+	u32 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT) 
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT) 
 									| BIT_SET(!!(readCommand & BIT(4) || readCommand & BIT(5) || readCommand & BIT(6) || readCommand & BIT(7)), DSLITE_BIT));
 

--- a/romsel_aktheme/arm9/source/common/arm7status.h
+++ b/romsel_aktheme/arm9/source/common/arm7status.h
@@ -2,7 +2,7 @@
 #ifndef A7STAT_H
 #define A7STAT_H
 
-#define SNDEXCNT_BIT 2
+#define SNDEXTCNT_BIT 2
 #define REGSCFG_BIT 1
 #define DSLITE_BIT 0
 

--- a/romsel_aktheme/arm9/source/common/systemdetails.cpp
+++ b/romsel_aktheme/arm9/source/common/systemdetails.cpp
@@ -34,7 +34,7 @@ SystemDetails::SystemDetails()
 
     fifoWaitValue32(FIFO_USER_03);
 
-    // status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+    // status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
     u32 status = ((fifoGetValue32(FIFO_USER_03)) >> INIT_OFF);
 
     if (CHECK_BIT(status, REGSCFG_BIT) == 0) 
@@ -42,7 +42,7 @@ SystemDetails::SystemDetails()
         _arm7SCFGLocked = true; // If TWiLight Menu++ is being run from DSiWarehax or flashcard, then arm7 SCFG is locked.
     }
 
-    if (CHECK_BIT(status, SNDEXCNT_BIT) != 0)
+    if (CHECK_BIT(status, REG_SNDEXTCNT_BIT) != 0)
     {
         _isRegularDS = false; // If sound frequency setting is found, then the console is not a DS Phat/Lite
     }

--- a/romsel_dsimenutheme/arm7/source/main.c
+++ b/romsel_dsimenutheme/arm7/source/main.c
@@ -40,7 +40,6 @@ u8 my_i2cWriteRegister(u8 device, u8 reg, u8 data);
 
 #define BIT_SET(c, n) ((c) << (n))
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int timeTilVolumeLevelRefresh = 0;
@@ -150,7 +149,7 @@ int main() {
 
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 	
 
 	// 03: Status: Init/Volume/Battery/SD
@@ -158,16 +157,16 @@ int main() {
 	// Battery is 7 bits -- bits 0-7
 	// Volume is 00h to 1Fh = 5 bits -- bits 8-12
 	// SD status -- bits 13-14
-	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): sndExcnt)
+	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): REG_SNDEXTCNT)
 
-	u8 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT) 
+	u8 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT) 
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT) 
 									| BIT_SET(!!(pmBacklight & BIT(4) || pmBacklight & BIT(5) || pmBacklight & BIT(6) || pmBacklight & BIT(7)), DSLITE_BIT));
 
 	status = (status & ~INIT_MASK) | ((initStatus << INIT_OFF) & INIT_MASK);
 	fifoSendValue32(FIFO_USER_03, status);
 
-	if (SNDEXCNT == 0) {
+	if (REG_SNDEXTCNT == 0) {
 		if (pmBacklight & 0xF0) { // DS Lite
 			int backlightLevel = pmBacklight & 3; // Brightness
 			*(int*)0x02003000 = backlightLevel;

--- a/romsel_r4theme/arm7/source/main.c
+++ b/romsel_r4theme/arm7/source/main.c
@@ -40,7 +40,6 @@ u8 my_i2cWriteRegister(u8 device, u8 reg, u8 data);
 
 #define BIT_SET(c, n) ((c) << (n))
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int timeTilVolumeLevelRefresh = 0;
@@ -150,7 +149,7 @@ int main() {
 
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 	
 
 	// 03: Status: Init/Volume/Battery/SD
@@ -158,16 +157,16 @@ int main() {
 	// Battery is 7 bits -- bits 0-7
 	// Volume is 00h to 1Fh = 5 bits -- bits 8-12
 	// SD status -- bits 13-14
-	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): sndExcnt)
+	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): REG_SNDEXTCNT)
 
-	u8 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT) 
+	u8 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT) 
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT) 
 									| BIT_SET(!!(pmBacklight & BIT(4) || pmBacklight & BIT(5) || pmBacklight & BIT(6) || pmBacklight & BIT(7)), DSLITE_BIT));
 
 	status = (status & ~INIT_MASK) | ((initStatus << INIT_OFF) & INIT_MASK);
 	fifoSendValue32(FIFO_USER_03, status);
 
-	if (SNDEXCNT == 0) {
+	if (REG_SNDEXTCNT == 0) {
 		if (pmBacklight & 0xF0) { // DS Lite
 			int backlightLevel = pmBacklight & 3; // Brightness
 			*(int*)0x02003000 = backlightLevel;

--- a/settings/arm7/source/main.c
+++ b/settings/arm7/source/main.c
@@ -42,7 +42,6 @@ u8 my_i2cWriteRegister(u8 device, u8 reg, u8 data);
 
 #define BIT_SET(c, n) ((c) << (n))
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int timeTilVolumeLevelRefresh = 0;
@@ -221,7 +220,7 @@ int main() {
 
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 
 
 	// 03: Status: Init/Volume/Battery/SD
@@ -229,9 +228,9 @@ int main() {
 	// Battery is 7 bits -- bits 0-7
 	// Volume is 00h to 1Fh = 5 bits -- bits 8-12
 	// SD status -- bits 13-14
-	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): sndExcnt)
+	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): REG_SNDEXTCNT)
 
-	u8 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT)
+	u8 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT)
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT)
 									| BIT_SET(!!(readCommand & BIT(4) || readCommand & BIT(5) || readCommand & BIT(6) || readCommand & BIT(7)), DSLITE_BIT));
 

--- a/title/arm7/source/main.c
+++ b/title/arm7/source/main.c
@@ -42,7 +42,6 @@ u8 my_i2cWriteRegister(u8 device, u8 reg, u8 data);
 
 #define BIT_SET(c, n) ((c) << (n))
 
-#define SNDEXCNT (*(vu16*)0x4004700)
 #define SD_IRQ_STATUS (*(vu32*)0x400481C)
 
 volatile int timeTilVolumeLevelRefresh = 0;
@@ -240,7 +239,7 @@ int main() {
 
 	// 01: Fade Out
 	// 02: Return
-	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// 03: status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 
 
 	// 03: Status: Init/Volume/Battery/SD
@@ -248,16 +247,16 @@ int main() {
 	// Battery is 7 bits -- bits 0-7
 	// Volume is 00h to 1Fh = 5 bits -- bits 8-12
 	// SD status -- bits 13-14
-	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): sndExcnt)
+	// Init status -- bits 15-17 (Bit 0 (15): isDSLite, Bit 1 (16): scfgEnabled, Bit 2 (17): REG_SNDEXTCNT)
 
-	u8 initStatus = (BIT_SET(!!(SNDEXCNT), SNDEXCNT_BIT)
+	u8 initStatus = (BIT_SET(!!(REG_SNDEXTCNT), SNDEXTCNT_BIT)
 									| BIT_SET(!!(REG_SCFG_EXT), REGSCFG_BIT)
 									| BIT_SET(!!(pmBacklight & BIT(4) || pmBacklight & BIT(5) || pmBacklight & BIT(6) || pmBacklight & BIT(7)), DSLITE_BIT));
 
 	status = (status & ~INIT_MASK) | ((initStatus << INIT_OFF) & INIT_MASK);
 	fifoSendValue32(FIFO_USER_03, status);
 
-	if (SNDEXCNT == 0) {
+	if (REG_SNDEXTCNT == 0) {
 		if (pmBacklight & 0xF0) { // DS Lite
 			int backlightLevel = pmBacklight & 3; // Brightness
 			*(int*)0x02003000 = backlightLevel;

--- a/universal/include/common/arm7status.h
+++ b/universal/include/common/arm7status.h
@@ -2,7 +2,7 @@
 #ifndef A7STAT_H
 #define A7STAT_H
 
-#define SNDEXCNT_BIT 2
+#define SNDEXTCNT_BIT 2
 #define REGSCFG_BIT 1
 #define DSLITE_BIT 0
 

--- a/universal/source/common/systemdetails.cpp
+++ b/universal/source/common/systemdetails.cpp
@@ -38,7 +38,7 @@ SystemDetails::SystemDetails()
 
 	fifoWaitValue32(FIFO_USER_03);
 
-	// status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: sndExcnt)
+	// status (Bit 0: isDSLite, Bit 1: scfgEnabled, Bit 2: REG_SNDEXTCNT)
 	u32 status = ((fifoGetValue32(FIFO_USER_03)) >> INIT_OFF);
 
 	if (isDSiMode()) {
@@ -52,7 +52,7 @@ SystemDetails::SystemDetails()
 		_arm7SCFGLocked = true; // If TWiLight Menu++ is being run from DSiWarehax or flashcard, then arm7 SCFG is locked.
 	}
 
-	if (CHECK_BIT(status, SNDEXCNT_BIT) != 0) {
+	if (CHECK_BIT(status, SNDEXTCNT_BIT) != 0) {
 		_isRegularDS = false; // If sound frequency setting is found, then the console is not a DS Phat/Lite
 	}
 


### PR DESCRIPTION
#### What's changed?

libnds defines REG_SNDEXTCNT already: <https://github.com/devkitPro/libnds/blob/6cfbd4494d94a16982b8e7cefb7c63155a3d894b/include/nds/arm7/audio.h#L97>

So let's just use that.

#### Where have you tested it?

It compiled. Didn't test anything else, given it is the exact same define just renamed.

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
