### PR TITLE
Add the ability to set default starting directory

### DIFF
--- a/romsel_dsimenutheme/arm9/source/language.inl
+++ b/romsel_dsimenutheme/arm9/source/language.inl
@@ -124,6 +124,12 @@ STRING(AP_PATCH_RGF, "This game has AP (Anti-Piracy)\nand MUST be patched using 
 STRING(AP_USE_LATEST, "This game has AP (Anti-Piracy).\nPlease make sure you're\nusing the latest version of\nTWiLight Menu++.")
 STRING(B_A_OK_X_DONT_SHOW, "\\B/\\A OK, \\X Don't show again")
 
+// Default Directory Selector
+STRING(DEFAULT_DIR_SET, "Do you want to set this\nas the default directory\nfor this device?")
+STRING(DEFAULT_DIR_ALREADY, "This is already the\ndefault directory\nfor this device!")
+STRING(X_SET_DEFAULT_DIR, "\\X Set Default Directory")
+STRING(Y_DISABLE, "\\Y Disable")
+
 // Misc buttons
 STRING(A_OK, "\\A OK")
 STRING(B_NO, "\\B No")

--- a/romsel_dsimenutheme/nitrofiles/languages/en/language.ini
+++ b/romsel_dsimenutheme/nitrofiles/languages/en/language.ini
@@ -114,6 +114,11 @@ AP_PATCH_RGF = This game has AP (Anti-Piracy)\nand MUST be patched using the\nRG
 AP_USE_LATEST = This game has AP (Anti-Piracy).\nPlease make sure you're\nusing the latest version of\nTWiLight Menu++.
 B_A_OK_X_DONT_SHOW = \B/\A OK, \X Don't show again
 
+DEFAULT_DIR_SET = Do you want to set this\nas the default directory\nfor this device?
+DEFAULT_DIR_ALREADY = This is already the\ndefault directory\nfor this device!
+X_SET_DEFAULT_DIR = \X Set Default Directory
+Y_DISABLE = \Y Disable
+
 A_OK = \A OK
 B_NO = \B No
 B_BACK = \B Back

--- a/universal/include/common/twlmenusettings.h
+++ b/universal/include/common/twlmenusettings.h
@@ -253,7 +253,9 @@ public:
 	const char* getAppName();
 public:
 	std::string romfolder[2];
+	std::string defaultRomfolder[2];
 	std::string romPath[2];
+
 	int pagenum[2];
 	int cursorPosition[2];
 

--- a/universal/source/common/twlmenusettings.cpp
+++ b/universal/source/common/twlmenusettings.cpp
@@ -16,8 +16,8 @@ TWLSettings::TWLSettings()
 	romfolder[0] = "sd:/";
 	romfolder[1] = "fat:/";
 
-	defaultRomfolder[0] = "-1";
-	defaultRomfolder[1] = "-1";
+	defaultRomfolder[0] = "null";
+	defaultRomfolder[1] = "null";
 
 	pagenum[0] = 0;
 	pagenum[1] = 0;

--- a/universal/source/common/twlmenusettings.cpp
+++ b/universal/source/common/twlmenusettings.cpp
@@ -16,6 +16,9 @@ TWLSettings::TWLSettings()
 	romfolder[0] = "sd:/";
 	romfolder[1] = "fat:/";
 
+	defaultRomfolder[0] = "-1";
+	defaultRomfolder[1] = "-1";
+
 	pagenum[0] = 0;
 	pagenum[1] = 0;
 
@@ -150,7 +153,20 @@ void TWLSettings::loadSettings()
 
 	// UI settings.
 	romfolder[0] = settingsini.GetString("SRLOADER", "ROM_FOLDER", romfolder[0]);
+	defaultRomfolder[0] = settingsini.GetString("SRLOADER", "INITIAL_ROM_FOLDER", "null");
+
 	romfolder[1] = settingsini.GetString("SRLOADER", "SECONDARY_ROM_FOLDER", romfolder[1]);
+	defaultRomfolder[1] = settingsini.GetString("SRLOADER", "INITIAL_SECONDARY_ROM_FOLDER", "null");
+
+	// Overwrite rom folder with the default one, if available.
+	bool usingdefaultdir[2] = { false, false };
+	for (int i = 0; i < 2; ++i) { 
+		if (!defaultRomfolder[i].empty() && defaultRomfolder[i] != "null") {
+			romfolder[i] = defaultRomfolder[i];
+			usingdefaultdir[i] = true;
+		}
+	}
+
 	if (sdFound() && (strncmp(romfolder[0].c_str(), "sd:", 3) != 0 || access(romfolder[0].c_str(), F_OK) != 0)) {
 		romfolder[0] = "sd:/";
 	}
@@ -167,11 +183,15 @@ void TWLSettings::loadSettings()
 		romPath[1] = "";
 	}
 
