### PR TITLE
Add indicator for modified settings

### DIFF
--- a/settings/arm9/source/settingsgui.cpp
+++ b/settings/arm9/source/settingsgui.cpp
@@ -96,6 +96,22 @@ void SettingsGUI::processInputs(int pressed, touchPosition &touch)
 	}
 }
 
+static bool wasOptionModified(Option& option) {
+	if (auto action = std::get_if<Option::Bool>(&option.action())) {
+		return action->was_modified();
+	}
+	if (auto action = std::get_if<Option::Int>(&option.action())) {
+		return action->was_modified();
+	}
+	if (auto action = std::get_if<Option::Str>(&option.action())) {
+		return action->was_modified();
+	}
+	if (auto action = std::get_if<Option::Nul>(&option.action())) {
+		return action->was_modified();
+	}
+	return false;
+}
+
 void SettingsGUI::draw()
 {
 	if (_selectedPage < 0 || (int)_pages.size() < 1 || _selectedPage >= (int)_pages.size())
@@ -123,32 +139,51 @@ void SettingsGUI::draw()
 	if (ms().rtl()) {
 		printLarge(false, SCREEN_WIDTH - 6, 1, titleDisplayLength>=60*4 ? STR_SELECT_SEE_DESC_VER : _pages[_selectedPage].title().c_str(), Alignment::right);
 
+		std::string str;
 		for (int i = _topCursor; i < _bottomCursor; i++) {
-			int selected = _pages[_selectedPage].options()[i].selected();
+			auto option = _pages[_selectedPage].options()[i];
+			int selected = option.selected();
+
 			if (i == _selectedOption) {
 				printSmall(false, SCREEN_WIDTH - 4, 29 + (i - _topCursor) * 14, "<", Alignment::right);
 				// print scroller on the other side
 				drawScroller(30 + i * CURSOR_HEIGHT / _pages[_selectedPage].options().size() + 1, (CURSOR_HEIGHT / _pages[_selectedPage].options().size() + 1), true);
 			}
 
+			bool modified = wasOptionModified(option);
+
 			printSmall(false, SCREEN_WIDTH - 12, 30 + (i - _topCursor) * 14, _pages[_selectedPage].options()[i].displayName().c_str(), Alignment::right);
 			if (selected < 0) continue;
-			printSmall(false, 12, 30 + (i - _topCursor) * 14, _pages[_selectedPage].options()[i].labels()[selected].c_str());
+
+			str = _pages[_selectedPage].options()[i].labels()[selected];
+			if (modified)
+				str += "*";
+			printSmall(false, 12, 30 + (i - _topCursor) * 14, str.c_str());
 		}
 	} else {
 		printLarge(false, 6, 1, titleDisplayLength>=60*4 ? STR_SELECT_SEE_DESC_VER : _pages[_selectedPage].title().c_str());
 
+		std::string str;
 		for (int i = _topCursor; i < _bottomCursor; i++) {
-			int selected = _pages[_selectedPage].options()[i].selected();
+			auto option = _pages[_selectedPage].options()[i];
+			int selected = option.selected();
+
 			if (i == _selectedOption) {
 				printSmall(false, 4, 29 + (i - _topCursor) * 14, ">");
 				// print scroller on the other side
 				drawScroller(30 + i * CURSOR_HEIGHT / _pages[_selectedPage].options().size() + 1, (CURSOR_HEIGHT / _pages[_selectedPage].options().size() + 1), false);
 			}
 
+			bool modified = wasOptionModified(option);
+
 			printSmall(false, 12, 30 + (i - _topCursor) * 14, _pages[_selectedPage].options()[i].displayName().c_str());
 			if (selected < 0) continue;
-			printSmall(false, SCREEN_WIDTH - 12, 30 + (i - _topCursor) * 14, _pages[_selectedPage].options()[i].labels()[selected].c_str(), Alignment::right);
+
+			str = _pages[_selectedPage].options()[i].labels()[selected];
+			if (modified)
+				str += "*";
+
+			printSmall(false, SCREEN_WIDTH - 12, 30 + (i - _topCursor) * 14, str.c_str(), Alignment::right);
 		}
 	}
 

--- a/settings/arm9/source/settingspage.h
+++ b/settings/arm9/source/settingspage.h
@@ -124,6 +124,7 @@ public:
         _changed();
     };
 
+    bool was_modified() { return false; }
   private:
     OptionGenerator_Nul _generator;
     OptionChangedHandler_Nul _changed;
@@ -143,12 +144,13 @@ public:
 
     //typedef std::function<Option(Bool&)> OptionGenerator_Bool;
     Bool(bool *pointer)
