### PR TITLE
Fix buffer overflow in slot1launch

### DIFF
--- a/slot1launch/arm9/source/main.cpp
+++ b/slot1launch/arm9/source/main.cpp
@@ -33,7 +33,10 @@
 #include "launch_engine.h"
 #include "crc.h"
 
-sNDSHeader ndsHeader;
+struct {
+sNDSHeader header;
+char padding[0x200 - sizeof(sNDSHeader)];
+} ndsHeader;
 
 bool consoleInited = false;
 bool scfgUnlock = false;
@@ -113,7 +116,7 @@ int main() {
 			cardReadHeader((uint8*)&ndsHeader);
 
 			char gameTid[5];
-			tonccpy(gameTid, ndsHeader.gameCode, 4);
+			tonccpy(gameTid, ndsHeader.header.gameCode, 4);
 			char pergamefilepath[256];
 			sprintf(pergamefilepath, "/_nds/TWiLightMenu/gamesettings/slot1/%s.ini", gameTid);
 
@@ -182,7 +185,7 @@ int main() {
 			cardReadHeader((uint8*)&ndsHeader);
 		}
 
-		if (ndsHeader.unitCode > 0 && TWLMODE) {
+		if (ndsHeader.header.unitCode > 0 && TWLMODE) {
 			runCardEngine = false;
 		}
 	} else {
@@ -225,7 +228,7 @@ int main() {
 			for (int i = 0; i < 30; i++) { swiWaitForVBlank(); }
 		} else if (io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA) {
 			// Check header CRC
-			if (ndsHeader.headerCRC16 != swiCRC16(0xFFFF, (void*)&ndsHeader, 0x15E)) {
+			if (ndsHeader.header.headerCRC16 != swiCRC16(0xFFFF, (void*)&ndsHeader, 0x15E)) {
 				consoleDemoInit();
 				consoleInited = true;
 				iprintf ("Please reboot the console with\n");
@@ -249,7 +252,8 @@ int main() {
 				}
 				tonccpy((void*)0x023F0000, cheatData, 0x8000);
 			}
-			runLaunchEngine ((memcmp(ndsHeader.gameCode, "UBRP", 4) == 0 || memcmp(ndsHeader.gameCode, "AMFE", 4) == 0 || memcmp(ndsHeader.gameCode, "ALXX", 4) == 0 || memcmp(ndsHeader.gameTitle, "D!S!XTREME", 10) == 0), (memcmp(ndsHeader.gameCode, "UBRP", 4) == 0));
+			const auto& gameCode = ndsHeader.header.gameCode;
+			runLaunchEngine ((memcmp(gameCode, "UBRP", 4) == 0 || memcmp(gameCode, "AMFE", 4) == 0 || memcmp(gameCode, "ALXX", 4) == 0 || memcmp(ndsHeader.header.gameTitle, "D!S!XTREME", 10) == 0), (memcmp(gameCode, "UBRP", 4) == 0));
 		}
 	}
 	return 0;


### PR DESCRIPTION
cardReadHeader reads 512 bytes which is more than the size of the sNDSHeader struct (352). Add padding to the struct used so that there's enough space to read into.
This caused freezing when using slot1launch on a ds where cart swapping was required