### PR TITLE
Fix MPU region before checking size of DSi RAM

### DIFF
--- a/title/arm9/source/cp15.s
+++ b/title/arm9/source/cp15.s
@@ -1,0 +1,19 @@
+#include <nds/asminc.h>
+
+    .syntax  unified
+    .arch    armv5te
+    .cpu     arm946e-s
+
+    .arm
+
+#define CP15_CONFIG_REGION_ENABLE               (1 << 0)
+
+#define CP15_REGION_SIZE_16MB                   (0x17 << 1)
+#define CP15_REGION_SIZE_32MB                   (0x18 << 1)
+
+// Region 6 is used as non cacheable main RAM by libnds
+
+BEGIN_ASM_FUNC CP15_ExtendRegion6
+    ldr     r0, =(0xC000000 | CP15_CONFIG_REGION_ENABLE | CP15_REGION_SIZE_32MB)
+    mcr     p15, 0, r0, c6, c6, 0
+    bx      lr

--- a/title/arm9/source/main.cpp
+++ b/title/arm9/source/main.cpp
@@ -89,6 +89,15 @@ int subscreenmode = 0;
 
 touchPosition touch;
 
+// Used to switch MPU region 6 from 16 MB to 32 MB. This region is the one that
+// starts at address 0xC000000, and we need it to check if we have 16 or 32 MB
+// available.
+//
+// If the loader of TWiLightMenu doesn't set SCFG_EXT9 bits 14-15 to 3, the crt0
+// of libnds will get confused and only map 16 MB. To be sure that the code
+// never crashes, even with buggy loaders, we need to manually set it to 32 MB.
+extern "C" void CP15_ExtendRegion6(void);
+
 using namespace std;
 
 //---------------------------------------------------------------------------------
@@ -2716,6 +2725,12 @@ int titleMode(void)
 				fclose(addon);
 			}
 		}
+	}
+
+	if (isDSiMode()) {
+		// Extend the MPU region that is mapped at address 0xC000000 up to
+		// 0xE000000 instead of potentially ending at 0xD000000.
+		CP15_ExtendRegion6();
 	}
 
 	if (REG_SCFG_EXT != 0) {


### PR DESCRIPTION
#### What's changed?

Some loaders don't set SCFG_EXT9 bits 14-15 to 32 MB. The crt0 of TWiLightMenu gets confused and it only maps 16 MB at 0xC000000 instead of 32 MB, so the check to determine if the RAM is mirrored crashes.

This bug is exposed when BlocksDS programs try to use the exit to loader hooks of nds-hb-menu or TWiLightMenu, for example.

More information here:

https://github.com/blocksds/sdk/issues/10#issuecomment-3268419526

I'm not 100% sure if this is the right fix, though.

#### Where have you tested it?

I've tested this on DSi, but I'm not 100% sure if I've been able to install my build of TWiLightMenu correctly.

I've created a test ROM and uploaded it here: https://github.com/blocksds/sdk/issues/10#issuecomment-3268457595

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.