-        : _generator(nullptr), _changed(nullptr) { _pointer = pointer; };
+        : _generator(nullptr), _changed(nullptr) { _pointer = pointer; _startValue = *pointer; };
 
     Bool(bool *pointer, const OptionGenerator_Bool generator)
         : _generator(generator), _changed(nullptr)
     {
       _pointer = pointer;
+      _startValue = *pointer;
       _generator = generator;
     };
 
@@ -156,6 +158,7 @@ public:
         : _generator(generator), _changed(changed)
     {
       _pointer = pointer;
+      _startValue = *pointer;
       _generator = generator;
       _changed = changed;
     };
@@ -164,6 +167,7 @@ public:
         : _generator(nullptr), _changed(changed)
     {
       _pointer = pointer;
+      _startValue = *pointer;
       _changed = changed;
     };
 
@@ -176,6 +180,8 @@ public:
     };
 
     bool get() { return *_pointer; };
+    bool was_modified() { return _startValue != *_pointer; };
+
     std::unique_ptr<Option> sub()
     {
       if (!_generator)
@@ -189,6 +195,7 @@ public:
 
   private:
     bool *_pointer;
+    bool _startValue;
     OptionGenerator_Bool _generator;
     OptionChangedHandler_Bool _changed;
   };
@@ -205,11 +212,12 @@ public:
     typedef void (*OptionChangedHandler_Int)(int, int);
 
     //typedef std::function<Option(Int&)> OptionGenerator_Int;
-    Int(int *pointer) : _generator(nullptr), _changed(nullptr) { _pointer = pointer; };
+    Int(int *pointer) : _generator(nullptr), _changed(nullptr) { _pointer = pointer; _startValue = *pointer;};
     Int(int *pointer, const OptionGenerator_Int generator)
         : _generator(generator)
     {
       _pointer = pointer;
+      _startValue = *pointer;
       _generator = generator;
     };
 
@@ -217,6 +225,7 @@ public:
         : _generator(generator), _changed(changed)
     {
       _pointer = pointer;
+      _startValue = *pointer;
       _generator = generator;
       _changed = changed;
     };
@@ -225,6 +234,7 @@ public:
         : _generator(nullptr), _changed(changed)
     {
       _pointer = pointer;
+      _startValue = *pointer;
       _changed = changed;
     };
 
@@ -247,8 +257,10 @@ public:
     }
     bool has_sub() { return _generator != nullptr; }
 
+    bool was_modified() { return _startValue != *_pointer; };
   private:
     int *_pointer;
+    int _startValue;
     OptionGenerator_Int _generator;
     OptionChangedHandler_Int _changed;
   };
@@ -266,12 +278,13 @@ public:
 
     //typedef std::function<Option(Str&)> OptionGenerator_Str;
     Str(std::string *pointer)
-        : _generator(nullptr), _changed(nullptr) { _pointer = pointer; };
+        : _generator(nullptr), _changed(nullptr) { _pointer = pointer; _startString = *pointer; };
 
     Str(std::string *pointer, const OptionGenerator_Str generator)
         : _generator(generator), _changed(nullptr)
     {
       _pointer = pointer;
+      _startString = *pointer;
       _generator = generator;
     };
 
@@ -279,6 +292,7 @@ public:
         : _generator(generator), _changed(changed)
     {
       _pointer = pointer;
+      _startString = *pointer;
       _generator = generator;
       _changed = changed;
     };
@@ -287,6 +301,7 @@ public:
         : _generator(nullptr), _changed(changed)
     {
       _pointer = pointer;
+      _startString = *pointer;
       _changed = changed;
     };
 
@@ -295,6 +310,8 @@ public:
     {
       if (_changed)
         _changed(std::string(*_pointer), value);
+
+      _was_modified = _startString != value;
       (*_pointer) = value;
     };
 
@@ -309,9 +326,11 @@ public:
       return std::make_unique<Option>(*option);
     }
     bool has_sub() { return _generator != nullptr; }
-
+    bool was_modified() { return _was_modified; }
   private:
     std::string *_pointer;
+    std::string _startString;
+    bool _was_modified = false;
     OptionGenerator_Str _generator;
     OptionChangedHandler_Str _changed;
   };


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
- Added an indicator to the end of changed options. It disappears after you save your settings.

![Settings](https://github.com/DS-Homebrew/TWiLightMenu/assets/163408439/d81f91b8-4a0e-4ad7-8c66-d63627722bad)

#### Where have you tested it?
melonDS 0.9.5
Nintendo DSi XL UTL-001(USA) with Unlaunch
***

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
