### PR TITLE
DS Classic Menu: Fix black background when using Saturn & HBL UIs

### DIFF
--- a/quickmenu/arm9/source/graphics/graphics.cpp
+++ b/quickmenu/arm9/source/graphics/graphics.cpp
@@ -1201,8 +1201,6 @@ void topBgLoad(void) {
 	else if (tempNested[0] != '\0' && access(tempNested, F_OK) == 0)
 		sprintf(filePath, "%s", tempNested);
 
-	logPrint("%s\n", filePath);
-
 	std::vector<unsigned char> image;
 	uint imageWidth, imageHeight;
 	lodepng::decode(image, imageWidth, imageHeight, std::string(filePath));


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- The background code was loading uninitialized data when using Saturn & HBL UIs. This has been fixed.

#### Where have you tested it?

melonDS 1.0 RC

***

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
