### PR TITLE
Explicitly check for the extra ram to be available and working when running off a SuperCard

### DIFF
--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -1885,7 +1885,11 @@ int titleMode(void)
 			} else if (memcmp(io_dldi_data->friendlyName, "G6", 2) == 0) {
 				*(u16*)(0x020000C0) = 0x3647;
 			} else if (memcmp(io_dldi_data->friendlyName, "SuperCard", 9) == 0 || memcmp(io_dldi_data->friendlyName, "SCSD", 4) == 0) {
-				*(u16*)(0x020000C0) = 0x4353;
+				_SC_changeMode(SC_MODE_RAM);
+				*(vu16*)(0x08000000) = 0x4D54;
+				if(*(vu16*)(0x08000000) == 0x4D54) {
+					*(u16*)(0x020000C0) = 0x4353;
+				}
 			}
 		  }
 		}


### PR DESCRIPTION
Same change as in https://github.com/DS-Homebrew/nds-bootstrap/pull/1753