### PR TITLE
 DS Classic Menu: Fix topbar date text not displaying correctly in German

### DIFF
--- a/quickmenu/arm9/source/graphics/graphics.cpp
+++ b/quickmenu/arm9/source/graphics/graphics.cpp
@@ -1276,7 +1276,7 @@ void drawDateTime(bool date, bool showTimeColon) {
 	if (!date && !showTimeColon) text[2] = ' ';
 
 	const int posX = date ? 204 : 172;
-	if (text.length <= 5)
+	if (text.length() <= 5)
 		printTinyMonospaced(true, posX, 3, text, Alignment::right, FontPalette::white);
 	else
 		// If datetime exceeds 5 characters, don't print it as monospaced to avoid overflow.

--- a/quickmenu/arm9/source/graphics/graphics.cpp
+++ b/quickmenu/arm9/source/graphics/graphics.cpp
@@ -1276,7 +1276,12 @@ void drawDateTime(bool date, bool showTimeColon) {
 	if (!date && !showTimeColon) text[2] = ' ';
 
 	const int posX = date ? 204 : 172;
-	printTinyMonospaced(true, posX, 3, text, Alignment::right, FontPalette::white);
+	if (text.length <= 5)
+		printTinyMonospaced(true, posX, 3, text, Alignment::right, FontPalette::white);
+	else
+		// If datetime exceeds 5 characters, don't print it as monospaced to avoid overflow.
+		printTiny(true, posX+2, 3, text, Alignment::right, FontPalette::white); 
+		
 	updateTopTextArea(posX - 27, 3, 27, tinyFontHeight(), bmpImageBuffer);
 }
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Fixed an oversight where the topbar date text in languages that uses 6 or more characters for the date format (like German) would overflow the "draw region," causing the first character to not get rendered.

Before:
![Screenshot_20250619_235850](https://github.com/user-attachments/assets/ce560911-4ffc-4959-8056-d97e652969fa)

After:
![Screenshot_20250619_235807](https://github.com/user-attachments/assets/c52084ea-782f-4f14-8d39-fefcc67242a0)


#### Where have you tested it?

<!-- Specify where you've tested it. -->
melonDS 1.0 RC
***

#### Pull Request status
- [X] This PR has been tested using the latest version of devkitARM and libnds.
