### PR TITLE
Fix glitchy palettes for some animated icons

### DIFF
--- a/quickmenu/arm9/source/graphics/graphics.cpp
+++ b/quickmenu/arm9/source/graphics/graphics.cpp
@@ -44,6 +44,7 @@
 #include "common/lodepng.h"
 #include "color.h"
 #include "fontHandler.h"
+#include "../iconTitle.h"
 #include "../ndsheaderbanner.h"
 #include "../errorScreen.h"
 #include "../date.h"
@@ -636,6 +637,8 @@ void vBlankHandler()
 			waitUntilFadeOut++;
 		}
 	}
+
+	loadDeferredIconPalettes();
 
 	static bool updateFrame = true;
 	static bool whiteScreenPrev = whiteScreen;

--- a/quickmenu/arm9/source/iconTitle.cpp
+++ b/quickmenu/arm9/source/iconTitle.cpp
@@ -231,6 +231,15 @@ void reloadIconPalettes() {
 	}
 }
 
+void loadDeferredIconPalettes() {
+	for (int i = 0; i < NDS_ICON_BANK_COUNT; i++) {
+		if (bnriconPalLoaded[i] == -1) {
+			glLoadPalette(i, dsi_palette[i][bnriconPalLine[i]]);
+			bnriconPalLoaded[i] = bnriconPalLine[i];
+		}
+	}
+}
+
 void loadConsoleIcons()
 {
 	if (!colorTable) {
@@ -270,8 +279,7 @@ static void clearIcon(int num)
 void drawIcon(int num, int Xpos, int Ypos) {
 	glSprite(Xpos, Ypos, bannerFlip[num], &ndsIcon[num][bnriconframenumY[num] & 31]);
 	if (bnriconPalLine[num] != bnriconPalLoaded[num]) {
-		glLoadPalette(num, dsi_palette[num][bnriconPalLine[num]]);
-		bnriconPalLoaded[num] = bnriconPalLine[num];
+		bnriconPalLoaded[num] = -1; // defer loading the palette
 	}
 }
 

--- a/quickmenu/arm9/source/iconTitle.h
+++ b/quickmenu/arm9/source/iconTitle.h
@@ -14,6 +14,7 @@ void iconTitleInit();
  * they have been corrupted.
  */
 void reloadIconPalettes();
+void loadDeferredIconPalettes();
 
 void loadConsoleIcons();
 void getGameInfo(int num, bool isDir, const char* name, bool fromArgv);

--- a/romsel_aktheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_aktheme/arm9/source/graphics/graphics.cpp
@@ -1603,6 +1603,8 @@ void vBlankHandler()
 		if (controlTopBright) SetBrightness(1, screenBrightness);
 	}
 
+	loadDeferredIconPalettes();
+
 	static bool showdialogboxPrev = showdialogbox;
 	static int dialogboxHeightPrev = dialogboxHeight;
 	static bool displayIconsPrev = displayIcons;

--- a/romsel_aktheme/arm9/source/iconTitle.cpp
+++ b/romsel_aktheme/arm9/source/iconTitle.cpp
@@ -698,6 +698,15 @@ void reloadIconPalettes() {
 	}
 }
 
