### PR TITLE
Fix wrong bottom cart texture in quickmenu if using SLOT2 flashcart

### DIFF
--- a/quickmenu/arm9/source/graphics/graphics.cpp
+++ b/quickmenu/arm9/source/graphics/graphics.cpp
@@ -563,7 +563,7 @@ auto getMenuEntryTexture(MenuEntry entry) {
 			return &dlp_icons.images[0];
 		case MenuEntry::GBA:
 		{
-			bool hasGbaCart = sys().isRegularDS() && (((u8*)GBAROM)[0xB2] == 0x96);
+			bool hasGbaCart = sys().isRegularDS() && ((io_dldi_data->ioInterface.features & FEATURE_SLOT_GBA) || (((u8*)GBAROM)[0xB2] == 0x96));
 			if(hasGbaCart || sdFound()) {
 				if(initialTouchedPosition == MenuEntry::GBA) {
 					if(currentTouchedPosition != MenuEntry::GBA)


### PR DESCRIPTION
If the current dldi is a slot2 dldi, properly display the right texture as "SLOT 2" entry in the ds quick menu instead of the "no cart inserted" one

#### Where have you tested it?
Hardware, booting twilight from a supercard