### PR TITLE
Wood UI additions

### DIFF
--- a/romsel_aktheme/arm9/source/fileBrowse.cpp
+++ b/romsel_aktheme/arm9/source/fileBrowse.cpp
@@ -1175,9 +1175,9 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 	}
 
 	// Scroll screen if needed
-	if (fileOffset > screenOffset + entriesPerScreen - 1) {
-		screenOffset = fileOffset - entriesPerScreen + 1;
-		cursorPosOnScreen = entriesPerScreen - 1;
+	if (fileOffset - screenOffset > (0.5 * entriesPerScreen)) {
+		screenOffset = screenOffset + 1;
+		cursorPosOnScreen = fileOffset - screenOffset;  // cursorPosOnScreen should always be this anyways
 	}
 
 	displayIcons = (ms().ak_viewMode != TWLSettings::EViewList);
@@ -1201,14 +1201,12 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 
 		if (pressed & KEY_UP) {
 			fileOffset--;
-			cursorPosOnScreen--;
-			if (cursorPosOnScreen < 0) cursorPosOnScreen = 0;
+			cursorPosOnScreen = fileOffset - screenOffset;
 			resetIconScale();
 		}
 		if (pressed & KEY_DOWN) {
 			fileOffset++;
-			cursorPosOnScreen++;
-			if (cursorPosOnScreen > entriesPerScreen - 1) cursorPosOnScreen = entriesPerScreen - 1;
+			cursorPosOnScreen = fileOffset - screenOffset;
 			resetIconScale();
 		}
 		if (pressed & KEY_LEFT) {
@@ -1269,26 +1267,27 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 
 		if (fileOffset < 0) {
 			fileOffset = dirContents.size() - 1;		// Wrap around to bottom of list
-			cursorPosOnScreen = file_count-1;
-			if (cursorPosOnScreen > entriesPerScreen - 1) cursorPosOnScreen = entriesPerScreen - 1;
+			fileOffset = 0;					// Temporarily disabled for testing
+			cursorPosOnScreen = fileOffset - screenOffset;
 		}
 		if (fileOffset > ((int)dirContents.size() - 1)) {
 			fileOffset = 0;		// Wrap around to top of list
-			cursorPosOnScreen = 0;
+			fileOffset = ((int)dirContents.size() - 1); // Temporarily disabled for testing
+			cursorPosOnScreen = fileOffset - screenOffset;
 		}
 
 		// Scroll screen if needed
-		if (fileOffset < screenOffset) {
-			screenOffset = fileOffset;
-			cursorPosOnScreen = 0;
+		if ((fileOffset - screenOffset < (0.5 * entriesPerScreen) - 1) && (screenOffset > 0)) {
+			screenOffset = screenOffset - 1;
+			cursorPosOnScreen = fileOffset - screenOffset;
 			if (displayIcons) {
 				loadIcons(screenOffset, dirContents);
 			} else {
 				refreshBanners(screenOffset, fileOffset, dirContents);
 			}
-		} else if (fileOffset > screenOffset + entriesPerScreen - 1) {
-			screenOffset = fileOffset - entriesPerScreen + 1;
-			cursorPosOnScreen = entriesPerScreen - 1;
+		} else if ((fileOffset - screenOffset > (0.5 * entriesPerScreen)) && (screenOffset + entriesPerScreen < file_count)) {
+			screenOffset = screenOffset + 1;
+			cursorPosOnScreen = fileOffset - screenOffset;
 			if (displayIcons) {
 				loadIcons(screenOffset, dirContents);
 			} else {

--- a/romsel_aktheme/arm9/source/fileBrowse.cpp
+++ b/romsel_aktheme/arm9/source/fileBrowse.cpp
@@ -62,7 +62,7 @@
 #include "fileCopy.h"
 
 #define ENTRIES_PER_SCREEN 4
-#define ENTRIES_PER_SCREEN_LIST 13
+#define ENTRIES_PER_SCREEN_LIST 10
 #define ENTRY_PAGE_LENGTH 10
 
 extern bool lcdSwapped;

--- a/romsel_aktheme/arm9/source/fileBrowse.cpp
+++ b/romsel_aktheme/arm9/source/fileBrowse.cpp
@@ -412,8 +412,10 @@ void loadIcons(const int screenOffset, std::vector<DirEntry> dirContents) {
 
 	printSmall(false, startTextX, startTextY, startText, Alignment::left, FontPalette::startText);
 
-	getcwd(path, PATH_MAX);
-	printSmall(false, folderTextX, folderTextY, path, Alignment::left, FontPalette::folderText);
+	getcwd(path, PATH_MAX);		// Only print path if directories are shown
+	if (ms().showDirectories) {
+		printSmall(false, folderTextX, folderTextY, path, Alignment::left, FontPalette::folderText);
+	}
 
 	displayDiskIcon(ms().secondaryDevice);
 	int n = 0;
@@ -509,8 +511,10 @@ void refreshBanners(const int startRow, const int fileOffset, std::vector<DirEnt
 
 	printSmall(false, startTextX, startTextY, startText, Alignment::left, FontPalette::startText);
 
-	getcwd(path, PATH_MAX);
-	printSmall(false, folderTextX, folderTextY, path, Alignment::left, FontPalette::folderText);
+	getcwd(path, PATH_MAX);		// Only print path if directories are shown
+	if (ms().showDirectories) {
+		printSmall(false, folderTextX, folderTextY, path, Alignment::left, FontPalette::folderText);
+	}
 
 	if (file_count == 0) {} else
 	if (ms().ak_viewMode == TWLSettings::EViewList) {

--- a/romsel_aktheme/arm9/source/fileBrowse.cpp
+++ b/romsel_aktheme/arm9/source/fileBrowse.cpp
@@ -524,7 +524,7 @@ void refreshBanners(const int startRow, const int fileOffset, std::vector<DirEnt
 		// Print directory listing
 		for (int i = 0; i < ((int)dirContents.size() - startRow) && i < ENTRIES_PER_SCREEN_LIST; i++) {
 			const DirEntry* entry = &dirContents.at(i + startRow);
-			printSmall(false, xPos, yPos+(i*11), entry->isDirectory ? ("["+entry->name+"]") : entry->name, Alignment::left, ((i + startRow) == fileOffset) ? FontPalette::mainTextHilight : FontPalette::mainText);
+			printSmall(false, xPos, yPos+(i*15), entry->isDirectory ? ("["+entry->name+"]") : entry->name, Alignment::left, ((i + startRow) == fileOffset) ? FontPalette::mainTextHilight : FontPalette::mainText);
 		}
 	} else {
 		int n = 0;

--- a/romsel_aktheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_aktheme/arm9/source/graphics/graphics.cpp
@@ -353,7 +353,7 @@ ITCM_CODE void updateSelectionBar(void) {
 	}
 	swiWaitForVBlank();
 	if (prevCurPos != 20) {
-		const int h = (prevViewMode != TWLSettings::EViewList) ? 38 : 11;
+		const int h = (prevViewMode != TWLSettings::EViewList) ? 38 : 15;
 		// const int hl = h-1;
 		const int hl = h;
 		for (int y = 19+(prevCurPos*h); y <= 19+hl+(prevCurPos*h); y++) {
@@ -364,7 +364,7 @@ ITCM_CODE void updateSelectionBar(void) {
 		}
 	}
 
-	const int h = (ms().ak_viewMode != TWLSettings::EViewList) ? 38 : 11;
+	const int h = (ms().ak_viewMode != TWLSettings::EViewList) ? 38 : 15;
 	const int hl = h-1;
 	bool color2 = false;
 	if (selectionBarOpacity == 100) {


### PR DESCRIPTION
Hello. Just made some minor changes to the Wood UI, and thought I might as well submit them in case anyone else thinks they are worth keeping.

Changes:
- File list scrolls when the selection passes half of the list rather than the very end.
- Directory path is only displayed if directories are shown. (This is what chyyran did before.)
- Changed list view line width from 11 to 15 to make the file list easier to read. (This is also what chyyran did before.)

This was tested on my half of a DS Lite.

In addition, I also have an alternate 'white' theme which was edited (with very little effort) from the 'black' theme. I could upload this somewhere too if anyone is interested.

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
