### PR TITLE
DSi-Based themes: Fix launching app with wrong info when sorting by recent

### DIFF
--- a/romsel_aktheme/arm9/source/fileBrowse.cpp
+++ b/romsel_aktheme/arm9/source/fileBrowse.cpp
@@ -1931,8 +1931,8 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 
 						if (ms().sortMethod == TWLSettings::ESortRecent) {
 							// Set cursor pos to the first slot that isn't a directory so it won't be misplaced with recent sort
+							CURPOS = fileStartPos % 40;
 							PAGENUM = fileStartPos / 40;
-							CURPOS = fileStartPos - PAGENUM * 40;
 						}
 
 						displayDiskIcon(false);

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -90,6 +90,7 @@ int last_used_box = 0;
 static int fileStartPos = 0; // The position of the first thing that is not a directory.
 
 extern int spawnedtitleboxes;
+extern int cursorPosOnScreen;
 
 extern int titleboxXpos[2];
 extern int titleboxXdest[2];
@@ -3896,6 +3897,7 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 						snd().playLaunch();
 						controlTopBright = true;
 						applaunch = true;
+						cursorPosOnScreen = CURPOS;
 
 						if (ms().theme == TWLSettings::EThemeDSi) {
 							applaunchprep = true;
@@ -3974,8 +3976,8 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 
 							if (ms().sortMethod == TWLSettings::ESortRecent) {
 								// Set cursor pos to the first slot that isn't a directory so it won't be misplaced with recent sort
+								CURPOS = fileStartPos % 40;
 								PAGENUM = fileStartPos / 40;
-								CURPOS = fileStartPos - PAGENUM * 40;
 							}
 
 							if (ms().theme == TWLSettings::EThemeHBL) {

--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -133,6 +133,7 @@ bool useRumble = false;
 bool applaunchprep = false;
 
 int spawnedtitleboxes = 0;
+int cursorPosOnScreen = 0;
 
 bool showColon = true;
 
@@ -1354,7 +1355,7 @@ int dsiMenuTheme(void) {
 			ms().slot1Launched = false;
 
 			// Launch DSiWare .nds via Unlaunch
-			if (isDSiWare[CURPOS]) {
+			if (isDSiWare[cursorPosOnScreen]) {
 				remove(sys().isRunFromSD() ? "sd:/_nds/nds-bootstrap/esrb.bin" : "fat:/_nds/nds-bootstrap/esrb.bin");
 
 				std::string typeToReplace = filename.substr(filename.rfind('.'));
@@ -1390,7 +1391,7 @@ int dsiMenuTheme(void) {
 				if (!isArgv) {
 					ms().romPath[ms().secondaryDevice] = std::string(argarray[0]);
 				}
-				ms().homebrewBootstrap = isHomebrew[CURPOS];
+				ms().homebrewBootstrap = isHomebrew[cursorPosOnScreen];
 				ms().launchType[ms().secondaryDevice] = Launch::EDSiWareLaunch;
 				ms().previousUsedDevice = ms().secondaryDevice;
 				ms().saveSettings();
@@ -1715,9 +1716,9 @@ int dsiMenuTheme(void) {
 					dsModeDSiWare = true;
 					useBackend = false; // Bypass nds-bootstrap
 					ms().homebrewBootstrap = true;
-				} else */ if (isHomebrew[CURPOS]) {
-					int pgsDSiMode = (perGameSettings_dsiMode == -1 ? isModernHomebrew[CURPOS] : perGameSettings_dsiMode);
-					if ((perGameSettings_directBoot && ms().secondaryDevice) || (isModernHomebrew[CURPOS] && pgsDSiMode && (ms().secondaryDevice || perGameSettings_ramDiskNo == -1))) {
+				} else */ if (isHomebrew[cursorPosOnScreen]) {
+					int pgsDSiMode = (perGameSettings_dsiMode == -1 ? isModernHomebrew[cursorPosOnScreen] : perGameSettings_dsiMode);
+					if ((perGameSettings_directBoot && ms().secondaryDevice) || (isModernHomebrew[cursorPosOnScreen] && pgsDSiMode && (ms().secondaryDevice || perGameSettings_ramDiskNo == -1))) {
 						useBackend = false; // Bypass nds-bootstrap
 					} else {
 						useBackend = true;
@@ -1735,7 +1736,7 @@ int dsiMenuTheme(void) {
 				strcpy(filePath + pathLen, name);
 				free(argarray.at(0));
 				argarray.at(0) = filePath;
-				if (!ms().secondaryDevice && !sys().arm7SCFGLocked() && ms().consoleModel == TWLSettings::EDSiRetail && isHomebrew[CURPOS] && !(perGameSettings_useBootstrap == -1 ? true : perGameSettings_useBootstrap)) {
+				if (!ms().secondaryDevice && !sys().arm7SCFGLocked() && ms().consoleModel == TWLSettings::EDSiRetail && isHomebrew[cursorPosOnScreen] && !(perGameSettings_useBootstrap == -1 ? true : perGameSettings_useBootstrap)) {
 					ms().romPath[ms().secondaryDevice] = std::string(argarray[0]);
 					ms().launchType[ms().secondaryDevice] = Launch::ESDFlashcardLaunch;
 					ms().previousUsedDevice = ms().secondaryDevice;
@@ -1751,9 +1752,9 @@ int dsiMenuTheme(void) {
 
 					unlaunchRomBoot(argarray[0]);
 				} else if (useBackend) {
-					if ((((perGameSettings_useBootstrap == -1 ? ms().useBootstrap : perGameSettings_useBootstrap) && !ms().homebrewBootstrap) || !ms().secondaryDevice) || (dsiFeatures() && unitCode[CURPOS] > 0 && (perGameSettings_dsiMode == -1 ? DEFAULT_DSI_MODE : perGameSettings_dsiMode))
+					if ((((perGameSettings_useBootstrap == -1 ? ms().useBootstrap : perGameSettings_useBootstrap) && !ms().homebrewBootstrap) || !ms().secondaryDevice) || (dsiFeatures() && unitCode[cursorPosOnScreen] > 0 && (perGameSettings_dsiMode == -1 ? DEFAULT_DSI_MODE : perGameSettings_dsiMode))
 					|| (ms().secondaryDevice && (io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA))
-					|| (unitCode[CURPOS] == 3 && !ms().homebrewBootstrap)) {
+					|| (unitCode[cursorPosOnScreen] == 3 && !ms().homebrewBootstrap)) {
 						std::string path = argarray[0];
 						std::string savename = replaceAll(filename, typeToReplace, getSavExtension());
 						std::string ramdiskname = replaceAll(filename, typeToReplace, getImgExtension(perGameSettings_ramDiskNo));
@@ -1761,7 +1762,7 @@ int dsiMenuTheme(void) {
 						RemoveTrailingSlashes(romFolderNoSlash);
 						std::string savepath = romFolderNoSlash + "/saves/" + savename;
 						std::string ramdiskpath = romFolderNoSlash + "/ramdisks/" + ramdiskname;
-						if (isHomebrew[CURPOS]) {
+						if (isHomebrew[cursorPosOnScreen]) {
 							mkdir("ramdisks", 0777);
 						} else if (ms().saveLocation == TWLSettings::ETWLMFolder) {
 							std::string twlmSavesFolder = sys().isRunFromSD() ? "sd:/_nds/TWiLightMenu/saves" : "fat:/_nds/TWiLightMenu/saves";
@@ -1773,7 +1774,7 @@ int dsiMenuTheme(void) {
 							mkdir("saves", 0777);
 						}
 
-						createSaveFile(savepath.c_str(), isHomebrew[CURPOS], gameTid[CURPOS]);
+						createSaveFile(savepath.c_str(), isHomebrew[cursorPosOnScreen], gameTid[cursorPosOnScreen]);
 
 						SetMPUSettings();
 
@@ -1784,8 +1785,8 @@ int dsiMenuTheme(void) {
 						CIniFile bootstrapini(bootstrapinipath);
 						bootstrapini.SetString("NDS-BOOTSTRAP", "NDS_PATH", path);
 						bootstrapini.SetString("NDS-BOOTSTRAP", "SAV_PATH", savepath);
-						bootstrapini.SetString("NDS-BOOTSTRAP", "HOMEBREW_ARG", (useWidescreen && (gameTid[CURPOS][0] == 'W' || romVersion[CURPOS] == 0x57)) ? "wide" : "");
-						if (!isHomebrew[CURPOS]) {
+						bootstrapini.SetString("NDS-BOOTSTRAP", "HOMEBREW_ARG", (useWidescreen && (gameTid[cursorPosOnScreen][0] == 'W' || romVersion[cursorPosOnScreen] == 0x57)) ? "wide" : "");
+						if (!isHomebrew[cursorPosOnScreen]) {
 							bootstrapini.SetString("NDS-BOOTSTRAP", "AP_FIX_PATH", setApFix(argarray[0]));
 							bootstrapini.SetString("NDS-BOOTSTRAP", "MANUAL_PATH", getGameManual(filename.c_str()));
 						}
@@ -1794,7 +1795,7 @@ int dsiMenuTheme(void) {
 						bootstrapini.SetInt("NDS-BOOTSTRAP", "LANGUAGE", perGameSettings_language == -2 ? ms().gameLanguage : perGameSettings_language);
 						bootstrapini.SetInt("NDS-BOOTSTRAP", "REGION", perGameSettings_region < -1 ? ms().gameRegion : perGameSettings_region);
 						bootstrapini.SetInt("NDS-BOOTSTRAP", "USE_ROM_REGION", perGameSettings_region < -1 ? ms().useRomRegion : 0);
-						bootstrapini.SetInt("NDS-BOOTSTRAP", "DSI_MODE", (dsModeForced || (unitCode[CURPOS] == 0 && !isDSiMode())) ? 0 : (perGameSettings_dsiMode == -1 ? DEFAULT_DSI_MODE : perGameSettings_dsiMode));
+						bootstrapini.SetInt("NDS-BOOTSTRAP", "DSI_MODE", (dsModeForced || (unitCode[cursorPosOnScreen] == 0 && !isDSiMode())) ? 0 : (perGameSettings_dsiMode == -1 ? DEFAULT_DSI_MODE : perGameSettings_dsiMode));
 						if (dsiFeatures() || !ms().secondaryDevice) {
 							bootstrapini.SetInt("NDS-BOOTSTRAP", "BOOST_CPU", boostCpu);
 							bootstrapini.SetInt("NDS-BOOTSTRAP", "BOOST_VRAM", perGameSettings_boostVram == -1 ? DEFAULT_BOOST_VRAM : perGameSettings_boostVram);
@@ -1821,7 +1822,7 @@ int dsiMenuTheme(void) {
 						if (!isArgv) {
 							ms().romPath[ms().secondaryDevice] = std::string(argarray[0]);
 						}
-						ms().homebrewHasWide = (isHomebrew[CURPOS] && gameTid[CURPOS][0] == 'W');
+						ms().homebrewHasWide = (isHomebrew[cursorPosOnScreen] && gameTid[cursorPosOnScreen][0] == 'W');
 						ms().launchType[ms().secondaryDevice] = Launch::ESDFlashcardLaunch; // 1
 						ms().previousUsedDevice = ms().secondaryDevice;
 						ms().saveSettings();
@@ -1848,7 +1849,7 @@ int dsiMenuTheme(void) {
 							sprintf(ndsToBoot, "%s:/_nds/nds-bootstrap-%s%s.nds", sys().isRunFromSD() ? "fat" : "sd", ms().homebrewBootstrap ? "hb-" : "", useNightly ? "nightly" : "release");
 						}
 
-						if (ms().btsrpBootloaderDirect && isHomebrew[CURPOS]) {
+						if (ms().btsrpBootloaderDirect && isHomebrew[cursorPosOnScreen]) {
 							bootFSInit(ndsToBoot);
 							bootstrapHbRunPrep(-1);
 						}
@@ -1873,13 +1874,13 @@ int dsiMenuTheme(void) {
 						}
 
 						int err = 0;
-						if (ms().btsrpBootloaderDirect && isHomebrew[CURPOS]) {
+						if (ms().btsrpBootloaderDirect && isHomebrew[cursorPosOnScreen]) {
 							if (access(ndsToBoot, F_OK) == 0) {
-								if (gameTid[CURPOS][0] == 0) {
-									toncset(gameTid[CURPOS], '#', 4); // Fix blank TID
+								if (gameTid[cursorPosOnScreen][0] == 0) {
+									toncset(gameTid[cursorPosOnScreen], '#', 4); // Fix blank TID
 								}
 								char patchOffsetCacheFilePath[64];
-								sprintf(patchOffsetCacheFilePath, "sd:/_nds/nds-bootstrap/patchOffsetCache/%s-%04X.bin", gameTid[CURPOS], headerCRC[CURPOS]);
+								sprintf(patchOffsetCacheFilePath, "sd:/_nds/nds-bootstrap/patchOffsetCache/%s-%04X.bin", gameTid[cursorPosOnScreen], headerCRC[cursorPosOnScreen]);
 								std::string fatPath = replaceAll(path, "sd:/", "fat:/");
 
 								err = bootstrapHbRunNdsFile (path.c_str(), fatPath.c_str(),
@@ -1894,7 +1895,7 @@ int dsiMenuTheme(void) {
 								argarray.size(),
 								(const char **)&argarray[0],
 								perGameSettings_language == -2 ? ms().gameLanguage : perGameSettings_language,
-								perGameSettings_dsiMode == -1 ? isModernHomebrew[CURPOS] : perGameSettings_dsiMode,
+								perGameSettings_dsiMode == -1 ? isModernHomebrew[cursorPosOnScreen] : perGameSettings_dsiMode,
 								perGameSettings_boostCpu == -1 ? DEFAULT_BOOST_CPU : perGameSettings_boostCpu,
 								perGameSettings_boostVram == -1 ? DEFAULT_BOOST_VRAM : perGameSettings_boostVram,
 								ms().consoleModel, false);
@@ -1963,7 +1964,7 @@ int dsiMenuTheme(void) {
 					if (!isArgv) {
 						ms().romPath[ms().secondaryDevice] = std::string(argarray[0]);
 					}
-					ms().homebrewHasWide = (isHomebrew[CURPOS] && (gameTid[CURPOS][0] == 'W' || romVersion[CURPOS] == 0x57));
+					ms().homebrewHasWide = (isHomebrew[cursorPosOnScreen] && (gameTid[cursorPosOnScreen][0] == 'W' || romVersion[cursorPosOnScreen] == 0x57));
 					ms().launchType[ms().secondaryDevice] = Launch::ESDFlashcardDirectLaunch;
 					ms().previousUsedDevice = ms().secondaryDevice;
 					if (isDSiMode() || !ms().secondaryDevice) {
@@ -1979,7 +1980,7 @@ int dsiMenuTheme(void) {
 						swiWaitForVBlank();
 					}
 
-					if (!isDSiMode() && !ms().secondaryDevice && strncmp(filename.c_str(), "GodMode9i", 9) != 0 && strcmp(gameTid[CURPOS], "HGMA") != 0) {
+					if (!isDSiMode() && !ms().secondaryDevice && strncmp(filename.c_str(), "GodMode9i", 9) != 0 && strcmp(gameTid[cursorPosOnScreen], "HGMA") != 0) {
 						ntrStartSdGame();
 					}
 
@@ -1987,18 +1988,18 @@ int dsiMenuTheme(void) {
 					int gameRegion = perGameSettings_region < -1 ? ms().gameRegion : perGameSettings_region;
 
 					// Set region flag
-					if (ms().useRomRegion && perGameSettings_region < -1 && gameTid[CURPOS][3] != 'A' && gameTid[CURPOS][3] != 'O' && gameTid[CURPOS][3] != '#') {
-						if (gameTid[CURPOS][3] == 'J') {
+					if (ms().useRomRegion && perGameSettings_region < -1 && gameTid[cursorPosOnScreen][3] != 'A' && gameTid[cursorPosOnScreen][3] != 'O' && gameTid[cursorPosOnScreen][3] != '#') {
+						if (gameTid[cursorPosOnScreen][3] == 'J') {
 							*(u8*)(0x02FFFD70) = 0;
-						} else if (gameTid[CURPOS][3] == 'E' || gameTid[CURPOS][3] == 'T') {
+						} else if (gameTid[cursorPosOnScreen][3] == 'E' || gameTid[cursorPosOnScreen][3] == 'T') {
 							*(u8*)(0x02FFFD70) = 1;
-						} else if (gameTid[CURPOS][3] == 'P' || gameTid[CURPOS][3] == 'V') {
+						} else if (gameTid[cursorPosOnScreen][3] == 'P' || gameTid[cursorPosOnScreen][3] == 'V') {
 							*(u8*)(0x02FFFD70) = 2;
-						} else if (gameTid[CURPOS][3] == 'U') {
+						} else if (gameTid[cursorPosOnScreen][3] == 'U') {
 							*(u8*)(0x02FFFD70) = 3;
-						} else if (gameTid[CURPOS][3] == 'C') {
+						} else if (gameTid[cursorPosOnScreen][3] == 'C') {
 							*(u8*)(0x02FFFD70) = 4;
-						} else if (gameTid[CURPOS][3] == 'K') {
+						} else if (gameTid[cursorPosOnScreen][3] == 'K') {
 							*(u8*)(0x02FFFD70) = 5;
 						}
 					} else if (gameRegion == -1) {
@@ -2179,7 +2180,7 @@ int dsiMenuTheme(void) {
 						u32 ptr = 0x08000000;
 						u32 romSize = getFileSize(filename.c_str());
 						FILE* gbaFile = fopen(filename.c_str(), "rb");
-						if (strncmp(gameTid[CURPOS], "AGBJ", 4) == 0 && romSize <= 0x40000) {
+						if (strncmp(gameTid[cursorPosOnScreen], "AGBJ", 4) == 0 && romSize <= 0x40000) {
 							ptr += 0x400;
 						}
 						u32 curPtr = ptr;
@@ -2188,7 +2189,7 @@ int dsiMenuTheme(void) {
 						if (romSize > 0x2000000) romSize = 0x2000000;
 
 						bool nor = false;
-						if (*(u16*)(0x020000C0) == 0x5A45 && strncmp(gameTid[CURPOS], "AGBJ", 4) != 0) {
+						if (*(u16*)(0x020000C0) == 0x5A45 && strncmp(gameTid[cursorPosOnScreen], "AGBJ", 4) != 0) {
 							cExpansion::SetRompage(0);
 							expansion().SetRampage(cExpansion::ENorPage);
 							cExpansion::OpenNorWrite();
@@ -2265,7 +2266,7 @@ int dsiMenuTheme(void) {
 
 						if (dsiFeatures()) {
 							ndsToBoot = ms().consoleModel > 0 ? "sd:/_nds/GBARunner2_arm7dldi_3ds.nds" : "sd:/_nds/GBARunner2_arm7dldi_dsi.nds";
-						} else if (memcmp(gameTid[CURPOS], "BPE", 3) == 0) { // If game is Pokemon Emerald...
+						} else if (memcmp(gameTid[cursorPosOnScreen], "BPE", 3) == 0) { // If game is Pokemon Emerald...
 							ndsToBoot = ms().gbar2DldiAccess ? "sd:/_nds/GBARunner2_arm7dldi_rom3m_ds.nds" : "sd:/_nds/GBARunner2_arm9dldi_rom3m_ds.nds";
 						} else {
 							ndsToBoot = ms().gbar2DldiAccess ? "sd:/_nds/GBARunner2_arm7dldi_ds.nds" : "sd:/_nds/GBARunner2_arm9dldi_ds.nds";
@@ -2273,7 +2274,7 @@ int dsiMenuTheme(void) {
 						if (!isDSiMode() || access(ndsToBoot, F_OK) != 0) {
 							if (dsiFeatures()) {
 								ndsToBoot = ms().consoleModel > 0 ? "fat:/_nds/GBARunner2_arm7dldi_3ds.nds" : "fat:/_nds/GBARunner2_arm7dldi_dsi.nds";
-							} else if (memcmp(gameTid[CURPOS], "BPE", 3) == 0) { // If game is Pokemon Emerald...
+							} else if (memcmp(gameTid[cursorPosOnScreen], "BPE", 3) == 0) { // If game is Pokemon Emerald...
 								ndsToBoot = ms().gbar2DldiAccess ? "fat:/_nds/GBARunner2_arm7dldi_rom3m_ds.nds" : "fat:/_nds/GBARunner2_arm9dldi_rom3m_ds.nds";
 							} else {
 								ndsToBoot = ms().gbar2DldiAccess ? "fat:/_nds/GBARunner2_arm7dldi_ds.nds" : "fat:/_nds/GBARunner2_arm9dldi_ds.nds";

--- a/romsel_r4theme/arm9/source/fileBrowse.cpp
+++ b/romsel_r4theme/arm9/source/fileBrowse.cpp
@@ -1507,8 +1507,8 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 
 						if (ms().sortMethod == TWLSettings::ESortRecent) {
 							// Set cursor pos to the first slot that isn't a directory so it won't be misplaced with recent sort
+							ms().cursorPosition[ms().secondaryDevice] = fileStartPos % 40;
 							ms().pagenum[ms().secondaryDevice] = fileStartPos / 40;
-							ms().cursorPosition[ms().secondaryDevice] = fileStartPos - ms().pagenum[ms().secondaryDevice] * 40;
 						}
 					}
 


### PR DESCRIPTION
#### What's changed?
Fixes #2432: In my previous pull request, I made an oversight that broke game detection when sorting by recently played. This caused the game to launch with incorrect information, such as the wrong game type, region, or AP-patch.

This happened because the app launching code depended on the `CURPOS` variable, and my code modified its value right before the game launched. This led to TWLmenu failing to detect the game properly.

To fix this, the app launching code now uses the variable `cursorPosOnScreen` instead of `CURPOS`. This name matches the one used in _romsel_akmenu_ for consistency.

#### Where have you tested it?
- Nintendo DSi XL with Unlaunch
- melonDS 0.9.5

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
