### PR TITLE
Fix partial EXRAM clear on debugger hardware

### DIFF
--- a/slot1launch/bootloader/source/main.arm7.c
+++ b/slot1launch/bootloader/source/main.arm7.c
@@ -328,9 +328,12 @@ void arm7_resetMemory (void)
 	// clear more of EXRAM, skipping the cheat data section
 	toncset ((void*)0x023F8000, 0, 0x8000);
 
+	if(my_isDSiMode() || swiIsDebugger())
+		memset_addrs_arm7(0x02400000, 0x02800000); // Clear the rest of EXRAM
+
 	if (my_isDSiMode()) {
 		// clear last part of EXRAM
-		memset_addrs_arm7(0x02400000, 0x02FFD7BC); // Leave eMMC CID intact
+		memset_addrs_arm7(0x02800000, 0x02FFD7BC); // Leave eMMC CID intact
 		memset_addrs_arm7(0x02FFD7CC, 0x03000000);
 	}
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?
Fixed bootloader of slot1launch not fully clearing RAM when using Debugger DS hardware (which has double the RAM).
This caused issues due to some cartridges expecting said RAM to be cleared.

#### Where have you tested it?

Tested on retail DSs and Debugger DSs.
Won't change anything for other hardware.

***

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
