### PR TITLE
Fix DSi Mode related setup

### DIFF
--- a/slot1launch/bootloader/Makefile
+++ b/slot1launch/bootloader/Makefile
@@ -15,8 +15,11 @@ endif
 UNIVERSAL	:=	../../universal
 TARGET		:=	load
 BUILD		:=	build
+DSIMODE_FULL_SOURCES := source/twltool source/polarssl source/gm9i
 SOURCES		:=	source $(UNIVERSAL)/source/tonccpy
+#SOURCES		:=	source $(UNIVERSAL)/source/tonccpy $(DSIMODE_FULL_SOURCES)
 INCLUDES	:=	build source $(UNIVERSAL)/include
+#INCLUDES		:=	build source $(UNIVERSAL)/include $(DSIMODE_FULL_SOURCES)
 DATA		:=	../data
 SPECS		:=  specs
  

--- a/slot1launch/bootloader/source/main.arm9.c
+++ b/slot1launch/bootloader/source/main.arm9.c
@@ -322,6 +322,8 @@ void __attribute__((target("arm"))) arm9_main (void) {
 	
 	// arm9_errorOutput (*(u32*)(first), true);
 
+	REG_IE = 0;
+	REG_IF = ~0;
 	VoidFn arm9code = (VoidFn)ndsHeader->arm9executeAddress;
 	arm9code();
 }


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Fixes various setup issues preventing slot1launch from launching DSi games in DSi mode.

In particular:
- Made sure the 0x10 bytes at 0x0380FFC0 are cleared if not launching is DSi mode. These bytes are used by the ARM7 binaries to determine whether the game is launched on a DSi or not. (In particular, it's bit 2 of 0x0380FFC8, I think... Though it may be bit 7, I'd have to check). So having them mismatch ARM9's mode would cause crashes.
- Set __dsimode, the internal libnds register. This is needed to make sure isDSiMode works properly. In particular, that method is used by disableSlot1 and enableSlot1, so not having it set would cause problems (i.e. cartridge reads not working).
- REG_IF is cleared before booting, as turning off and on the slot 1 triggers an interrupt. If not cleared, that interrupt flag would make the games think the cartridge was removed.

This PR just fixes the setup, but it's not going to enable DSi mode by default. This is mainly because:
- The size of the binary becomes too big with DSi mode stuff enabled. As such, it's disabled by default. To test it, I personally disabled the cardengine (not included in the PR). As such, all DSi related stuff is covered by ifdefs et simila (in the Makefile the needed source/include definitions are commented). I leave to the team the decision on how to handle this problem. Personally, though, I'd suggest moving the spot in which cardengine is copied to RAM so it's not done by bootloader.
- There should be options to choose how to launch your DSi game. So if you want to use DS mode or DSi mode, etc. There currently aren't.

#### Where have you tested it?
3DS via TwilightMenu++ application and DSi via unlaunch + TwilightMenu++.

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
