### PR TITLE
Add panning to page switch sound effect

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -2738,7 +2738,7 @@ static bool previousPage(SwitchState scrn, vector<vector<DirEntry>> dirContents)
 		return false;
 	}
 
-	snd().playSwitch();
+	snd().playSwitch(55);
 	if (ms().theme != TWLSettings::EThemeSaturn && ms().theme != TWLSettings::EThemeHBL) {
 		fadeType = false; // Fade to white
 		for (int i = 0; i < 6; i++) {
@@ -2807,7 +2807,7 @@ static bool nextPage(SwitchState scrn, vector<vector<DirEntry>> dirContents) {
 		return false;
 	}
 
-	snd().playSwitch();
+	snd().playSwitch(200);
 	if (ms().theme != TWLSettings::EThemeSaturn && ms().theme != TWLSettings::EThemeHBL) {
 		fadeType = false; // Fade to white
 		for (int i = 0; i < 6; i++) {
@@ -3232,7 +3232,7 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 						break;
 					} else if (pressed & KEY_L) {
 						if (PAGENUM > 0) {
-							snd().playSwitch();
+							snd().playSwitch(55);
 							fadeType = false; // Fade to white
 							for (int i = 0; i < 6; i++) {
 								bgOperations(true);
@@ -3265,7 +3265,7 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 						}
 					} else if (pressed & KEY_R) {
 						if (file_count > 40 + PAGENUM * 40) {
-							snd().playSwitch();
+							snd().playSwitch(200);
 							fadeType = false; // Fade to white
 							for (int i = 0; i < 6; i++) {
 								bgOperations(true);

--- a/romsel_dsimenutheme/arm9/source/sound.cpp
+++ b/romsel_dsimenutheme/arm9/source/sound.cpp
@@ -338,13 +338,13 @@ SoundControl::SoundControl()
 	}
 }
 
-mm_sfxhand SoundControl::playLaunch() { return mmEffectEx(&snd_launch); }
-mm_sfxhand SoundControl::playSelect() { return mmEffectEx(&snd_select); }
-mm_sfxhand SoundControl::playBack() { return mmEffectEx(&snd_back); }
-mm_sfxhand SoundControl::playSwitch() { return mmEffectEx(&snd_switch); }
-mm_sfxhand SoundControl::playStartup() { return mmEffectEx(&mus_startup); }
-mm_sfxhand SoundControl::playStop() { return mmEffectEx(&snd_stop); }
-mm_sfxhand SoundControl::playWrong() { return mmEffectEx(&snd_wrong); }
+mm_sfxhand SoundControl::playLaunch(u8 panning)  { snd_launch.panning = panning;  return mmEffectEx(&snd_launch); }
+mm_sfxhand SoundControl::playSelect(u8 panning)  { snd_select.panning = panning;  return mmEffectEx(&snd_select); }
+mm_sfxhand SoundControl::playBack(u8 panning)    { snd_back.panning = panning;    return mmEffectEx(&snd_back); }
+mm_sfxhand SoundControl::playSwitch(u8 panning)  { snd_switch.panning = panning;  return mmEffectEx(&snd_switch); }
+mm_sfxhand SoundControl::playStartup(u8 panning) { mus_startup.panning = panning; return mmEffectEx(&mus_startup); }
+mm_sfxhand SoundControl::playStop(u8 panning)    { snd_stop.panning = panning;    return mmEffectEx(&snd_stop); }
+mm_sfxhand SoundControl::playWrong(u8 panning)   { snd_wrong.panning = panning;   return mmEffectEx(&snd_wrong); }
 
 void SoundControl::beginStream() {
 	if (!stream_source) return;

--- a/romsel_dsimenutheme/arm9/source/sound.h
+++ b/romsel_dsimenutheme/arm9/source/sound.h
@@ -14,13 +14,13 @@
 class SoundControl {
     public:
         SoundControl();
-        mm_sfxhand playLaunch();
-        mm_sfxhand playSelect();
-        mm_sfxhand playBack();
-        mm_sfxhand playSwitch();
-        mm_sfxhand playStartup();
-        mm_sfxhand playStop();
-        mm_sfxhand playWrong();
+        mm_sfxhand playLaunch(u8 panning = 128);
+        mm_sfxhand playSelect(u8 panning = 128);
+        mm_sfxhand playBack(u8 panning = 128);
+        mm_sfxhand playSwitch(u8 panning = 128);
+        mm_sfxhand playStartup(u8 panning = 128);
+        mm_sfxhand playStop(u8 panning = 128);
+        mm_sfxhand playWrong(u8 panning = 128);
         
         // Refill the stream buffers
         volatile void updateStream();

--- a/settings/arm9/source/settingsgui.cpp
+++ b/settings/arm9/source/settingsgui.cpp
@@ -68,13 +68,19 @@ void SettingsGUI::processInputs(int pressed, touchPosition &touch)
 		}
 
 		if ((pressed & KEY_X || pressed & KEY_R) && !inSub()) {
-			mmEffectEx(currentTheme == 4 ? &snd().snd_saturn_launch : &snd().snd_switch);
+			mm_sound_effect pannedSound = currentTheme == 4 ? snd().snd_saturn_launch : snd().snd_switch;
+			pannedSound.panning = 178;
+
+			mmEffectEx(&pannedSound);
 			titleDisplayLength = 0;
 			rotatePage(1);
 		}
 
 		if ((pressed & KEY_Y || pressed & KEY_L) && !inSub()) {
-			mmEffectEx(currentTheme==4 ? &snd().snd_saturn_launch : &snd().snd_switch);
+			mm_sound_effect pannedSound = currentTheme == 4 ? snd().snd_saturn_launch : snd().snd_switch;
+			pannedSound.panning = 76;
+
+			mmEffectEx(&pannedSound);
 			titleDisplayLength = 0;
 			rotatePage(-1);
 		}


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
- This PR adds panning to the sound effect that plays when switching pages (for example, the sound is louder on the right speaker when switching to the next page and vice-versa). This applies to all DSi based themes and the Settings Menu.

#### Where have you tested it?
Nintendo DSi XL with Unlaunch
melonDS 0.9.5
***

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
