### PR TITLE
DSi-based Themes: Don't open select menu when changing brightness on DSi

### DIFF
--- a/romsel_dsimenutheme/arm7/source/main.c
+++ b/romsel_dsimenutheme/arm7/source/main.c
@@ -175,6 +175,9 @@ int main() {
 		}
 	}
 
+	bool reportBacklightLevelChange = false;
+	u8 currentBacklightLevel;
+
 	// Keep the ARM7 mostly idle
 	while (!exitflag) {
 		if ( 0 == (REG_KEYINPUT & (KEY_SELECT | KEY_START | KEY_L | KEY_R))) {
@@ -215,6 +218,17 @@ int main() {
 
 		if (fifoCheckValue32(FIFO_USER_02)) {
 			ReturntoDSiMenu();
+		}
+
+		if (fifoCheckValue32(FIFO_USER_04)) {
+			reportBacklightLevelChange = fifoGetValue32(FIFO_USER_04) == 1;
+			if (reportBacklightLevelChange) currentBacklightLevel = my_i2cReadRegister(I2C_PM, 0x41);
+		}
+		if (reportBacklightLevelChange) {
+			if (my_i2cReadRegister(I2C_PM, 0x41) != currentBacklightLevel) {
+				fifoSendValue32(FIFO_USER_04, 1);
+				reportBacklightLevelChange = false;
+			}
 		}
 
 		if (*(u32*)(0x2FFFD0C) == 0x54494D52) {

--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -4316,6 +4316,9 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 				bannerTextShown = false;
 				bool runSelectMenu = pressed & KEY_SELECT;
 				bool break2 = false;
+				if (pressed & KEY_SELECT && dsiFeatures() && ms().consoleModel < 2) {
+					fifoSendValue32(FIFO_USER_04, 1); // enable backlight level change reports
+				}
 				while (held & KEY_SELECT) {
 					scanKeys();
 					pressed = keysDown();
@@ -4351,7 +4354,14 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 							return "null";
 						}
 					}
+
+					// detect backlight level change on DSi consoles
+					if (runSelectMenu && dsiFeatures() && ms().consoleModel < 2 && fifoGetValue32(FIFO_USER_04)) {
+						runSelectMenu = false;
+						fifoSendValue32(FIFO_USER_04, 2); // disable backlight level change report
+					}
 				}
+				if (dsiFeatures() && ms().consoleModel < 2) fifoSendValue32(FIFO_USER_04, 2); // disable backlight level change report
 				if (break2) break;
 				if (runSelectMenu && (ms().theme == TWLSettings::EThemeDSi || ms().theme == TWLSettings::EThemeSaturn || ms().theme == TWLSettings::EThemeHBL)) {
 					if (ms().showSelectMenu) {


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

On DSi consoles, changing the brightness via SELECT+VOL keys will prevent the SELECT Menu or DS Classic Menu from opening.

This key combo is detected by checking for a backlight level change while holding SELECT. I'm not sure if there's a better way to detect the volume keys.

#### Where have you tested it?

DSi with Unlaunch

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
