### PR TITLE
DSi Theme: Added more dropdown animations!

### DIFF
--- a/romsel_dsimenutheme/arm9/source/main.cpp
+++ b/romsel_dsimenutheme/arm9/source/main.cpp
@@ -1171,12 +1171,12 @@ int dsiMenuTheme(void) {
 		}
 	}
 
+	srand(time(NULL));
+	
 	graphicsInit();
 	iconManagerInit();
 
 	keysSetRepeat(10, 2);
-
-	srand(time(NULL));
 
 	logPrint("snd()\n");
 	snd();


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
- Added more dropdown animations to closely match DSi menu's behaviour. In it, there are 4 dropdown types: Left-to-Right, Right-to-Left, and what I like to call V-Shaped and Inverted V-Shaped (see below). This PR adds these animations for TWLmenu's DSi theme. Also, just like the original, they are randomly picked upon boot.
- While at it, I also cleaned up some of the dropdown code to be more readable and slightly tweaked the old left-to-right animation.

**Left-to-Right**

https://github.com/DS-Homebrew/TWiLightMenu/assets/167481805/0b81ec0f-b22a-444c-813e-ba34590d71e5

**Right-to-Left**

https://github.com/DS-Homebrew/TWiLightMenu/assets/167481805/bdb3a2d7-7de2-4582-83a5-46ad13060263

**V-Shaped**

https://github.com/DS-Homebrew/TWiLightMenu/assets/167481805/eb0680cf-063b-497e-b209-45e82b2d7d35

**Inverted V-Shaped**

https://github.com/DS-Homebrew/TWiLightMenu/assets/167481805/cc0e1872-0b82-423f-af38-51773ab4689b


#### Where have you tested it?
Nintendo DSi XL with Unlaunch
melonDS 0.9.5

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
