### PR TITLE
Slot1launch: Properly reset registers before passing control to cartridge

### DIFF
--- a/slot1launch/bootloader/source/actual_jump.arm7.s
+++ b/slot1launch/bootloader/source/actual_jump.arm7.s
@@ -1,0 +1,29 @@
+@ __attribute__((noreturn)) void arm7_actual_jump(void* fn)
+@ Clears most registers and properly sets the other ones.
+@ Then calls fn.
+@ ARM9 and ARM7 versions of the function need to be separate
+@ to prevent issues with cross-calling.
+
+#include <nds/asminc.h>
+
+#define DEFAULT_SP_DSI 0x03FFFF80
+
+.arm
+
+BEGIN_ASM_FUNC arm7_actual_jump
+	mov lr, r0
+	mov r0, #0
+	mov r1, #0
+	mov r2, #0
+	mov r3, #0
+	mov r4, #0
+	mov r5, #0
+	mov r6, #0
+	mov r7, #0
+	mov r8, #0
+	mov r9, #0
+	mov r10, #0
+	mov r11, #0
+	mov r12, #0
+	ldr sp,=#DEFAULT_SP_DSI
+	bx lr

--- a/slot1launch/bootloader/source/actual_jump.arm9.s
+++ b/slot1launch/bootloader/source/actual_jump.arm9.s
@@ -1,0 +1,29 @@
+@ __attribute__((noreturn)) void arm9_actual_jump(void* fn)
+@ Clears most registers and properly sets the other ones.
+@ Then calls fn.
+@ ARM9 and ARM7 versions of the function need to be separate
+@ to prevent issues with cross-calling.
+
+#include <nds/asminc.h>
+
+#define DEFAULT_SP_DSI 0x0E003F80
+
+.arm
+
+BEGIN_ASM_FUNC arm9_actual_jump
+	mov lr, r0
+	mov r0, #0
+	mov r1, #0
+	mov r2, #0
+	mov r3, #0
+	mov r4, #0
+	mov r5, #0
+	mov r6, #0
+	mov r7, #0
+	mov r8, #0
+	mov r9, #0
+	mov r10, #0
+	mov r11, #0
+	mov r12, #0
+	ldr sp,=#DEFAULT_SP_DSI
+	bx lr

--- a/slot1launch/bootloader/source/main.arm7.c
+++ b/slot1launch/bootloader/source/main.arm7.c
@@ -99,7 +99,8 @@ int twlCfgLang = 0;
 
 bool gameSoftReset = false;
 
-void arm7_clearmem (void* loc, size_t len);
+extern void arm7_clearmem (void* loc, size_t len);
+extern __attribute__((noreturn)) void arm7_actual_jump(void* fn);
 
 static const u32 cheatDataEndSignature[2] = {0xCF000000, 0x00000000};
 
@@ -835,8 +836,7 @@ void arm7_startBinary (void) {
 	REG_AUXIE = 0;
 	REG_AUXIF = ~0;
 	// Start ARM7
-	VoidFn arm7code = (VoidFn)ndsHeader->arm7executeAddress;
-	arm7code();
+	arm7_actual_jump((void*)ndsHeader->arm7executeAddress);
 }
 
 
@@ -1169,7 +1169,5 @@ void arm7_main (void) {
 	setMemoryAddress(ndsHeader);
 
 	arm7_startBinary();
-
-	while (1);
 }
 

--- a/slot1launch/bootloader/source/main.arm9.c
+++ b/slot1launch/bootloader/source/main.arm9.c
@@ -63,7 +63,7 @@ External functions
 --------------------------------------------------------------------------*/
 extern void arm9_clearCache (void);
 extern void arm9_write_to_scfg_clk(uint16_t);
