### PR TITLE
DSi-based UIs: Allow stop sounds in 3DS themes

### DIFF
--- a/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
+++ b/romsel_dsimenutheme/arm9/source/fileBrowse.cpp
@@ -3577,7 +3577,7 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 							while (titleboxXpos[ms().secondaryDevice] != titleboxXdest[ms().secondaryDevice]) {
 								swiWaitForVBlank();
 							}
-							snd().playStop();
+							if (tc().playStopSound()) snd().playStop();
 							startBorderZoomOut = true;
 						}
 						dsiCursorMove = true;
@@ -3726,6 +3726,7 @@ std::string browseForFile(const std::vector<std::string_view> extensionList) {
 					bannerTextShown = false;
 					titleboxXspeed = (ms().theme == TWLSettings::EThemeDSi) ? 8 : 3;
 					touch = startTouch;
+					needToPlayStopSound = true;
 					if (!gameTapped && CURPOS + PAGENUM * 40 < ((int)dirContents[scrn].size())) {
 						showSTARTborder = (ms().theme == TWLSettings::ETheme3DS ? true : false);
 					}

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.cpp
@@ -31,6 +31,7 @@ ThemeConfig::ThemeConfig()
 	_iconSMSUserPalette(false), _iconSNESUserPalette(false), _iconUnknownUserPalette(false), _iconVIDUserPalette(false),
 	_iconWSUserPalette(false), _usernameUserPalette(true), _progressBarUserPalette(true),
 	_purpleBatteryAvailable(false), _renderPhoto(true), _darkLoading(false), _useAlphaBlend(true),
+	_playStopSound(true),
 	_playStartupJingle(false), _startupJingleDelayAdjust(0), _progressBarColor(0x7C00),
 	_fontPalette1(0x0000), _fontPalette2(0xDEF7), _fontPalette3(0xC631), _fontPalette4(0xA108),
 	_fontPaletteDisabled1(0x0000), _fontPaletteDisabled2(0xDEF7), _fontPaletteDisabled3(0xC631), _fontPaletteDisabled4(0xA108),
@@ -40,6 +41,10 @@ ThemeConfig::ThemeConfig()
 	_fontPaletteUsername1(0x0000), _fontPaletteUsername2(0xDEF7), _fontPaletteUsername3(0xC631), _fontPaletteUsername4(0xA108),
 	_fontPaletteDateTime1(0x0000), _fontPaletteDateTime2(0xDEF7), _fontPaletteDateTime3(0xC631), _fontPaletteDateTime4(0xA108)
 {
+	if (ms().theme != TWLSettings::EThemeDSi) {
+		_playStopSound = false;
+	}
+
 	if (ms().theme == TWLSettings::ETheme3DS) {
 		_startBorderUserPalette = false;
 		_dialogBoxUserPalette = false;
@@ -167,6 +172,7 @@ void ThemeConfig::loadConfig() {
 	_darkLoading = getInt(themeConfig, "DarkLoading", _darkLoading);
 	_useAlphaBlend = getInt(themeConfig, "UseAlphaBlend", _useAlphaBlend);
 
+	_playStopSound = getInt(themeConfig, "PlayStopSound", _playStopSound);
 	_playStartupJingle = getInt(themeConfig, "PlayStartupJingle", _playStartupJingle);
 	_startupJingleDelayAdjust = getInt(themeConfig, "StartupJingleDelayAdjust", _startupJingleDelayAdjust);
 	_progressBarColor = getInt(themeConfig, "ProgressBarColor", _progressBarColor);

--- a/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
+++ b/romsel_dsimenutheme/arm9/source/graphics/ThemeConfig.h
@@ -112,6 +112,7 @@ private:
 	bool _renderPhoto;
 	bool _darkLoading;
 	bool _useAlphaBlend;
+	bool _playStopSound;
 	bool _playStartupJingle;
 	int _startupJingleDelayAdjust;
 	u16 _progressBarColor;
@@ -253,6 +254,7 @@ public:
 	bool darkLoading() const { return _darkLoading; }
 	bool useAlphaBlend() const { return _useAlphaBlend; }
 
+	bool playStopSound() const { return _playStopSound; }
 	bool playStartupJingle() const { return _playStartupJingle; }
 	int startupJingleDelayAdjust() const { return _startupJingleDelayAdjust; }
 	u16 progressBarColor() const { return _progressBarColor; }

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -1093,14 +1093,13 @@ void vBlankHandler() {
 				glSprite(96, tc().startBorderRenderY(), GL_FLIP_NONE,
 					 &tex().wirelessIcons()[(bnrWirelessIcon[CURPOS] - 1) & 31]);
 
-			if (ms().theme == TWLSettings::EThemeDSi) {
-				if (currentBg == 1 && ms().theme == TWLSettings::EThemeDSi && needToPlayStopSound &&
-					waitForNeedToPlayStopSound == 0) {
-					// mmEffectEx(&snd_stop);
-					snd().playStop();
-					waitForNeedToPlayStopSound = 1;
-					needToPlayStopSound = false;
-				}
+			if (currentBg == 1 && tc().playStopSound() && needToPlayStopSound &&
+				waitForNeedToPlayStopSound == 0) {
+				snd().playStop();
+				waitForNeedToPlayStopSound = 1;
+				needToPlayStopSound = false;
+			}
+			// if (ms().theme == TWLSettings::EThemeDSi) {
 				// glSprite(96, tc().startBorderRenderY(), GL_FLIP_NONE,
 				// 	 &tex().startbrdImage()[startBorderZoomAnimSeq[startBorderZoomAnimNum] &
 				// (tc().startBorderSpriteH() - 1)]); glSprite(96 + tc().startBorderSpriteW(),
@@ -1109,7 +1108,7 @@ void vBlankHandler() {
 				// (tc().startBorderSpriteH() - 1)]); if (bnrWirelessIcon[CURPOS] > 0) 	glSprite(96,
 				// tc().startBorderRenderY(), GL_FLIP_NONE,
 				// 		 &tex().wirelessIcons()[(bnrWirelessIcon[CURPOS] - 1) & 31]);
-			}
+			// }
 		}
 
 		// Refresh the background layer.


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

- Add `PlayStopSound` option to `theme.ini` that defaults to true for DSi themes and false for others.
- Allow stop sounds to play in all themes when enabled, and added one to the non-DSi-style cursor movement.

#### Where have you tested it?

melonDS 1.0

***

#### Pull Request status
- [x] This PR has been tested using the ~~latest~~ [before November 2024] version of devkitARM and libnds.
