### PR TITLE
Add autoboot support for R4 3DS Gold RTS and PK3DS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ ipch/
 7zfile/Flashcard users/Autoboot/R4i-SDHC, r4isdhc.com cards 2014+, R4i SDHC Upgrade Revolution, R4DSiXL3D, R4i Advance, R4-IIIi, R4 SDHC Revolution, R4(i) Pocket, R4i Gold (v1.4.1) (3DS) & R4xDS
 7zfile/Flashcard users/Autoboot/R4iDSN
 7zfile/Flashcard users/Autoboot/R4IIISDHC (v3.07 kernel), R4i SDHC Silver RTS Lite, R4iTT v1.6
+7zfile/Flashcard users/Autoboot/r4i-gold.com R4 3DS Gold RTS, PK3DS
 7zfile/Flashcard users/Autoboot/r4i.cn
 7zfile/Flashcard users/Autoboot/r4dspro.com
 7zfile/Flashcard users/Autoboot/SuperCard DSONE

--- a/booter_fc/Makefile
+++ b/booter_fc/Makefile
@@ -290,9 +290,13 @@ autoboot:
 
 	mkdir -p "../7zfile/Flashcard users/Autoboot/R4i-REDANT/"
 	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i-REDANT/Redant.dat"
-	# Since this is the last one, move it instead of copy
-	mv TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i-REDANT/TTMenu.dat"
+	cp TTMenu.dat "../7zfile/Flashcard users/Autoboot/R4i-REDANT/TTMenu.dat"
 
+	##### For DSTT clones which do not support the ttio_sdhc driver
+	dlditool flashcart_specifics/DLDI/DSTTDLDIboyakkeyver.dldi TTMenu.dat
+	mkdir -p "../7zfile/Flashcard users/Autoboot/r4i-gold.com R4 3DS Gold RTS, PK3DS/"
+	# Since this is the last one, move it instead of copy
+	mv TTMenu.dat "../7zfile/Flashcard users/Autoboot/r4i-gold.com R4 3DS Gold RTS, PK3DS/TTMenu.dat"
 
 $(TARGET).nds:	makearm7_fc makearm7_r4ils makearm9_fc makearm9_r4ig makearm9_acekard2 makearm9_r4idsn
 	# simple nds srl without dsi extended header


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

I have added autoboot support for the R4 3DS Gold RTS from r4i-gold.com, which is a clone of the PK3DS flashcart.

These flashcarts do not support the normal ttio_sdhc DLDI driver. Therefore once all of the normal DSTT clone autoboot files have been made, I have added a line to DLDI patch `TTMenu.dat` using Boyakkey's DSTT DLDI driver. The `TTMenu.dat` file will then be moved into the cart's autoboot folder, `r4i-gold.com R4 3DS Gold RTS, PK3DS`, as it is the last flashcart in the makefile to require `TTMenu.dat`.

I have also added the cart's autoboot folder to the `.gitignore` file to prevent git from tracking it.

#### Where have you tested it?

DS Phat with an R4 3DS Gold RTS

***

#### Pull Request status
- [x] This PR has been tested using the latest version of devkitARM and libnds.