+void loadDeferredIconPalettes() {
+	for (int i = 0; i < NDS_ICON_BANK_COUNT; i++) {
+		if (bnriconPalLoaded[i] == -1) {
+			glLoadPalette(i, bnriconTile[i].dsi_palette[bnriconPalLine[i]]);
+			bnriconPalLoaded[i] = bnriconPalLine[i];
+		}
+	}
+}
+
 void loadConsoleIcons()
 {
 	if (!colorTable) {
@@ -880,8 +889,7 @@ void iconTitleInit()
 void drawIcon(int num, int Xpos, int Ypos, s32 scale) {
 	(scale == 0) ? glSprite(Xpos, Ypos, bannerFlip[num], &ndsIcon[num][bnriconframenumY[num] & 31]) : glSpriteScale(Xpos, Ypos, scale, bannerFlip[num], &ndsIcon[num][bnriconframenumY[num] & 31]);
 	if (bnriconPalLine[num] != bnriconPalLoaded[num]) {
-		glLoadPalette(num, bnriconTile[num].dsi_palette[bnriconPalLine[num]]);
-		bnriconPalLoaded[num] = bnriconPalLine[num];
+		bnriconPalLoaded[num] = -1; // defer loading the palette
 	}
 }
 

--- a/romsel_aktheme/arm9/source/iconTitle.h
+++ b/romsel_aktheme/arm9/source/iconTitle.h
@@ -16,6 +16,7 @@ void iconTitleInit();
  * they have been corrupted.
  */
 void reloadIconPalettes();
+void loadDeferredIconPalettes();
 
 void loadConsoleIcons();
 void copyGameInfo(int numDst, int numSrc);

--- a/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
+++ b/romsel_dsimenutheme/arm9/source/graphics/graphics.cpp
@@ -401,6 +401,7 @@ void playRotatingCubesVideo(void) {
 void vBlankHandler() {
 	execQueue();		   // Execute any actions queued during last vblank.
 	execDeferredIconUpdates(); // Update any icons queued during last vblank.
+	loadDeferredIconPalettes();
 
 	if (waitForNeedToPlayStopSound > 0) {
 		waitForNeedToPlayStopSound++;

--- a/romsel_dsimenutheme/arm9/source/iconTitle.cpp
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.cpp
@@ -161,14 +161,21 @@ void drawIcon(int Xpos, int Ypos, int num) {
 	if (num == -1) { // Moving app icon
 		glSprite(Xpos, Ypos, bannerFlip[40], &getIcon(6)[bnriconframenumY[40]]);
 		if (bnriconPalLine[40] != bnriconPalLoaded[40]) {
-			glLoadPalette(6, bnriconTile[40].dsi_palette[bnriconPalLine[40]]);
-			bnriconPalLoaded[40] = bnriconPalLine[40];
+			bnriconPalLoaded[40] = -1; // defer loading the palette
 		}
 	} else {
 		glSprite(Xpos, Ypos, bannerFlip[num], &getIcon(num % 6)[bnriconframenumY[num]]);
 		if (bnriconPalLine[num] != bnriconPalLoaded[num]) {
-			glLoadPalette(num % 6, bnriconTile[num].dsi_palette[bnriconPalLine[num]]);
-			bnriconPalLoaded[num] = bnriconPalLine[num];
+			bnriconPalLoaded[num] = -1; // defer loading the palette
+		}
+	}
+}
+
+void loadDeferredIconPalettes() {
+	for (int i = 0; i < 41; i++) {
+		if (bnriconPalLoaded[i] == -1) {
+			glLoadPalette(i < 40 ? i % 6 : 6, bnriconTile[i].dsi_palette[bnriconPalLine[i]]);
+			bnriconPalLoaded[i] = bnriconPalLine[i];
 		}
 	}
 }

--- a/romsel_dsimenutheme/arm9/source/iconTitle.h
+++ b/romsel_dsimenutheme/arm9/source/iconTitle.h
@@ -28,6 +28,7 @@ void iconUpdate(bool isDir, const char* name, int num);
 void titleUpdate(bool isDir, std::string_view name, int num);
 void drawIcon(int Xpos, int Ypos, int num);
 void execDeferredIconUpdates();
+void loadDeferredIconPalettes();
 void writeBannerText(std::string_view name, std::string_view text);
 void writeBannerText(std::string_view name, std::u16string text);
 void writeBannerText(std::u16string name, std::u16string text);

--- a/romsel_r4theme/arm9/source/graphics/graphics.cpp
+++ b/romsel_r4theme/arm9/source/graphics/graphics.cpp
@@ -546,6 +546,8 @@ void vBlankHandler()
 		if (controlTopBright) SetBrightness(1, ms().theme==6 ? -screenBrightness : screenBrightness);
 	}
 
+	loadDeferredIconPalettes();
+
 	static bool whiteScreenPrev = whiteScreen;
 	static bool blackScreenPrev = blackScreen;
 	static bool startMenuPrev = startMenu;

--- a/romsel_r4theme/arm9/source/iconTitle.cpp
+++ b/romsel_r4theme/arm9/source/iconTitle.cpp
@@ -735,6 +735,13 @@ void reloadIconPalettes() {
 	glReloadIconPalette();
 }
 
+void loadDeferredIconPalettes() {
+	if (bnriconPalLoaded == -1) {
+		glLoadPalette(dsi_palette[bnriconPalLine]);
+		bnriconPalLoaded = bnriconPalLine;
+	}
+}
+
 void loadConsoleIcons()
 {
 	if (!colorTable) {
@@ -892,8 +899,7 @@ static void clearIcon()
 void drawIcon(int Xpos, int Ypos) {
 	glSprite(Xpos, Ypos, bannerFlip, &ndsIcon[bnriconframenumY & 31]);
 	if (bnriconPalLine != bnriconPalLoaded) {
-		glLoadPalette(dsi_palette[bnriconPalLine]);
-		bnriconPalLoaded = bnriconPalLine;
+		bnriconPalLoaded = -1; // defer loading the palette
 	}
 }
 

--- a/romsel_r4theme/arm9/source/iconTitle.h
+++ b/romsel_r4theme/arm9/source/iconTitle.h
@@ -12,6 +12,7 @@ void iconTitleInit();
  * they have been corrupted.
  */
 void reloadIconPalettes();
+void loadDeferredIconPalettes();
 
 void loadConsoleIcons();
 void getGameInfo(int fileOffset, bool isDir, const char* name, bool fromArgv);


### PR DESCRIPTION
<!-- ##### REMEMBER TO ALWAYS TEST YOUR PR! -->
#### What's changed?

For some reason, palettes seem to update faster than the graphics when the next icon of the animation is drawn. This causes an issue where there is 1 frame in which the palette may be incorrect everytime the sequence updates to the next frame. As a hacky fix, I delay loading the new palette until the next vblank, which seems to keep things in sync.

#### Where have you tested it?

melonDS 1.1
DSi via Unlaunch
DS Lite via flashcard

***

#### Pull Request status
- [x] This PR has been tested using the ~~latest~~ [before November 2024]  version of devkitARM and libnds.
