### PR TITLE
Added install instructions + checks on CIA creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For DS(i) and 3DS SD card users, the `BOOT.NDS` file is found in `./7zfile/DSi&3
 
 For 3DS users, you can then generate the TwilightMenu CIA file by executing the following batch file : `./booter/make cia.bat`. The then generated cia file can be found at `./7zfile/3DS - CFW users/cia/TWiLight Menu.cia`.
 
-You can then install TwilightMenu++ the same way you can do it when downloading the app directly from the release page : copy the aforementioned .cia and .nds files to the root of your SD card, along with the `_nds/` and `roms/` folders generated in `./7zipfile/`. Then, use FBI to install TwilightMenu's .cia file.
+You can then install TwilightMenu++ the same way you can do it when downloading the app directly from the release page : copy the aforementioned .cia and .nds files to the root of your SD card, along with the `_nds/` and `roms/` folders generated in `./7zfile/`. Then, use FBI to install TwilightMenu's .cia file.
 
 # Translating
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,14 @@ TWiLight Menu++ is composed of multiple "sub-projects" which all work together t
 - **title**: boot splash screen (Nintendo logo by default)
   - Creates `/_nds/TWiLightMenu/main.srldr`
 
+## Files to install
+
+For DS(i) and 3DS SD card users, the `BOOT.NDS` file is found in `./7zfile/DSi&3DS - SD card users/`
+
+For 3DS users, you can then generate the TwilightMenu CIA file by executing the following batch file : `./booter/make cia.bat`. The then generated cia file can be found at `./7zfile/3DS - CFW users/cia/TWiLight Menu.cia`.
+
+You can then install TwilightMenu++ the same way you can do it when downloading the app directly from the release page : copy the aforementioned .cia and .nds files to the root of your SD card, along with the `_nds/` and `roms/` folders generated in `./7zipfile/`. Then, use FBI to install TwilightMenu's .cia file.
+
 # Translating
 
 You can help translate TWiLight Menu++ on the [Crowdin project](https://crowdin.com/project/TwilightMenu). If you'd like to request a new language be added then please ask on the [Discord server](https://ds-homebrew.com/discord).

--- a/booter/make cia.bat
+++ b/booter/make cia.bat
@@ -1,4 +1,5 @@
 @echo off
 make_cia --srl="booter.nds"
+if not exist "../7zfile/3DS - CFW users/cia" md "../7zfile/3DS - CFW users/cia"
 copy "booter.cia" "../7zfile/3DS - CFW users/cia/TWiLight Menu.cia"
 pause


### PR DESCRIPTION
#### What's changed?

- `README.md` now specify where to find useful files for installing TwilightMenu++ and, if needed, how to generate them in the first place.
- `./booster/make cia.bat` now checks for destination folder and create it if needed before creating and copying the .cia file. It also got referenced in the README

#### Where have you tested it?

Test cases (OSes and softwares are all in their latest version as of writing this PR) : 
- Full build with docker (working)
- Executing `./booster/make cia.bat` on Windows11 and CachyOS + Wine (working)

***

#### Pull Request status
- [ ] This PR has been tested using the latest version of devkitARM and libnds.
- [x] This PR has been tested using the versions of devkitARM and libnds specified in the `Dockerfile`, via docker.

It is to be noted that since the project uses old versions of devkitpro's libs, using latest versions of devkitARM and libnds causes errors during the build phase.