-
+extern __attribute__((noreturn)) void arm9_actual_jump(void* fn);
 
 void initMBKARM9() {
 	// default dsiware settings
@@ -338,7 +338,6 @@ void __attribute__((target("arm"))) arm9_main (void) {
 
 	REG_IE = 0;
 	REG_IF = ~0;
-	VoidFn arm9code = (VoidFn)ndsHeader->arm9executeAddress;
-	arm9code();
+	arm9_actual_jump((void*)ndsHeader->arm9executeAddress);
 }
 

--- a/slot1launch/bootloaderAlt/source/actual_jump.arm7.s
+++ b/slot1launch/bootloaderAlt/source/actual_jump.arm7.s
@@ -1,0 +1,29 @@
+@ __attribute__((noreturn)) void arm7_actual_jump(void* fn)
+@ Clears most registers and properly sets the other ones.
+@ Then calls fn.
+@ ARM9 and ARM7 versions of the function need to be separate
+@ to prevent issues with cross-calling.
+
+#include <nds/asminc.h>
+
+#define DEFAULT_SP_DSI 0x03FFFF80
+
+.arm
+
+BEGIN_ASM_FUNC arm7_actual_jump
+	mov lr, r0
+	mov r0, #0
+	mov r1, #0
+	mov r2, #0
+	mov r3, #0
+	mov r4, #0
+	mov r5, #0
+	mov r6, #0
+	mov r7, #0
+	mov r8, #0
+	mov r9, #0
+	mov r10, #0
+	mov r11, #0
+	mov r12, #0
+	ldr sp,=#DEFAULT_SP_DSI
+	bx lr

--- a/slot1launch/bootloaderAlt/source/actual_jump.arm9.s
+++ b/slot1launch/bootloaderAlt/source/actual_jump.arm9.s
@@ -1,0 +1,29 @@
+@ __attribute__((noreturn)) void arm9_actual_jump(void* fn)
+@ Clears most registers and properly sets the other ones.
+@ Then calls fn.
+@ ARM9 and ARM7 versions of the function need to be separate
+@ to prevent issues with cross-calling.
+
+#include <nds/asminc.h>
+
+#define DEFAULT_SP_DSI 0x0E003F80
+
+.arm
+
+BEGIN_ASM_FUNC arm9_actual_jump
+	mov lr, r0
+	mov r0, #0
+	mov r1, #0
+	mov r2, #0
+	mov r3, #0
+	mov r4, #0
+	mov r5, #0
+	mov r6, #0
+	mov r7, #0
+	mov r8, #0
+	mov r9, #0
+	mov r10, #0
+	mov r11, #0
+	mov r12, #0
+	ldr sp,=#DEFAULT_SP_DSI
+	bx lr

--- a/slot1launch/bootloaderAlt/source/main.arm7.c
+++ b/slot1launch/bootloaderAlt/source/main.arm7.c
@@ -83,7 +83,8 @@ bool my_isDSiMode() {
 
 bool gameSoftReset = false;
 
-void arm7_clearmem (void* loc, size_t len);
+extern void arm7_clearmem (void* loc, size_t len);
+extern __attribute__((noreturn)) void arm7_actual_jump(void* fn);
 extern void ensureBinaryDecompressed(const tNDSHeader* ndsHeader, module_params_t* moduleParams);
 
 static const u32 cheatDataEndSignature[2] = {0xCF000000, 0x00000000};
@@ -635,8 +636,7 @@ void arm7_startBinary (void)
 	while (REG_VCOUNT==191);
 
 	// Start ARM7
-	VoidFn arm7code = *(VoidFn*)(0x27FFE34);
-	arm7code();
+	arm7_actual_jump(*(void**)(0x27FFE34));
 }
 
 
@@ -820,7 +820,5 @@ void arm7_main (void) {
 	}
 
 	arm7_startBinary();
-
-	while (1);
 }
 

--- a/slot1launch/bootloaderAlt/source/main.arm9.c
+++ b/slot1launch/bootloaderAlt/source/main.arm9.c
@@ -53,7 +53,7 @@ volatile u32 arm9_BLANK_RAM = 0;
 External functions
 --------------------------------------------------------------------------*/
 extern void arm9_clearCache (void);
-
+extern __attribute__((noreturn)) void arm9_actual_jump(void* fn);
 
 void initMBKARM9() {
 	// default dsiware settings
@@ -285,7 +285,6 @@ void arm9_main (void) {
 	
 	// arm9_errorOutput (*(u32*)(first), true);
 
-	VoidFn arm9code = *(VoidFn*)(0x27FFE24);
-	arm9code();
+	arm9_actual_jump(*(void**)(0x27FFE24));
 }
 


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

Fixed crash for System Flaw (DSi-only title). The game uses a (probably bugged) "assembly hand-written" library (also used by some dsiware) that assumes that the ARM9 r8 register is pre-initialized to 0 by the launcher.
Not initializing it causes crashes when the r8 register is used.

<!-- Describe what you've changed. -->

The new assembly functions arm7_actual_jump and arm9_actual_jump init all the registers for the two cores in the same way a real DSi launcher would init them (for both DS and DSi games) before calling the real cartridge code.

Similar code already exists in nds-bootstrap (likely for the dsiwares also using the same library, or for some homebrew software).

#### Where have you tested it?

<!-- Specify where you've tested it. -->

3DS via TwilightMenu++ application, DSi via unlaunch + TwilightMenu++, DSi melonDS via godmode9i + TwilightMenu++.
Tested with a retail DS cartridge, a retail DSi cartridge and a dev DSi cartridge with homebrew on it with two custom crt0s to print the state of the registers at startup.

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.