### PR TITLE
DSi-based themes: Tweak startup jingle / music conditions

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -2889,7 +2889,7 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 
 		if (!musicplaying && ms().theme != TWLSettings::EThemeSaturn) {
 			if (ms().dsiMusic != 0) {
-				if ((ms().theme == TWLSettings::ETheme3DS && (ms().dsiMusic == 1 || ms().dsiMusic == 4)) || (ms().dsiMusic == 3 && tc().playStartupJingle())) {
+				if (ms().dsiMusic == 4 || (ms().dsiMusic == 3 && tc().playStartupJingle())) {
 					//logPrint("snd().playStartup()\n");
 					snd().playStartup();
 					//logPrint("snd().setStreamDelay(snd().getStartupSoundLength() - tc().startupJingleDelayAdjust())\n");

--- a/romsel_dsimenutheme/arm9/source/sound.cpp
+++ b/romsel_dsimenutheme/arm9/source/sound.cpp
@@ -270,9 +270,15 @@ SoundControl::SoundControl()
 			case 4:
 			case 1:
 			default: {
-				stream.sampling_rate = ms().dsiMusic == 4 ? 32000 : 16000;	 		// 32000Hz or 16000Hz
+				bool use3DSMusic = ms().dsiMusic == 4 || (ms().dsiMusic == 3 && ms().theme == TWLSettings::ETheme3DS);
+				bool useHBLMusic = ms().dsiMusic == 3 && ms().theme == TWLSettings::EThemeHBL;
+				stream.sampling_rate = useHBLMusic ? 44100 : (use3DSMusic ? 32000 : 16000);	 		// 44100Hz, 32000Hz, or 16000Hz
 				stream.format = MM_STREAM_16BIT_MONO;
-				stream_source = fopen(std::string(ms().dsiMusic == 4 ? TFN_DEFAULT_SOUND_BG_3D : TFN_DEFAULT_SOUND_BG).c_str(), "rb");
+				if (useHBLMusic) {
+					stream_start_source = fopen(std::string(TFN_HBL_START_SOUND_BG).c_str(), "rb");
+					loopableMusic = true;
+				}
+				stream_source = fopen(std::string(useHBLMusic ? TFN_HBL_LOOP_SOUND_BG : (use3DSMusic ? TFN_DEFAULT_SOUND_BG_3D : TFN_DEFAULT_SOUND_BG)).c_str(), "rb");
 				seekPos = 0x2C;
 				break; }
 		}

--- a/romsel_dsimenutheme/nitrofiles/themes/3ds/light/theme.ini
+++ b/romsel_dsimenutheme/nitrofiles/themes/3ds/light/theme.ini
@@ -34,6 +34,7 @@ FontPalette4		= 0xA108
 
 UsernameUserPalette		= 1
 PurpleBatteryAvailable	= 1
+PlayStartupJingle		= 1
 
 RotatingCubesRenderY	= 78
 RenderPhoto				= 0


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

The conditions for playing the startup jingle are now more closely tied to the music setting rather than just using the 3DS theme.
- The jingle plays when `Regular (3DS)` music is set and does not play when `Regular (DSi)` music is set, regardless of theme. (Saturn is still mute)
- When the music is set to `Theme` the jingle will only play if enabled via `theme.ini` (#2071 is also fixed)
- The built-in 3DS theme now enables the jingle in its config (partially addresses #2055)
- HBL theme now plays the HBL music when music is set to `Theme` (it previously used DSi music in this case)

#### Where have you tested it?

<!-- Specify where you've tested it. -->

melonDS 0.9.5

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.

#### Other notes
- I almost added behavior to set `PlayStartupJingle = 1` to be the default when unspecified in 3DS skins, but decided against it for two reasons. It would be a breaking change to pretty much every 3DS skin that uses custom music as most don't specify `PlayStartupJingle`, and this behavior would be removed anyway if a merger of all DSi-based skins is to happen eventually.
- In order to fully close #2055 that RVID file would have to be added to NitroFS, though that would obviously increase the binary size and I don't know if y'all want to do that so I'm just going to leave that alone lol