-	pagenum[0] = settingsini.GetInt("SRLOADER", "PAGE_NUMBER", pagenum[0]);
-	pagenum[1] = settingsini.GetInt("SRLOADER", "SECONDARY_PAGE_NUMBER", pagenum[1]);
-
-	cursorPosition[0] = settingsini.GetInt("SRLOADER", "CURSOR_POSITION", cursorPosition[0]);
-	cursorPosition[1] = settingsini.GetInt("SRLOADER", "SECONDARY_CURSOR_POSITION", cursorPosition[1]);
+	// Only remember cursor pos if we don't have default dirs
+	if (!usingdefaultdir[0]) {
+		pagenum[0] = settingsini.GetInt("SRLOADER", "PAGE_NUMBER", pagenum[0]);
+		cursorPosition[0] = settingsini.GetInt("SRLOADER", "CURSOR_POSITION", cursorPosition[0]);
+	}
+	if (!usingdefaultdir[1]) {
+		pagenum[1] = settingsini.GetInt("SRLOADER", "SECONDARY_PAGE_NUMBER", pagenum[1]);
+		cursorPosition[1] = settingsini.GetInt("SRLOADER", "SECONDARY_CURSOR_POSITION", cursorPosition[1]);
+	}
 
 	consoleModel = (TConsoleModel)settingsini.GetInt("SRLOADER", "CONSOLE_MODEL", consoleModel);
 	languageSet = settingsini.GetInt("SRLOADER", "LANGUAGE_SET", languageSet);
@@ -338,7 +358,9 @@ void TWLSettings::saveSettings()
 
 	// UI settings.
 	settingsini.SetString("SRLOADER", "ROM_FOLDER", romfolder[0]);
+	settingsini.SetString("SRLOADER", "INITIAL_ROM_FOLDER", defaultRomfolder[0]);
 	settingsini.SetString("SRLOADER", "SECONDARY_ROM_FOLDER", romfolder[1]);
+	settingsini.SetString("SRLOADER", "INITIAL_SECONDARY_ROM_FOLDER", defaultRomfolder[1]);
 
 	settingsini.SetString("SRLOADER", "ROM_PATH", romPath[0]);
 	settingsini.SetString("SRLOADER", "SECONDARY_ROM_PATH", romPath[1]);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
- Addresses #1794 and #2352;
- When you press `SELECT + X` in the DSi, 3DS, HBL, or Saturn menu, a new pop-up prompt will appear, asking the user to set the current directory as the default starting directory. You can disable any default directory by pressing `Y`. As of now, this prompt only appears in the themes mentioned above, but the setting is saved across all themes.

![prompt](https://github.com/DS-Homebrew/TWiLightMenu/assets/163408439/ccee7330-7e86-4bef-b6d2-89b96c05cb1e)


<!-- Describe what you've changed. -->

#### Where have you tested it?
melonDS 0.9.5
Nintendo DSi XL UTL-001(USA)

***

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
